### PR TITLE
fix: Use valid session source enum in test command

### DIFF
--- a/cmd/test.go
+++ b/cmd/test.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/promptconduit/cli/internal/client"
 	"github.com/promptconduit/cli/internal/schema"
@@ -29,7 +30,9 @@ func runTest(cmd *cobra.Command, args []string) error {
 
 	// Create a test event
 	event := schema.NewCanonicalEvent(schema.ToolClaudeCode, schema.EventSessionStart, Version)
-	source := "cli_test"
+	sessionID := fmt.Sprintf("test-%d", time.Now().UnixNano())
+	event.SessionID = &sessionID
+	source := "startup" // Must be a valid session source enum value
 	event.Session = &schema.SessionPayload{
 		Source: &source,
 	}


### PR DESCRIPTION
## Summary
Fixes the `promptconduit test` command which was failing with HTTP 500 errors due to using an invalid session source enum value.

## Changes
- **cmd/test.go**: Changed session source from `"cli_test"` to `"startup"` (valid DB enum)
- **cmd/test.go**: Added unique session_id generation using timestamp
- **cmd/hook.go**: Added file-based debug logging for troubleshooting hook issues
  - Writes to `$TMPDIR/promptconduit-hook.log` when `PROMPTCONDUIT_DEBUG=true`

## Test plan
- [x] Verified `promptconduit test` now returns success (HTTP 201)
- [x] Confirmed hooks continue to work with real Claude Code events
- [x] Verified prompts/sessions are being captured in the API

🤖 Generated with [Claude Code](https://claude.com/claude-code)