### PR TITLE
feat: add file size threshold and resume support for chunked uploads

### DIFF
--- a/internal/sync/types.go
+++ b/internal/sync/types.go
@@ -43,7 +43,17 @@ type ParsedMessage struct {
 
 // SyncState tracks which files have been synced
 type SyncState struct {
-	SyncedFiles map[string]SyncedFileInfo `json:"synced_files"`
+	SyncedFiles    map[string]SyncedFileInfo    `json:"synced_files"`
+	PendingUploads map[string]PendingUploadInfo `json:"pending_uploads,omitempty"`
+}
+
+// PendingUploadInfo tracks an in-progress chunked upload for resume support
+type PendingUploadInfo struct {
+	UploadID       string `json:"upload_id"`
+	SourceFileHash string `json:"source_file_hash"`
+	TotalChunks    int    `json:"total_chunks"`
+	ChunksUploaded int    `json:"chunks_uploaded"` // Last successfully uploaded chunk index + 1
+	StartedAt      string `json:"started_at"`
 }
 
 // SyncedFileInfo stores information about a synced file


### PR DESCRIPTION
## Summary
- Add file size threshold (5MB) to trigger chunked uploads for large files regardless of message count
- Add resume support for interrupted chunked uploads with progress tracking

## Changes
- **File size threshold**: Chunked upload now triggers on file size > 5MB OR message count > 1000
  - Catches large files with few but huge messages (e.g., 71MB file with 832 messages)
  - Output shows reason: `[chunked: 2 chunks, 71.5MB]` vs `[chunked: 3 chunks, messages]`

- **Resume support**: Track and resume interrupted chunked uploads
  - Pending uploads saved to `sync_state.json` with upload_id, hash, and progress
  - Resume from last successful chunk on retry
  - Clear pending upload on success or when file hash changes

## Test plan
- [x] Build and test passes
- [x] Dry-run shows correct chunking info (file size vs message count reason)
- [x] Actual sync works with chunked upload
- [x] Pending uploads cleared on successful completion
- [ ] Test resume by interrupting upload mid-chunk (manual test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)