### PR TITLE
fix: show parse errors during sync

### DIFF
--- a/cmd/sync.go
+++ b/cmd/sync.go
@@ -126,6 +126,12 @@ func runSync(cmd *cobra.Command, args []string) error {
 			// Parse file first to get hash
 			conversation, err := parser.ParseFile(filePath)
 			if err != nil {
+				// Show truncated path for parse errors
+				displayName := filepath.Base(filepath.Dir(filePath)) + "/" + filepath.Base(filePath)
+				if len(displayName) > 60 {
+					displayName = "..." + displayName[len(displayName)-57:]
+				}
+				fmt.Printf("  ❌ Parse error: %s: %v\n", displayName, err)
 				results = append(results, sync.SyncResult{
 					FilePath: filePath,
 					Status:   "error",


### PR DESCRIPTION
## Summary
Parse errors were being counted but not printed, leaving users confused about what the "errors" in the summary referred to.

## Changes
Now shows parse errors with the file path and error message:
```
❌ Parse error: path/file.jsonl: error message
```

## Discovery
This fix revealed the actual cause of the 5 errors:
```
bufio.Scanner: token too long
```

These are files with individual JSONL lines exceeding the 10MB scanner buffer limit (likely huge tool outputs). This is a **separate issue** that should be addressed by increasing the buffer or using a streaming approach.

## Test plan
- [x] Verified parse errors now display with file path and error message
- [x] Identified root cause of remaining errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)