### PR TITLE
feat(cli): trigger auto-sync on Stop events for reliable transcript syncing

### DIFF
--- a/internal/sync/claudecode.go
+++ b/internal/sync/claudecode.go
@@ -546,3 +546,8 @@ func calculateFileHash(path string) (string, error) {
 
 	return hex.EncodeToString(hasher.Sum(nil)), nil
 }
+
+// CalculateFileHash calculates the SHA256 hash of a file (exported for fast-path sync checks)
+func CalculateFileHash(path string) (string, error) {
+	return calculateFileHash(path)
+}


### PR DESCRIPTION
## Summary

- Auto-sync now triggers on `Stop` events (after each Claude response), not just `SessionEnd`
- `SessionEnd` rarely fires since users typically close terminal windows rather than using `/exit`
- Added fast-path hash check before parsing to make frequent triggers efficient

## Test plan

- [ ] Build and install: `make build`
- [ ] Start a Claude Code session and have a conversation
- [ ] Verify transcript syncs after each response by checking:
  ```bash
  cat ~/.config/promptconduit/sync_state.json | jq '.synced_files | to_entries | sort_by(.value.synced_at) | reverse | .[0]'
  ```
- [ ] Verify no duplicate uploads occur (hash deduplication working)

🤖 Generated with [Claude Code](https://claude.com/claude-code)