### PR TITLE
fix: treat empty transcripts as warnings instead of errors

### DIFF
--- a/cmd/sync.go
+++ b/cmd/sync.go
@@ -156,6 +156,13 @@ func runSync(cmd *cobra.Command, args []string) error {
 				displayName = "..." + displayName[len(displayName)-57:]
 			}
 
+			// Skip empty transcripts (no valid messages) - warn instead of error
+			if len(conversation.Messages) == 0 {
+				fmt.Printf("  ⚠️  Skipping empty transcript: %s\n", displayName)
+				totalSkipped++
+				continue
+			}
+
 			if syncDryRun {
 				chunkInfo := ""
 				if len(conversation.Messages) > CHUNKED_THRESHOLD {


### PR DESCRIPTION
## Summary
- Skip empty transcripts client-side before API call
- Show warning (⚠️) instead of error for empty files
- Count empty files as skipped, not errors

## Problem
Empty transcript files (0 messages) were being sent to the API, which returned a 400 error. This:
- Wastes HTTP round-trips
- Shows "errors" for non-error conditions
- Misleads users into thinking something is broken

## Solution
Check for empty transcripts before the API call and skip them with a warning:
```
⚠️  Skipping empty transcript: project/session.jsonl
```

## Test plan
- [x] Verified empty transcripts show warning instead of error
- [x] Verified skipped count increments correctly
- [x] Verified non-empty transcripts still sync normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)