### PR TITLE
docs: fix docs URL and update copyright year

### DIFF
--- a/README.md
+++ b/README.md
@@ -496,10 +496,10 @@ make snapshot
 
 ## License
 
-[MIT](LICENSE) - Copyright (c) 2025 PromptConduit
+[MIT](LICENSE) - Copyright (c) 2026 PromptConduit
 
 ## Links
 
 - [PromptConduit Website](https://promptconduit.dev)
-- [Documentation](https://docs.promptconduit.dev)
+- [Documentation](https://promptconduit.dev/docs)
 - [Issue Tracker](https://github.com/promptconduit/cli/issues)


### PR DESCRIPTION
## Summary

Two small fixes to keep the README accurate:

- `docs.promptconduit.dev` → `promptconduit.dev/docs` (no subdomain exists; docs are on the main site)
- Copyright year: 2025 → 2026

## Checklist
- [x] No breaking changes
- [x] Accurate links