### PR TITLE
feat: use raw sync endpoint for server-side categorization

### DIFF
--- a/internal/sync/types.go
+++ b/internal/sync/types.go
@@ -38,6 +38,7 @@ type ParsedMessage struct {
 	GitCommit         string
 	Cwd               string
 	AttachmentCount   int
+	RawJSON           string // Original JSONL line for server-side categorization
 }
 
 // SyncState tracks which files have been synced


### PR DESCRIPTION
## Summary
- Add `RawJSON` field to preserve original JSONL lines
- Update parser to store raw JSON for each message
- Add `SyncTranscriptRaw` client method for new `/v1/transcripts/sync/raw` endpoint
- Update sync command to use raw sync API

## Dependency
⚠️ **Requires platform PR https://github.com/promptconduit/platform/pull/33 to be deployed first** - this CLI version expects the new endpoint to exist.

## Files Changed
- `internal/sync/types.go` - Add RawJSON field
- `internal/sync/claudecode.go` - Preserve raw JSON in parser
- `internal/client/api.go` - Add raw sync method
- `cmd/sync.go` - Use raw sync endpoint

## Test plan
- [ ] Build CLI: `make build`
- [ ] Deploy platform PR first
- [ ] Test: `./promptconduit sync --force` 
- [ ] Verify messages synced with correct categorization

🤖 Generated with [Claude Code](https://claude.com/claude-code)