### PR TITLE
feat(cli): auto-sync transcripts on SessionEnd hook

### DIFF
--- a/internal/sync/types.go
+++ b/internal/sync/types.go
@@ -45,6 +45,16 @@ type ParsedMessage struct {
 type SyncState struct {
 	SyncedFiles    map[string]SyncedFileInfo    `json:"synced_files"`
 	PendingUploads map[string]PendingUploadInfo `json:"pending_uploads,omitempty"`
+	FailedSyncs    map[string]FailedSyncInfo    `json:"failed_syncs,omitempty"`
+}
+
+// FailedSyncInfo tracks a sync that failed and should be retried
+type FailedSyncInfo struct {
+	SessionID  string `json:"session_id"`
+	FilePath   string `json:"file_path"`
+	FailedAt   string `json:"failed_at"`
+	RetryCount int    `json:"retry_count"`
+	LastError  string `json:"last_error"`
 }
 
 // PendingUploadInfo tracks an in-progress chunked upload for resume support


### PR DESCRIPTION
## Summary

Automatically sync transcripts to the platform when a Claude Code session ends, eliminating the need for users to manually run `promptconduit sync`.

## Changes

- **cmd/hook.go**: Add SessionEnd detection that triggers auto-sync with 1-second delay
- **cmd/sync.go**: Add `--file` flag for single-file sync, track failures for retry
- **internal/sync/claudecode.go**: Add `FindTranscriptBySessionID()` to locate transcripts
- **internal/sync/state.go**: Add failed sync tracking methods
- **internal/sync/types.go**: Add `FailedSyncInfo` type for retry queue

## How It Works

1. On `SessionEnd` hook: waits 1 second, finds transcript file, spawns `promptconduit sync --file <path>` in background
2. On sync failure: adds to retry queue in `~/.config/promptconduit/sync_state.json`
3. On next `SessionEnd`: also retries any failed syncs (max 3 attempts each)
4. Always enabled, no opt-out configuration
5. Existing hash-based deduplication prevents duplicate uploads

## Testing

- `make build` - compiles successfully
- `make test` - all 12 tests pass
- `make lint` - no new lint errors from these changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)