### PR TITLE
fix: increase attachment extraction timeout to 1500ms

### DIFF
--- a/internal/transcript/extractors.go
+++ b/internal/transcript/extractors.go
@@ -49,7 +49,7 @@ func (e *ClaudeCodeExtractor) ExtractAttachments(nativeEvent map[string]interfac
 
 	// Use polling to wait for the transcript to contain the current message
 	// This handles the timing issue where the hook fires before transcript is updated
-	attachments, _, err := ExtractLatestAttachmentsWithWait(transcriptPath, promptText, 500*time.Millisecond)
+	attachments, _, err := ExtractLatestAttachmentsWithWait(transcriptPath, promptText, 1500*time.Millisecond)
 	if err != nil {
 		return nil, "", err
 	}


### PR DESCRIPTION
## Summary
- Increase transcript polling timeout from 500ms to 1500ms for attachment extraction
- Fixes intermittent failures where images weren't captured because the transcript wasn't written yet

## Test plan
- [x] Tested locally - image attachments now captured consistently when UserPromptSubmit fires

🤖 Generated with [Claude Code](https://claude.com/claude-code)