### PR TITLE
feat: unified attachment upload via /v1/events/raw endpoint

### DIFF
--- a/internal/envelope/envelope.go
+++ b/internal/envelope/envelope.go
@@ -24,6 +24,19 @@ type RawEventEnvelope struct {
 
 	// Raw native payload (passed through untouched)
 	NativePayload json.RawMessage `json:"native_payload"`
+
+	// Attachment metadata (binary data sent separately in multipart)
+	Attachments []AttachmentMetadata `json:"attachments,omitempty"`
+}
+
+// AttachmentMetadata describes an attachment sent with the envelope.
+// The actual binary data is sent as a separate multipart field.
+type AttachmentMetadata struct {
+	AttachmentID string `json:"attachment_id"` // UUID for correlation
+	Filename     string `json:"filename"`
+	ContentType  string `json:"content_type"`
+	SizeBytes    int64  `json:"size_bytes"`
+	Type         string `json:"type"` // "image", "document", "file"
 }
 
 // GitContext contains git repository state at event time.
@@ -56,6 +69,20 @@ func New(cliVersion, tool, hookEvent string, nativePayload []byte, git *GitConte
 		CapturedAt:      time.Now().UTC().Format(time.RFC3339),
 		Git:             git,
 		NativePayload:   nativePayload,
+	}
+}
+
+// NewWithAttachments creates a new RawEventEnvelope with attachment metadata
+func NewWithAttachments(cliVersion, tool, hookEvent string, nativePayload []byte, git *GitContext, attachments []AttachmentMetadata) *RawEventEnvelope {
+	return &RawEventEnvelope{
+		EnvelopeVersion: "1.0",
+		CliVersion:      cliVersion,
+		Tool:            tool,
+		HookEvent:       hookEvent,
+		CapturedAt:      time.Now().UTC().Format(time.RFC3339),
+		Git:             git,
+		NativePayload:   nativePayload,
+		Attachments:     attachments,
 	}
 }
 


### PR DESCRIPTION
## Summary

- Adds unified attachment support to the CLI, sending attachments via the same `/v1/events/raw` endpoint using multipart form data
- Aligns with the platform's unified event handling architecture for all adapter types

## Changes

- `internal/envelope/envelope.go`: Add `AttachmentMetadata` type and `NewWithAttachments` constructor
- `internal/client/api.go`: Add `SendEnvelopeWithAttachments` multipart upload function
- `cmd/hook.go`: Update hook processing to use unified envelope format for attachments

## Test plan

- [x] CLI compiles successfully
- [x] All existing tests pass
- [x] Manual test: multipart upload with attachment works correctly
- [x] Downloaded attachments match original files (verified via MD5)

## Notes

This replaces the previous `/v1/prompts/ingest-multipart` approach with a unified format:
- `envelope` field: JSON `RawEventEnvelope` with attachment metadata
- `attachment[uuid]` fields: Binary attachment data

🤖 Generated with [Claude Code](https://claude.com/claude-code)