### PR TITLE
feat: skills command — generate, list, sync, patterns

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -39,6 +39,7 @@ func init() {
 	rootCmd.AddCommand(versionCmd)
 	rootCmd.AddCommand(configCmd)
 	rootCmd.AddCommand(insightsCmd)
+	rootCmd.AddCommand(skillsCmd)
 }
 
 var versionCmd = &cobra.Command{

--- a/cmd/skills.go
+++ b/cmd/skills.go
@@ -11,7 +11,6 @@ import (
 )
 
 var (
-	skillsFormat   string
 	skillsApproved string
 	skillsType     string
 	skillsLimit    int
@@ -95,18 +94,18 @@ Requires the Anthropic API key to be configured on the platform.`,
 }
 
 func init() {
-	skillsListCmd.Flags().StringVarP(&skillsFormat, "format", "f", "text", "Output format (text, json)")
+	skillsListCmd.Flags().StringP("format", "f", "text", "Output format (text, json)")
 	skillsListCmd.Flags().StringVar(&skillsApproved, "approved", "", "Filter by approval: true, false, or pending")
 	skillsListCmd.Flags().StringVar(&skillsType, "type", "", "Filter by type: workflow, command, template, checklist")
 	skillsListCmd.Flags().IntVarP(&skillsLimit, "limit", "l", 50, "Maximum number of skills to show")
 
 	skillsGenerateCmd.Flags().BoolVar(&skillsForce, "force", false, "Re-analyze even if cache is still valid")
-	skillsGenerateCmd.Flags().StringVarP(&skillsFormat, "format", "f", "text", "Output format (text, json)")
+	skillsGenerateCmd.Flags().StringP("format", "f", "text", "Output format (text, json)")
 
 	skillsSyncCmd.Flags().StringVar(&skillsSyncDir, "dir", "", "Target directory (default: ~/.claude/commands/)")
-	skillsSyncCmd.Flags().StringVarP(&skillsFormat, "format", "f", "text", "Output format (text, json)")
+	skillsSyncCmd.Flags().StringP("format", "f", "text", "Output format (text, json)")
 
-	skillsPatternsCmd.Flags().StringVarP(&skillsFormat, "format", "f", "text", "Output format (text, json)")
+	skillsPatternsCmd.Flags().StringP("format", "f", "text", "Output format (text, json)")
 
 	skillsCmd.AddCommand(skillsListCmd)
 	skillsCmd.AddCommand(skillsGenerateCmd)
@@ -139,7 +138,8 @@ func runSkillsList(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("failed to list skills: %s", resp.Error)
 	}
 
-	if skillsFormat == "json" {
+	format, _ := cmd.Flags().GetString("format")
+	if format == "json" {
 		return outputJSON(resp.Data)
 	}
 
@@ -163,7 +163,8 @@ func runSkillsGenerate(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("failed to generate skills: %s", resp.Error)
 	}
 
-	if skillsFormat == "json" {
+	format, _ := cmd.Flags().GetString("format")
+	if format == "json" {
 		return outputJSON(resp.Data)
 	}
 
@@ -285,7 +286,8 @@ func runSkillsPatterns(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("failed to get patterns: %s", resp.Error)
 	}
 
-	if skillsFormat == "json" {
+	format, _ := cmd.Flags().GetString("format")
+	if format == "json" {
 		return outputJSON(resp.Data)
 	}
 
@@ -474,8 +476,9 @@ func outputPromptPatterns(data map[string]interface{}) error {
 }
 
 func truncateString(s string, max int) string {
-	if len(s) <= max {
+	runes := []rune(s)
+	if len(runes) <= max {
 		return s
 	}
-	return s[:max-3] + "..."
+	return string(runes[:max-3]) + "..."
 }

--- a/cmd/skills.go
+++ b/cmd/skills.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/promptconduit/cli/internal/client"
+	"github.com/promptconduit/cli/internal/git"
 	"github.com/spf13/cobra"
 )
 
@@ -16,6 +17,7 @@ var (
 	skillsLimit    int
 	skillsForce    bool
 	skillsSyncDir  string
+	skillsRepo     string
 )
 
 // skillsCmd is the parent command
@@ -98,14 +100,17 @@ func init() {
 	skillsListCmd.Flags().StringVar(&skillsApproved, "approved", "", "Filter by approval: true, false, or pending")
 	skillsListCmd.Flags().StringVar(&skillsType, "type", "", "Filter by type: workflow, command, template, checklist")
 	skillsListCmd.Flags().IntVarP(&skillsLimit, "limit", "l", 50, "Maximum number of skills to show")
+	skillsListCmd.Flags().StringVar(&skillsRepo, "repo", "", "Filter to a specific project (e.g. my-org/my-repo)")
 
 	skillsGenerateCmd.Flags().BoolVar(&skillsForce, "force", false, "Re-analyze even if cache is still valid")
 	skillsGenerateCmd.Flags().StringP("format", "f", "text", "Output format (text, json)")
+	skillsGenerateCmd.Flags().StringVar(&skillsRepo, "repo", "", "Scope to a specific project (auto-detected if in a git repo)")
 
-	skillsSyncCmd.Flags().StringVar(&skillsSyncDir, "dir", "", "Target directory (default: ~/.claude/commands/)")
+	skillsSyncCmd.Flags().StringVar(&skillsSyncDir, "dir", "", "Override global command directory (default: ~/.claude/commands/)")
 	skillsSyncCmd.Flags().StringP("format", "f", "text", "Output format (text, json)")
 
 	skillsPatternsCmd.Flags().StringP("format", "f", "text", "Output format (text, json)")
+	skillsPatternsCmd.Flags().StringVar(&skillsRepo, "repo", "", "Scope to a specific project (auto-detected if in a git repo)")
 
 	skillsCmd.AddCommand(skillsListCmd)
 	skillsCmd.AddCommand(skillsGenerateCmd)
@@ -132,7 +137,7 @@ func runSkillsList(cmd *cobra.Command, args []string) error {
 	}
 
 	apiClient := client.NewClient(cfg, Version)
-	resp := apiClient.GetSkills(approvedFilter, skillsType, skillsLimit)
+	resp := apiClient.GetSkills(approvedFilter, skillsType, skillsLimit, skillsRepo)
 
 	if !resp.Success {
 		return fmt.Errorf("failed to list skills: %s", resp.Error)
@@ -152,12 +157,25 @@ func runSkillsGenerate(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("API key not configured. Run: promptconduit config set --api-key=\"your-key\"")
 	}
 
-	fmt.Println("Analyzing your AI coding session patterns...")
+	// Auto-detect repo from working directory if --repo not explicitly set
+	repo := skillsRepo
+	if repo == "" {
+		cwd, err := os.Getwd()
+		if err == nil {
+			repo = git.GetRepoName(cwd)
+		}
+	}
+
+	if repo != "" {
+		fmt.Printf("Analyzing AI coding session patterns for %q...\n", repo)
+	} else {
+		fmt.Println("Analyzing your AI coding session patterns (global)...")
+	}
 	fmt.Println("This may take up to 30 seconds.")
 	fmt.Println()
 
 	apiClient := client.NewClient(cfg, Version)
-	resp := apiClient.GenerateSkills(skillsForce)
+	resp := apiClient.GenerateSkills(skillsForce, repo)
 
 	if !resp.Success {
 		return fmt.Errorf("failed to generate skills: %s", resp.Error)
@@ -177,25 +195,24 @@ func runSkillsSync(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("API key not configured. Run: promptconduit config set --api-key=\"your-key\"")
 	}
 
-	// Determine target directory
-	targetDir := skillsSyncDir
-	if targetDir == "" {
+	// Determine the global commands directory (~/.claude/commands/ or --dir override)
+	globalDir := skillsSyncDir
+	if globalDir == "" {
 		home, err := os.UserHomeDir()
 		if err != nil {
 			return fmt.Errorf("failed to determine home directory: %w", err)
 		}
-		targetDir = filepath.Join(home, ".claude", "commands")
+		globalDir = filepath.Join(home, ".claude", "commands")
 	}
 
-	// Ensure target directory exists
-	if err := os.MkdirAll(targetDir, 0755); err != nil {
-		return fmt.Errorf("failed to create commands directory %s: %w", targetDir, err)
-	}
+	// Detect git root for project-scoped skill routing (.claude/commands/ in repo)
+	cwd, _ := os.Getwd()
+	gitRoot := detectGitRoot(cwd)
 
 	apiClient := client.NewClient(cfg, Version)
 
-	// Fetch approved skills
-	resp := apiClient.GetSkills("true", "", 100)
+	// Fetch all approved skills (global + project)
+	resp := apiClient.GetSkills("true", "", 100, "")
 	if !resp.Success {
 		return fmt.Errorf("failed to fetch approved skills: %s", resp.Error)
 	}
@@ -214,7 +231,7 @@ func runSkillsSync(cmd *cobra.Command, args []string) error {
 	synced := 0
 	failed := 0
 
-	fmt.Printf("Syncing %d approved skills to %s\n\n", len(skillsList), targetDir)
+	fmt.Printf("Syncing %d approved skills...\n\n", len(skillsList))
 
 	for _, s := range skillsList {
 		skill, ok := s.(map[string]interface{})
@@ -225,11 +242,24 @@ func runSkillsSync(cmd *cobra.Command, args []string) error {
 		id, _ := skill["id"].(string)
 		name, _ := skill["name"].(string)
 		displayName, _ := skill["display_name"].(string)
+		repoName, _ := skill["repo_name"].(string)
 		if displayName == "" {
 			displayName = name
 		}
 
 		if id == "" || name == "" {
+			continue
+		}
+
+		// Route: project skills → .claude/commands/ at git root; global → ~/.claude/commands/
+		targetDir := globalDir
+		if repoName != "" && gitRoot != "" {
+			targetDir = filepath.Join(gitRoot, ".claude", "commands")
+		}
+
+		if err := os.MkdirAll(targetDir, 0755); err != nil {
+			fmt.Printf("  [FAIL] %s: failed to create directory %s: %v\n", name, targetDir, err)
+			failed++
 			continue
 		}
 
@@ -241,7 +271,6 @@ func runSkillsSync(cmd *cobra.Command, args []string) error {
 			continue
 		}
 
-		// Write to ~/.claude/commands/<name>.md
 		filename := filepath.Join(targetDir, name+".md")
 		if err := os.WriteFile(filename, []byte(content), 0644); err != nil {
 			fmt.Printf("  [FAIL] %s: failed to write file: %v\n", name, err)
@@ -249,10 +278,11 @@ func runSkillsSync(cmd *cobra.Command, args []string) error {
 			continue
 		}
 
-		fmt.Printf("  [OK]   /%s → %s\n", name, filepath.Base(filename))
-		if displayName != name {
-			fmt.Printf("         %s\n", displayName)
+		scope := "global"
+		if repoName != "" {
+			scope = repoName
 		}
+		fmt.Printf("  [OK]   /%s (%s) → %s\n", name, scope, filename)
 		synced++
 	}
 
@@ -260,7 +290,10 @@ func runSkillsSync(cmd *cobra.Command, args []string) error {
 
 	if synced > 0 {
 		fmt.Printf("\nSkills installed! Use them in Claude Code with /<skill-name>\n")
-		fmt.Printf("Location: %s\n", targetDir)
+		if gitRoot != "" {
+			fmt.Printf("Project skills: %s\n", filepath.Join(gitRoot, ".claude", "commands"))
+		}
+		fmt.Printf("Global skills:  %s\n", globalDir)
 	}
 
 	if failed > 0 {
@@ -270,17 +303,48 @@ func runSkillsSync(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
+// detectGitRoot walks up from dir to find the git repository root.
+// Returns empty string if not in a git repo.
+func detectGitRoot(dir string) string {
+	if dir == "" {
+		return ""
+	}
+	for {
+		if _, err := os.Stat(filepath.Join(dir, ".git")); err == nil {
+			return dir
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			return ""
+		}
+		dir = parent
+	}
+}
+
 func runSkillsPatterns(cmd *cobra.Command, args []string) error {
 	cfg := client.LoadConfig()
 	if !cfg.IsConfigured() {
 		return fmt.Errorf("API key not configured. Run: promptconduit config set --api-key=\"your-key\"")
 	}
 
-	fmt.Println("Analyzing your prompt history for recurring patterns...")
+	// Auto-detect repo from working directory if --repo not explicitly set
+	repo := skillsRepo
+	if repo == "" {
+		cwd, err := os.Getwd()
+		if err == nil {
+			repo = git.GetRepoName(cwd)
+		}
+	}
+
+	if repo != "" {
+		fmt.Printf("Analyzing prompt history for %q...\n", repo)
+	} else {
+		fmt.Println("Analyzing your prompt history for recurring patterns...")
+	}
 	fmt.Println()
 
 	apiClient := client.NewClient(cfg, Version)
-	resp := apiClient.GetSkillPatterns()
+	resp := apiClient.GetSkillPatterns(repo)
 
 	if !resp.Success {
 		return fmt.Errorf("failed to get patterns: %s", resp.Error)

--- a/cmd/skills.go
+++ b/cmd/skills.go
@@ -1,0 +1,481 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/promptconduit/cli/internal/client"
+	"github.com/spf13/cobra"
+)
+
+var (
+	skillsFormat   string
+	skillsApproved string
+	skillsType     string
+	skillsLimit    int
+	skillsForce    bool
+	skillsSyncDir  string
+)
+
+// skillsCmd is the parent command
+var skillsCmd = &cobra.Command{
+	Use:   "skills",
+	Short: "Manage AI-generated skills and slash commands",
+	Long: `PromptConduit analyzes your AI assistant usage patterns and generates
+reusable slash commands (skills) tailored to how you work.
+
+Skills are Claude Code command files stored in ~/.claude/commands/.
+Once synced, invoke them with /skill-name inside Claude Code.
+
+Examples:
+  promptconduit skills generate         # Detect skills from your usage patterns
+  promptconduit skills list             # List detected skills
+  promptconduit skills list --approved  # Show only approved skills
+  promptconduit skills sync             # Install approved skills to ~/.claude/commands/
+  promptconduit skills patterns         # Show recurring prompt patterns`,
+}
+
+// skillsListCmd lists skills from the platform
+var skillsListCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List detected skills",
+	Long: `List skills detected from your AI coding session patterns.
+
+Use --approved to filter for approved skills ready to install.
+Use --type to filter by skill type (workflow, command, template, checklist).`,
+	RunE: runSkillsList,
+}
+
+// skillsGenerateCmd triggers skill generation on the platform
+var skillsGenerateCmd = &cobra.Command{
+	Use:   "generate",
+	Short: "Detect skills from your usage patterns",
+	Long: `Analyze your AI coding session history to detect repeatable workflows
+and generate suggested slash commands (skills).
+
+The platform analyzes:
+  - Conversation patterns from synced transcripts
+  - Recurring prompt themes (repeated questions and requests)
+
+Generated skills are pending approval. Review them with 'skills list',
+then install with 'skills sync' after approving in the dashboard.
+
+Results are cached for 24 hours. Use --force to re-analyze.`,
+	RunE: runSkillsGenerate,
+}
+
+// skillsSyncCmd downloads approved skills to ~/.claude/commands/
+var skillsSyncCmd = &cobra.Command{
+	Use:   "sync",
+	Short: "Install approved skills to ~/.claude/commands/",
+	Long: `Download all approved skills as Claude Code command files.
+
+Each skill becomes a .md file in ~/.claude/commands/ (or --dir).
+After syncing, invoke skills with /skill-name inside Claude Code.
+
+Skills are only synced if they have been approved in the PromptConduit
+dashboard or via the API. Pending skills are not installed.`,
+	RunE: runSkillsSync,
+}
+
+// skillsPatternsCmd shows detected prompt patterns
+var skillsPatternsCmd = &cobra.Command{
+	Use:   "patterns",
+	Short: "Show recurring prompt patterns from your usage",
+	Long: `Analyze your prompt history to show recurring themes and requests.
+
+This shows what you repeatedly ask your AI assistant, grouped by theme.
+These patterns drive skill generation — if you see a pattern here,
+running 'skills generate' will produce a skill for it.
+
+Requires the Anthropic API key to be configured on the platform.`,
+	RunE: runSkillsPatterns,
+}
+
+func init() {
+	skillsListCmd.Flags().StringVarP(&skillsFormat, "format", "f", "text", "Output format (text, json)")
+	skillsListCmd.Flags().StringVar(&skillsApproved, "approved", "", "Filter by approval: true, false, or pending")
+	skillsListCmd.Flags().StringVar(&skillsType, "type", "", "Filter by type: workflow, command, template, checklist")
+	skillsListCmd.Flags().IntVarP(&skillsLimit, "limit", "l", 50, "Maximum number of skills to show")
+
+	skillsGenerateCmd.Flags().BoolVar(&skillsForce, "force", false, "Re-analyze even if cache is still valid")
+	skillsGenerateCmd.Flags().StringVarP(&skillsFormat, "format", "f", "text", "Output format (text, json)")
+
+	skillsSyncCmd.Flags().StringVar(&skillsSyncDir, "dir", "", "Target directory (default: ~/.claude/commands/)")
+	skillsSyncCmd.Flags().StringVarP(&skillsFormat, "format", "f", "text", "Output format (text, json)")
+
+	skillsPatternsCmd.Flags().StringVarP(&skillsFormat, "format", "f", "text", "Output format (text, json)")
+
+	skillsCmd.AddCommand(skillsListCmd)
+	skillsCmd.AddCommand(skillsGenerateCmd)
+	skillsCmd.AddCommand(skillsSyncCmd)
+	skillsCmd.AddCommand(skillsPatternsCmd)
+}
+
+// ============================================================================
+// HANDLERS
+// ============================================================================
+
+func runSkillsList(cmd *cobra.Command, args []string) error {
+	cfg := client.LoadConfig()
+	if !cfg.IsConfigured() {
+		return fmt.Errorf("API key not configured. Run: promptconduit config set --api-key=\"your-key\"")
+	}
+
+	// Translate --approved flag
+	approvedFilter := ""
+	if skillsApproved == "true" {
+		approvedFilter = "true"
+	} else if skillsApproved == "false" || skillsApproved == "pending" {
+		approvedFilter = "false"
+	}
+
+	apiClient := client.NewClient(cfg, Version)
+	resp := apiClient.GetSkills(approvedFilter, skillsType, skillsLimit)
+
+	if !resp.Success {
+		return fmt.Errorf("failed to list skills: %s", resp.Error)
+	}
+
+	if skillsFormat == "json" {
+		return outputJSON(resp.Data)
+	}
+
+	return outputSkillsList(resp.Data)
+}
+
+func runSkillsGenerate(cmd *cobra.Command, args []string) error {
+	cfg := client.LoadConfig()
+	if !cfg.IsConfigured() {
+		return fmt.Errorf("API key not configured. Run: promptconduit config set --api-key=\"your-key\"")
+	}
+
+	fmt.Println("Analyzing your AI coding session patterns...")
+	fmt.Println("This may take up to 30 seconds.")
+	fmt.Println()
+
+	apiClient := client.NewClient(cfg, Version)
+	resp := apiClient.GenerateSkills(skillsForce)
+
+	if !resp.Success {
+		return fmt.Errorf("failed to generate skills: %s", resp.Error)
+	}
+
+	if skillsFormat == "json" {
+		return outputJSON(resp.Data)
+	}
+
+	return outputSkillsGenerated(resp.Data)
+}
+
+func runSkillsSync(cmd *cobra.Command, args []string) error {
+	cfg := client.LoadConfig()
+	if !cfg.IsConfigured() {
+		return fmt.Errorf("API key not configured. Run: promptconduit config set --api-key=\"your-key\"")
+	}
+
+	// Determine target directory
+	targetDir := skillsSyncDir
+	if targetDir == "" {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return fmt.Errorf("failed to determine home directory: %w", err)
+		}
+		targetDir = filepath.Join(home, ".claude", "commands")
+	}
+
+	// Ensure target directory exists
+	if err := os.MkdirAll(targetDir, 0755); err != nil {
+		return fmt.Errorf("failed to create commands directory %s: %w", targetDir, err)
+	}
+
+	apiClient := client.NewClient(cfg, Version)
+
+	// Fetch approved skills
+	resp := apiClient.GetSkills("true", "", 100)
+	if !resp.Success {
+		return fmt.Errorf("failed to fetch approved skills: %s", resp.Error)
+	}
+
+	skillsList, ok := resp.Data["skills"].([]interface{})
+	if !ok || len(skillsList) == 0 {
+		fmt.Println("No approved skills to sync.")
+		fmt.Println()
+		fmt.Println("To get started:")
+		fmt.Println("  1. Run 'promptconduit skills generate' to detect skills from your usage")
+		fmt.Println("  2. Approve skills in the PromptConduit dashboard")
+		fmt.Println("  3. Run 'promptconduit skills sync' again")
+		return nil
+	}
+
+	synced := 0
+	failed := 0
+
+	fmt.Printf("Syncing %d approved skills to %s\n\n", len(skillsList), targetDir)
+
+	for _, s := range skillsList {
+		skill, ok := s.(map[string]interface{})
+		if !ok {
+			continue
+		}
+
+		id, _ := skill["id"].(string)
+		name, _ := skill["name"].(string)
+		displayName, _ := skill["display_name"].(string)
+		if displayName == "" {
+			displayName = name
+		}
+
+		if id == "" || name == "" {
+			continue
+		}
+
+		// Fetch the formatted command file
+		content, err := apiClient.GetSkillCommandFile(id)
+		if err != nil {
+			fmt.Printf("  [FAIL] %s: %v\n", name, err)
+			failed++
+			continue
+		}
+
+		// Write to ~/.claude/commands/<name>.md
+		filename := filepath.Join(targetDir, name+".md")
+		if err := os.WriteFile(filename, []byte(content), 0644); err != nil {
+			fmt.Printf("  [FAIL] %s: failed to write file: %v\n", name, err)
+			failed++
+			continue
+		}
+
+		fmt.Printf("  [OK]   /%s → %s\n", name, filepath.Base(filename))
+		if displayName != name {
+			fmt.Printf("         %s\n", displayName)
+		}
+		synced++
+	}
+
+	fmt.Printf("\n%d synced, %d failed\n", synced, failed)
+
+	if synced > 0 {
+		fmt.Printf("\nSkills installed! Use them in Claude Code with /<skill-name>\n")
+		fmt.Printf("Location: %s\n", targetDir)
+	}
+
+	if failed > 0 {
+		return fmt.Errorf("%d skill(s) failed to sync", failed)
+	}
+
+	return nil
+}
+
+func runSkillsPatterns(cmd *cobra.Command, args []string) error {
+	cfg := client.LoadConfig()
+	if !cfg.IsConfigured() {
+		return fmt.Errorf("API key not configured. Run: promptconduit config set --api-key=\"your-key\"")
+	}
+
+	fmt.Println("Analyzing your prompt history for recurring patterns...")
+	fmt.Println()
+
+	apiClient := client.NewClient(cfg, Version)
+	resp := apiClient.GetSkillPatterns()
+
+	if !resp.Success {
+		return fmt.Errorf("failed to get patterns: %s", resp.Error)
+	}
+
+	if skillsFormat == "json" {
+		return outputJSON(resp.Data)
+	}
+
+	return outputPromptPatterns(resp.Data)
+}
+
+// ============================================================================
+// OUTPUT FORMATTERS
+// ============================================================================
+
+func outputSkillsList(data map[string]interface{}) error {
+	skills, _ := data["skills"].([]interface{})
+	total, _ := data["total"].(float64)
+
+	fmt.Println("Skills")
+	fmt.Println(strings.Repeat("=", 60))
+	fmt.Println()
+
+	if len(skills) == 0 {
+		fmt.Println("No skills found.")
+		fmt.Println()
+		fmt.Println("Run 'promptconduit skills generate' to detect skills from your usage patterns.")
+		return nil
+	}
+
+	for _, s := range skills {
+		skill, ok := s.(map[string]interface{})
+		if !ok {
+			continue
+		}
+
+		name, _ := skill["name"].(string)
+		displayName, _ := skill["display_name"].(string)
+		description, _ := skill["description"].(string)
+		skillType, _ := skill["skill_type"].(string)
+		confidence, _ := skill["confidence"].(float64)
+		isApproved := skill["is_approved"]
+
+		// Approval status indicator
+		status := "[pending]"
+		if isApproved == true || isApproved == float64(1) {
+			status = "[approved]"
+		} else if isApproved == false || isApproved == float64(0) {
+			status = "[rejected]"
+		}
+
+		fmt.Printf("/%s  %s  %s  %.0f%%\n", name, skillType, status, confidence*100)
+		if displayName != "" && displayName != name {
+			fmt.Printf("  %s\n", displayName)
+		}
+		if description != "" {
+			fmt.Printf("  %s\n", description)
+		}
+		fmt.Println()
+	}
+
+	if total > float64(len(skills)) {
+		fmt.Printf("Showing %d of %.0f skills\n", len(skills), total)
+	}
+
+	fmt.Println("Approve skills in the PromptConduit dashboard, then run 'promptconduit skills sync' to install.")
+	return nil
+}
+
+func outputSkillsGenerated(data map[string]interface{}) error {
+	skills, _ := data["skills"].([]interface{})
+	convCount, _ := data["conversationCount"].(float64)
+	fromCache, _ := data["fromCache"].(bool)
+
+	fmt.Println("Skill Detection Results")
+	fmt.Println(strings.Repeat("=", 60))
+	fmt.Println()
+
+	if fromCache {
+		fmt.Println("(Returned from cache — use --force to re-analyze)")
+		fmt.Println()
+	} else if convCount > 0 {
+		fmt.Printf("Analyzed %.0f conversations\n\n", convCount)
+	}
+
+	if len(skills) == 0 {
+		fmt.Println("No skills detected.")
+		fmt.Println()
+		fmt.Println("Tips:")
+		fmt.Println("  • Sync more transcripts: promptconduit sync")
+		fmt.Println("  • More sessions improve detection accuracy")
+		return nil
+	}
+
+	fmt.Printf("Detected %d skills:\n\n", len(skills))
+
+	for _, s := range skills {
+		skill, ok := s.(map[string]interface{})
+		if !ok {
+			continue
+		}
+
+		name, _ := skill["name"].(string)
+		displayName, _ := skill["display_name"].(string)
+		description, _ := skill["description"].(string)
+		skillType, _ := skill["skill_type"].(string)
+		confidence, _ := skill["confidence"].(float64)
+		triggerPattern, _ := skill["trigger_pattern"].(string)
+
+		fmt.Printf("  /%s  (%s, %.0f%% confidence)\n", name, skillType, confidence*100)
+		if displayName != "" {
+			fmt.Printf("  %s\n", displayName)
+		}
+		if description != "" {
+			fmt.Printf("  %s\n", description)
+		}
+		if triggerPattern != "" {
+			fmt.Printf("  Triggers: %s\n", truncateString(triggerPattern, 80))
+		}
+		fmt.Println()
+	}
+
+	fmt.Println("Next steps:")
+	fmt.Println("  1. Review and approve skills at promptconduit.io/skills")
+	fmt.Println("  2. Run 'promptconduit skills sync' to install approved skills")
+	return nil
+}
+
+func outputPromptPatterns(data map[string]interface{}) error {
+	clusters, _ := data["clusters"].([]interface{})
+	totalPrompts, _ := data["totalPromptsAnalyzed"].(float64)
+	analysisNotes, _ := data["analysisNotes"].(string)
+	available, _ := data["available"].(bool)
+
+	fmt.Println("Prompt Patterns")
+	fmt.Println(strings.Repeat("=", 60))
+	fmt.Println()
+
+	if !available {
+		fmt.Println("Prompt pattern analysis is not available.")
+		fmt.Println("The Anthropic API key must be configured on the platform.")
+		return nil
+	}
+
+	if totalPrompts > 0 {
+		fmt.Printf("Analyzed %.0f prompts\n\n", totalPrompts)
+	}
+
+	if len(clusters) == 0 {
+		fmt.Println("No recurring patterns detected yet.")
+		fmt.Println()
+		fmt.Println("Patterns emerge after using your AI assistant more.")
+		fmt.Println("Sync transcripts and try again: promptconduit sync")
+		return nil
+	}
+
+	fmt.Printf("Found %d recurring patterns:\n\n", len(clusters))
+
+	for i, cl := range clusters {
+		cluster, ok := cl.(map[string]interface{})
+		if !ok {
+			continue
+		}
+
+		theme, _ := cluster["theme"].(string)
+		frequency, _ := cluster["frequency"].(float64)
+		description, _ := cluster["description"].(string)
+		suggestedType, _ := cluster["suggestedSkillType"].(string)
+		examples, _ := cluster["examplePrompts"].([]interface{})
+
+		fmt.Printf("%d. %s (%.0fx, suggested: %s)\n", i+1, theme, frequency, suggestedType)
+		if description != "" {
+			fmt.Printf("   %s\n", description)
+		}
+		if len(examples) > 0 {
+			for _, ex := range examples {
+				if exStr, ok := ex.(string); ok {
+					fmt.Printf("   • \"%s\"\n", truncateString(exStr, 70))
+				}
+			}
+		}
+		fmt.Println()
+	}
+
+	if analysisNotes != "" {
+		fmt.Printf("Note: %s\n\n", analysisNotes)
+	}
+
+	fmt.Println("Run 'promptconduit skills generate' to turn these patterns into skills.")
+	return nil
+}
+
+func truncateString(s string, max int) string {
+	if len(s) <= max {
+		return s
+	}
+	return s[:max-3] + "..."
+}

