### PR TITLE
feat: register missing Claude Code hook events

### DIFF
--- a/configs/claude-code/hooks.json
+++ b/configs/claude-code/hooks.json
@@ -35,6 +35,18 @@
         ]
       }
     ],
+    "PostToolUseFailure": [
+      {
+        "matcher": "*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 \"${PROMPTCONDUIT_HOOK_PATH:-~/.local/share/promptconduit/promptconduit_hook.py}\"",
+            "timeout": 5000
+          }
+        ]
+      }
+    ],
     "SessionStart": [
       {
         "hooks": [
@@ -48,6 +60,77 @@
     ],
     "SessionEnd": [
       {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 \"${PROMPTCONDUIT_HOOK_PATH:-~/.local/share/promptconduit/promptconduit_hook.py}\"",
+            "timeout": 5000
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 \"${PROMPTCONDUIT_HOOK_PATH:-~/.local/share/promptconduit/promptconduit_hook.py}\"",
+            "timeout": 5000
+          }
+        ]
+      }
+    ],
+    "SubagentStart": [
+      {
+        "matcher": "*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 \"${PROMPTCONDUIT_HOOK_PATH:-~/.local/share/promptconduit/promptconduit_hook.py}\"",
+            "timeout": 5000
+          }
+        ]
+      }
+    ],
+    "SubagentStop": [
+      {
+        "matcher": "*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 \"${PROMPTCONDUIT_HOOK_PATH:-~/.local/share/promptconduit/promptconduit_hook.py}\"",
+            "timeout": 5000
+          }
+        ]
+      }
+    ],
+    "PreCompact": [
+      {
+        "matcher": "*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 \"${PROMPTCONDUIT_HOOK_PATH:-~/.local/share/promptconduit/promptconduit_hook.py}\"",
+            "timeout": 5000
+          }
+        ]
+      }
+    ],
+    "PermissionRequest": [
+      {
+        "matcher": "*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 \"${PROMPTCONDUIT_HOOK_PATH:-~/.local/share/promptconduit/promptconduit_hook.py}\"",
+            "timeout": 5000
+          }
+        ]
+      }
+    ],
+    "Notification": [
+      {
+        "matcher": "*",
         "hooks": [
           {
             "type": "command",


### PR DESCRIPTION
## Summary

Add hook registrations for 7 additional Claude Code events to capture better analytics and developer productivity insights.

## New Hook Registrations

| Event | Matcher | Purpose |
|-------|---------|---------|
| `Stop` | None (always fires) | When Claude finishes responding |
| `SubagentStart` | `"*"` | When a subagent is spawned |
| `SubagentStop` | `"*"` | When a subagent finishes |
| `PostToolUseFailure` | `"*"` | Tool execution failures |
| `PreCompact` | `"*"` | Context compaction events |
| `PermissionRequest` | `"*"` | Permission dialogs |
| `Notification` | `"*"` | System notifications |

## Changes

- `configs/claude-code/hooks.json`: Added 7 new hook registrations

## Testing

After merging, reinstall hooks to pick up new events:
```bash
promptconduit uninstall claude-code && promptconduit install claude-code
```

## Dependencies

Requires the corresponding platform PR to be merged first:
- https://github.com/promptconduit/platform/pull/61

🤖 Generated with [Claude Code](https://claude.ai/code)