### PR TITLE
feat(gemini): register all 11 hook events from the current spec

### DIFF
--- a/cmd/install.go
+++ b/cmd/install.go
@@ -374,6 +374,16 @@ func installGemini(exePath string) error {
 	return nil
 }
 
+// buildGeminiHooks registers for every event Gemini CLI's hooks reference
+// exposes (https://github.com/google-gemini/gemini-cli/blob/main/docs/hooks/reference.md).
+// Matchers are only meaningful on BeforeTool/AfterTool (regex on tool name);
+// other events use `matcher: "*"` only when the spec calls for matcher
+// filtering, otherwise we omit it.
+//
+// NOTE: AfterModel fires per response chunk during streaming, so it can be
+// high-volume on long Gemini turns. We register it for completeness —
+// downstream consumers (the platform + `promptconduit watch`) can filter
+// or sample if it becomes a problem in practice.
 func buildGeminiHooks(hookCmd string) map[string]interface{} {
 	makeHook := func(timeout int) []map[string]interface{} {
 		return []map[string]interface{}{
@@ -394,12 +404,29 @@ func buildGeminiHooks(hookCmd string) map[string]interface{} {
 		}
 	}
 
+	plainEvent := func() []map[string]interface{} {
+		return []map[string]interface{}{{"hooks": makeHook(5000)}}
+	}
+
 	return map[string]interface{}{
-		"BeforeAgent":  []map[string]interface{}{{"hooks": makeHook(5000)}},
-		"BeforeTool":   makeMatcherHook(5000),
-		"AfterTool":    makeMatcherHook(5000),
-		"SessionStart": []map[string]interface{}{{"hooks": makeHook(5000)}},
-		"SessionEnd":   []map[string]interface{}{{"hooks": makeHook(5000)}},
+		// Session lifecycle
+		"SessionStart": plainEvent(),
+		"SessionEnd":   plainEvent(),
+		// Per-turn lifecycle
+		"BeforeAgent": plainEvent(), // user submitted a prompt, before planning
+		"AfterAgent":  plainEvent(), // final turn response produced
+		// Model interaction (BeforeModel fires per LLM call; AfterModel
+		// fires per response chunk — see note above)
+		"BeforeModel":         plainEvent(),
+		"AfterModel":          plainEvent(),
+		"BeforeToolSelection": plainEvent(),
+		// Tool execution (matcher = regex on tool name)
+		"BeforeTool": makeMatcherHook(5000),
+		"AfterTool":  makeMatcherHook(5000),
+		// Context compaction
+		"PreCompress": plainEvent(),
+		// System alerts
+		"Notification": plainEvent(),
 	}
 }
 


### PR DESCRIPTION
## Summary

Brings Gemini CLI coverage up to spec. Before: we registered 5 of 11 documented events. Now: 11 of 11.

Canonical reference: [packages/core/src/hooks/types.ts](https://github.com/google-gemini/gemini-cli/blob/main/packages/core/src/hooks/types.ts) `HookEventName` enum and [docs/hooks/reference.md](https://github.com/google-gemini/gemini-cli/blob/main/docs/hooks/reference.md).

**Already registered (no changes):** `BeforeAgent`, `BeforeTool`, `AfterTool`, `SessionStart`, `SessionEnd`. All still current; no renames or deprecations.

**Newly added (6):**

| Event | When it fires |
| --- | --- |
| `AfterAgent` | Model produces a final turn response (Gemini's equivalent of Claude's `Stop`) |
| `BeforeModel` | Before each LLM call |
| `AfterModel` | Per response chunk during streaming — see volume note below |
| `BeforeToolSelection` | Before the model decides which tools to call |
| `PreCompress` | Before history summarization (Gemini's equivalent of `PreCompact`) |
| `Notification` | When the CLI emits a system alert |

### Volume note on `AfterModel`

`AfterModel` fires per streamed response chunk, so it can be high-volume on long turns. Registered for completeness; if it floods the pipeline in practice we can either filter at the platform side or carve out a sampling matcher here. Called out in the commit message and as a code comment in `buildGeminiHooks`.

### Idempotency

`installGemini` already inherited the idempotency cleanup added in #48: re-running `promptconduit install gemini` strips any of our stale entries while leaving user-owned hooks alone. Re-verified end-to-end.

## Test plan

- [x] `go build ./... && go vet ./... && go test ./...` clean
- [x] Smoke: `promptconduit install gemini` against a fake `$HOME` writes 11 hook entries to `~/.gemini/settings.json`
- [x] Smoke: planted a stale `OldDeprecatedEvent` entry pointing at our binary + a user-owned `UserCustomHook`, re-ran `install gemini`. Result: stale entry removed (11 → going from 13 with planted entries down to 12: 11 ours + 1 user), `UserCustomHook` preserved
- [ ] Run against a real Gemini CLI install and confirm events arrive at the platform end-to-end

## Up next (per session-running plan)

This is the first of three planned hook-coverage follow-ups:

1. **Gemini CLI** ← this PR
2. Claude Code `WorktreeCreate` (requires the generic hook handler in `cmd/hook.go` to detect that event and return a valid worktree path instead of `{"continue": true}`)
3. Codex CLI / GitHub Copilot CLI hooks (currently sync-only)

https://claude.ai/code/session_019CWBC2E8pQuShejfsKYrvp

---
_Generated by [Claude Code](https://claude.ai/code/session_019CWBC2E8pQuShejfsKYrvp)_