--- a/internal/client/api.go
+++ b/internal/client/api.go
@@ -1018,7 +1018,8 @@ func (c *Client) GetSessions(limit int, offset int, repo string) *APIResponse {
 
 // GetSkills retrieves the user's detected skills with optional filters.
 // approved: "true", "false", or "" (all); skillType: "workflow", "command", etc.
-func (c *Client) GetSkills(approved string, skillType string, limit int) *APIResponse {
+// repoName: filter to a specific project (empty = all scopes).
+func (c *Client) GetSkills(approved string, skillType string, limit int, repoName string) *APIResponse {
 	query := make(map[string]string)
 	if approved != "" {
 		query["approved"] = approved
@@ -1029,17 +1030,29 @@ func (c *Client) GetSkills(approved string, skillType string, limit int) *APIRes
 	if limit > 0 {
 		query["limit"] = fmt.Sprintf("%d", limit)
 	}
+	if repoName != "" {
+		query["repo"] = repoName
+	}
 	return c.Get("/v1/skills", query)
 }
 
 // GenerateSkills triggers skill detection on the platform.
-func (c *Client) GenerateSkills(force bool) *APIResponse {
-	return c.sendRequest("/v1/skills/generate", map[string]interface{}{"force": force})
+// repoName: scope to a specific project (empty = global).
+func (c *Client) GenerateSkills(force bool, repoName string) *APIResponse {
+	body := map[string]interface{}{"force": force}
+	if repoName != "" {
+		body["repo"] = repoName
+	}
+	return c.sendRequest("/v1/skills/generate", body)
 }
 
 // GetSkillPatterns returns detected prompt clusters for the user.
-func (c *Client) GetSkillPatterns() *APIResponse {
-	return c.Get("/v1/skills/patterns", nil)
+// repoName: scope to a specific project (empty = global).
+func (c *Client) GetSkillPatterns(repoName string) *APIResponse {
+	if repoName == "" {
+		return c.Get("/v1/skills/patterns", nil)
+	}
+	return c.Get("/v1/skills/patterns", map[string]string{"repo": repoName})
 }
 
 // ApproveSkill approves or rejects a skill by ID.

--- a/internal/client/api.go
+++ b/internal/client/api.go
@@ -1015,3 +1015,100 @@ func (c *Client) GetSessions(limit int, offset int, repo string) *APIResponse {
 	}
 	return c.Get("/v1/me/sessions", query)
 }
+
+// GetSkills retrieves the user's detected skills with optional filters.
+// approved: "true", "false", or "" (all); skillType: "workflow", "command", etc.
+func (c *Client) GetSkills(approved string, skillType string, limit int) *APIResponse {
+	query := make(map[string]string)
+	if approved != "" {
+		query["approved"] = approved
+	}
+	if skillType != "" {
+		query["skill_type"] = skillType
+	}
+	if limit > 0 {
+		query["limit"] = fmt.Sprintf("%d", limit)
+	}
+	return c.Get("/v1/skills", query)
+}
+
+// GenerateSkills triggers skill detection on the platform.
+func (c *Client) GenerateSkills(force bool) *APIResponse {
+	return c.sendRequest("/v1/skills/generate", map[string]interface{}{"force": force})
+}
+
+// GetSkillPatterns returns detected prompt clusters for the user.
+func (c *Client) GetSkillPatterns() *APIResponse {
+	return c.Get("/v1/skills/patterns", nil)
+}
+
+// ApproveSkill approves or rejects a skill by ID.
+func (c *Client) ApproveSkill(id string, approve bool) *APIResponse {
+	return c.patchRequest(fmt.Sprintf("/v1/skills/%s", id), map[string]interface{}{"is_approved": approve})
+}
+
+// GetSkillCommandFile fetches the raw markdown command file for a skill.
+// Returns the file content suitable for writing to ~/.claude/commands/<name>.md
+func (c *Client) GetSkillCommandFile(id string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Duration(c.config.TimeoutSeconds)*time.Second)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, "GET", c.config.APIURL+fmt.Sprintf("/v1/skills/%s/command", id), nil)
+	if err != nil {
+		return "", fmt.Errorf("failed to create request: %w", err)
+	}
+	c.setHeaders(req)
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", fmt.Errorf("failed to read response: %w", err)
+	}
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return "", fmt.Errorf("HTTP %d: %s", resp.StatusCode, string(body))
+	}
+
+	return string(body), nil
+}
+
+// patchRequest sends a PATCH request with a JSON payload
+func (c *Client) patchRequest(path string, payload interface{}) *APIResponse {
+	jsonData, err := json.Marshal(payload)
+	if err != nil {
+		return &APIResponse{Success: false, Error: fmt.Sprintf("failed to marshal payload: %v", err)}
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Duration(c.config.TimeoutSeconds)*time.Second)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, "PATCH", c.config.APIURL+path, bytes.NewReader(jsonData))
+	if err != nil {
+		return &APIResponse{Success: false, Error: fmt.Sprintf("failed to create request: %v", err)}
+	}
+	c.setHeaders(req)
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return &APIResponse{Success: false, Error: fmt.Sprintf("request failed: %v", err)}
+	}
+	defer resp.Body.Close()
+
+	body, _ := io.ReadAll(resp.Body)
+	result := &APIResponse{StatusCode: resp.StatusCode, Success: resp.StatusCode >= 200 && resp.StatusCode < 300}
+	if len(body) > 0 {
+		var data map[string]interface{}
+		if err := json.Unmarshal(body, &data); err == nil {
+			result.Data = data
+		}
+	}
+	if !result.Success {
+		result.Error = fmt.Sprintf("HTTP %d: %s", resp.StatusCode, string(body))
+	}
+	return result
+}


