### PR TITLE
fix: add missing hook registrations to install command

### DIFF
--- a/cmd/install.go
+++ b/cmd/install.go
@@ -133,14 +133,21 @@ func buildClaudeCodeHooks(hookCmd string) map[string]interface{} {
 	}
 
 	return map[string]interface{}{
-		"UserPromptSubmit": []map[string]interface{}{
-			{"hooks": makeHook(5000)},
-		},
-		"PreToolUse":   makeMatcherHook(5000),
-		"PostToolUse":  makeMatcherHook(5000),
-		"Stop":         []map[string]interface{}{{"hooks": makeHook(5000)}}, // For attachment extraction
-		"SessionStart": []map[string]interface{}{{"hooks": makeHook(5000)}},
-		"SessionEnd":   []map[string]interface{}{{"hooks": makeHook(5000)}},
+		// Core events
+		"UserPromptSubmit": []map[string]interface{}{{"hooks": makeHook(5000)}},
+		"PreToolUse":       makeMatcherHook(5000),
+		"PostToolUse":      makeMatcherHook(5000),
+		"PostToolUseFailure": makeMatcherHook(5000), // Tool execution failures
+		"SessionStart":     []map[string]interface{}{{"hooks": makeHook(5000)}},
+		"SessionEnd":       []map[string]interface{}{{"hooks": makeHook(5000)}},
+		// Agent events
+		"Stop":          []map[string]interface{}{{"hooks": makeHook(5000)}}, // Agent completes response
+		"SubagentStart": makeMatcherHook(5000),                               // Subagent spawned
+		"SubagentStop":  makeMatcherHook(5000),                               // Subagent completes
+		// Context and permission events
+		"PreCompact":        makeMatcherHook(5000), // Context compaction
+		"PermissionRequest": makeMatcherHook(5000), // Permission dialogs
+		"Notification":      makeMatcherHook(5000), // System notifications
 	}
 }
 


### PR DESCRIPTION
## Summary

The install.go file had hardcoded hooks that didn't include the new events. This adds all 12 Claude Code hooks to the install command.

## Problem

The previous PR (#25) only updated `configs/claude-code/hooks.json` but that file isn't actually read by the install command - the hooks are hardcoded in `cmd/install.go`.

## Changes

Updated `buildClaudeCodeHooks()` to include all 12 hooks:

**Core events:**
- UserPromptSubmit, PreToolUse, PostToolUse, PostToolUseFailure
- SessionStart, SessionEnd

**Agent events:**
- Stop, SubagentStart, SubagentStop

**Context and permission events:**
- PreCompact, PermissionRequest, Notification

## Testing

```bash
make build
./promptconduit uninstall claude-code && ./promptconduit install claude-code
# Verified all 12 hooks appear in ~/.claude/settings.json
```

🤖 Generated with [Claude Code](https://claude.ai/code)