### PR DESCRIPTION
## Summary

Closes #28

Companion to promptconduit/platform#63.

Adds a `skills` command family that brings the skill generation workflow to the terminal. The key piece is `skills sync`, which downloads approved skills as `.md` files to `~/.claude/commands/`, making them immediately available as `/skill-name` slash commands in Claude Code.

## Changes

### New command (`cmd/skills.go`)
- `skills generate [--force]` — calls `POST /v1/skills/generate`, shows detected skills and next steps
- `skills list [--approved] [--type] [--format json]` — lists skills with approval status indicators
- `skills sync [--dir]` — fetches approved skills via `GET /v1/skills/:id/command` and writes each as `<name>.md` to `~/.claude/commands/`
- `skills patterns` — shows prompt clusters from `GET /v1/skills/patterns` with frequency counts and examples

### API client methods (`internal/client/api.go`)
- `GetSkills(approved, skillType, limit)` — list with filters
- `GenerateSkills(force)` — trigger detection
- `GetSkillPatterns()` — fetch prompt clusters
- `ApproveSkill(id, approve)` — approve/reject
- `GetSkillCommandFile(id)` — fetch raw markdown (non-JSON response)
- `patchRequest()` — shared PATCH helper

### Registration (`cmd/root.go`)
- `skillsCmd` added to root command

## Code Walkthrough

### sync subcommand
```go
// Fetch approved skills, download each command file, write to disk
for _, s := range skillsList {
    content, err := apiClient.GetSkillCommandFile(id)
    filename := filepath.Join(targetDir, name+".md")
    os.WriteFile(filename, []byte(content), 0644)
    fmt.Printf("  [OK]   /%s → %s\n", name, filepath.Base(filename))
}
```

`GetSkillCommandFile` uses a raw HTTP GET (not `sendRequest`) because the response is `text/markdown`, not JSON — same pattern used elsewhere for binary/text responses.

## Testing
- `make build` passes cleanly
- `./promptconduit skills --help` shows all subcommands
- Follows identical structure to `insights.go` (same pattern for API calls, output formatters)

## Agent Review Context

- **change-type**: feature
- **risk-level**: low — purely additive, no changes to existing commands
- **key-files**: `cmd/skills.go`, `internal/client/api.go`
- **testing-confidence**: high — build verified, same patterns as existing commands

## Checklist
- [x] Tests pass (`make build` clean)
- [x] No breaking changes
- [x] Code follows project conventions