### PR TITLE
feat: register hooks for OpenAI Codex CLI and GitHub Copilot CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@ PromptConduit CLI captures prompts, tool executions, and session events from AI 
 | [Claude Code](https://claude.ai/code) | Prompts, Tools, Sessions, Attachments |
 | [Cursor](https://cursor.com) | Prompts, Shell, MCP, Files, Attachments |
 | [Gemini CLI](https://geminicli.com) | Prompts, Tools, Sessions |
+| [OpenAI Codex CLI](https://github.com/openai/codex) | Prompts, Tools, Permissions, Sessions |
+| [GitHub Copilot CLI](https://github.com/github/copilot-cli) | Prompts, Tools, Subagents, Errors, Sessions |
 
 **Local skill generation** (no account required):
 
@@ -140,6 +142,12 @@ promptconduit install cursor
 
 # For Gemini CLI
 promptconduit install gemini-cli
+
+# For OpenAI Codex CLI
+promptconduit install codex
+
+# For GitHub Copilot CLI
+promptconduit install copilot
 ```
 
 ### 4. Verify installation

--- a/cmd/hook.go
+++ b/cmd/hook.go
@@ -19,7 +19,15 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var sendEvent bool
+var (
+	sendEvent bool
+	// toolOverride is set by the install command (`--tool codex`,
+	// `--tool copilot`) when the host AI tool's hook payload can't be
+	// reliably distinguished from other tools by inspecting fields
+	// alone — Codex in particular sends `hook_event_name`, which would
+	// otherwise be tagged as Claude Code.
+	toolOverride string
+)
 
 var hookCmd = &cobra.Command{
 	Use:    "hook",
@@ -31,6 +39,7 @@ var hookCmd = &cobra.Command{
 
 func init() {
 	hookCmd.Flags().BoolVar(&sendEvent, "send-event", false, "Send event data from stdin (internal use)")
+	hookCmd.Flags().StringVar(&toolOverride, "tool", "", "Override tool name (codex, copilot, etc.); set by the install command")
 }
 
 func runHook(cmd *cobra.Command, args []string) error {
@@ -215,9 +224,16 @@ func hostname() string {
 	return h
 }
 
-// detectTool identifies which AI tool generated the event
+// detectTool identifies which AI tool generated the event.
+//
+// Precedence: --tool flag (set by install for Codex/Copilot whose payloads
+// can't be told apart from Claude Code by content) → PROMPTCONDUIT_TOOL
+// env var → heuristic field-presence detection.
 func detectTool(event map[string]interface{}) string {
-	// Check environment variable override first
+	if toolOverride != "" {
+		return toolOverride
+	}
+	// Check environment variable override next.
 	if tool := os.Getenv(client.EnvTool); tool != "" {
 		return tool
 	}

--- a/cmd/install.go
+++ b/cmd/install.go
@@ -17,9 +17,11 @@ var installCmd = &cobra.Command{
 	Long: `Install PromptConduit hooks for the specified AI coding assistant.
 
 Supported tools:
-  - claude-code: Claude Code CLI
-  - cursor: Cursor IDE
-  - gemini-cli: Gemini CLI (also accepts "gemini")
+  - claude-code: Claude Code CLI            (~/.claude/settings.json)
+  - cursor:      Cursor IDE                 (~/.cursor/hooks.json)
+  - gemini-cli:  Gemini CLI                 (~/.gemini/settings.json; also accepts "gemini")
+  - codex:       OpenAI Codex CLI           (~/.codex/hooks.json)
+  - copilot:     GitHub Copilot CLI         (~/.copilot/hooks/promptconduit.json)
 
 The hooks will capture events from the tool and send them to the PromptConduit API.
 
@@ -56,6 +58,10 @@ func runInstall(cmd *cobra.Command, args []string) error {
 		return installCursor(exePath)
 	case "gemini-cli", "gemini":
 		return installGemini(exePath)
+	case "codex":
+		return installCodex(exePath)
+	case "copilot":
+		return installCopilot(exePath)
 	default:
 		return fmt.Errorf("installation not implemented for: %s", toolName)
 	}
@@ -434,4 +440,228 @@ func buildGeminiHooks(hookCmd string) map[string]interface{} {
 func isCommandAvailable(name string) bool {
 	_, err := exec.LookPath(name)
 	return err == nil
+}
+
+// installCodex registers our hook handler with OpenAI Codex CLI.
+//
+// Codex's config format mirrors Claude Code's (event keys → matcher groups →
+// hook handlers), with two important differences from Claude Code:
+//   - timeout is in SECONDS (not milliseconds).
+//   - SessionEnd does not exist; sessions only emit SessionStart.
+//
+// We pass `--tool codex` to our hook binary because Codex's payload uses the
+// same `hook_event_name` field name as Claude Code, so the existing
+// detectTool heuristic would otherwise mistag the events.
+//
+// Spec: https://developers.openai.com/codex/hooks
+func installCodex(exePath string) error {
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		return fmt.Errorf("failed to get home directory: %w", err)
+	}
+
+	settingsPath := filepath.Join(homeDir, ".codex", "hooks.json")
+
+	// Read existing settings or create new
+	settings := make(map[string]interface{})
+	if data, err := os.ReadFile(settingsPath); err == nil {
+		if err := json.Unmarshal(data, &settings); err != nil {
+			return fmt.Errorf("failed to parse existing settings: %w", err)
+		}
+	}
+
+	hookCmd := fmt.Sprintf("%s hook --tool codex", exePath)
+	hooks := buildCodexHooks(hookCmd)
+
+	// Strip any of OUR previously-installed entries first so removed events
+	// (or stale --tool flags from earlier versions) self-heal on re-install.
+	// User-owned hook entries are left alone.
+	if existingHooks, ok := settings["hooks"].(map[string]interface{}); ok {
+		for name, config := range existingHooks {
+			if containsPromptConduit(config) {
+				delete(existingHooks, name)
+			}
+		}
+		for name, config := range hooks {
+			existingHooks[name] = config
+		}
+	} else {
+		settings["hooks"] = hooks
+	}
+
+	if err := os.MkdirAll(filepath.Dir(settingsPath), 0755); err != nil {
+		return fmt.Errorf("failed to create settings directory: %w", err)
+	}
+
+	data, err := json.MarshalIndent(settings, "", "  ")
+	if err != nil {
+		return fmt.Errorf("failed to marshal settings: %w", err)
+	}
+
+	if err := os.WriteFile(settingsPath, data, 0644); err != nil {
+		return fmt.Errorf("failed to write settings: %w", err)
+	}
+
+	fmt.Println("Successfully installed PromptConduit hooks for Codex CLI")
+	fmt.Printf("Settings file: %s\n", settingsPath)
+	fmt.Println("\nMake sure you have configured your API key:")
+	fmt.Println("  promptconduit config set --api-key=\"your-api-key\"")
+
+	return nil
+}
+
+// buildCodexHooks registers for every event in the Codex CLI hooks reference
+// (https://developers.openai.com/codex/hooks). Codex's matcher rules:
+//   - SessionStart matches start source: startup|resume|clear
+//   - PreToolUse / PostToolUse / PermissionRequest match tool name
+//   - UserPromptSubmit and Stop do not support matchers
+//
+// Codex's timeout field is in seconds; 30 is plenty for our hook
+// (read stdin → spawn async send → return).
+func buildCodexHooks(hookCmd string) map[string]interface{} {
+	makeHook := func(timeoutSec int) []map[string]interface{} {
+		return []map[string]interface{}{
+			{
+				"type":    "command",
+				"command": hookCmd,
+				"timeout": timeoutSec,
+			},
+		}
+	}
+
+	makeMatcherHook := func(timeoutSec int) []map[string]interface{} {
+		return []map[string]interface{}{
+			{
+				"matcher": "*",
+				"hooks":   makeHook(timeoutSec),
+			},
+		}
+	}
+
+	plainEvent := func() []map[string]interface{} {
+		return []map[string]interface{}{{"hooks": makeHook(30)}}
+	}
+
+	return map[string]interface{}{
+		// Session lifecycle (matcher = startup|resume|clear)
+		"SessionStart": makeMatcherHook(30),
+		// Per-turn (no matcher support)
+		"UserPromptSubmit": plainEvent(),
+		"Stop":             plainEvent(),
+		// Tool execution (matcher = tool name regex: Bash, apply_patch, mcp__*)
+		"PreToolUse":        makeMatcherHook(30),
+		"PostToolUse":       makeMatcherHook(30),
+		"PermissionRequest": makeMatcherHook(30),
+	}
+}
+
+// CopilotHookFile is the basename we write into ~/.copilot/hooks/. Copilot
+// loads every *.json in that directory, so owning a dedicated file lets us
+// uninstall cleanly without parsing or merging anything else.
+const CopilotHookFile = "promptconduit.json"
+
+// installCopilot registers our hook handler with GitHub Copilot CLI.
+//
+// Unlike Claude Code / Codex / Gemini which use a single merged settings
+// file, Copilot reads every *.json under ~/.copilot/hooks/ and combines
+// them, so we own a dedicated file (promptconduit.json) — uninstall is a
+// `rm` and idempotency is automatic.
+//
+// We pass `--tool copilot` to our hook binary because Copilot supports
+// both camelCase events (its native format, with sessionId/cwd payload
+// fields) AND PascalCase events (VS Code compatible, with hook_event_name
+// payload field). We use camelCase below; setting --tool ensures correct
+// attribution regardless of payload shape.
+//
+// Spec: https://docs.github.com/en/copilot/reference/copilot-cli-reference/cli-hooks-reference
+func installCopilot(exePath string) error {
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		return fmt.Errorf("failed to get home directory: %w", err)
+	}
+
+	hooksDir := filepath.Join(homeDir, ".copilot", "hooks")
+	settingsPath := filepath.Join(hooksDir, CopilotHookFile)
+
+	hookCmd := fmt.Sprintf("%s hook --tool copilot", exePath)
+	doc := map[string]interface{}{
+		"version": 1,
+		"hooks":   buildCopilotHooks(hookCmd),
+	}
+
+	if err := os.MkdirAll(hooksDir, 0755); err != nil {
+		return fmt.Errorf("failed to create hooks directory: %w", err)
+	}
+
+	data, err := json.MarshalIndent(doc, "", "  ")
+	if err != nil {
+		return fmt.Errorf("failed to marshal hooks: %w", err)
+	}
+
+	if err := os.WriteFile(settingsPath, data, 0644); err != nil {
+		return fmt.Errorf("failed to write hooks file: %w", err)
+	}
+
+	fmt.Println("Successfully installed PromptConduit hooks for GitHub Copilot CLI")
+	fmt.Printf("Hooks file: %s\n", settingsPath)
+	fmt.Println("\nMake sure you have configured your API key:")
+	fmt.Println("  promptconduit config set --api-key=\"your-api-key\"")
+
+	return nil
+}
+
+// buildCopilotHooks registers for every event in the Copilot CLI hooks
+// reference (camelCase form). Copilot's command-hook field semantics:
+//   - `command` is a cross-platform fallback used when neither `bash` nor
+//     `powershell` is set for the current platform. Since our hook is a
+//     single binary that invokes the same way on both, we use `command`
+//     alone and let Copilot pick.
+//   - timeoutSec, not timeout. Default is 30s which is plenty for our path.
+//
+// Matcher-supporting events get `"*"` for now (matches everything).
+// Note: under Copilot cloud agent, `notification` and `permissionRequest`
+// don't fire; harmless to register, just no-ops there.
+func buildCopilotHooks(hookCmd string) map[string]interface{} {
+	makeCmd := func() []map[string]interface{} {
+		return []map[string]interface{}{
+			{
+				"type":       "command",
+				"command":    hookCmd,
+				"timeoutSec": 30,
+			},
+		}
+	}
+
+	makeMatcherCmd := func(matcher string) []map[string]interface{} {
+		return []map[string]interface{}{
+			{
+				"type":       "command",
+				"command":    hookCmd,
+				"timeoutSec": 30,
+				"matcher":    matcher,
+			},
+		}
+	}
+
+	return map[string]interface{}{
+		// Session lifecycle
+		"sessionStart": makeCmd(),
+		"sessionEnd":   makeCmd(),
+		// Per-turn / agent lifecycle
+		"userPromptSubmitted": makeCmd(),
+		"agentStop":           makeCmd(),
+		// Subagent lifecycle (matcher = agent name regex)
+		"subagentStart": makeMatcherCmd("*"),
+		"subagentStop":  makeCmd(),
+		// Tool execution (matcher = tool name regex on preToolUse + permissionRequest)
+		"preToolUse":         makeMatcherCmd("*"),
+		"postToolUse":        makeCmd(),
+		"postToolUseFailure": makeCmd(),
+		"permissionRequest":  makeMatcherCmd("*"),
+		// Context compaction (matcher = "manual"|"auto")
+		"preCompact": makeMatcherCmd("*"),
+		// System / errors
+		"notification":  makeMatcherCmd("*"),
+		"errorOccurred": makeCmd(),
+	}
 }

--- a/cmd/uninstall.go
+++ b/cmd/uninstall.go
@@ -18,8 +18,10 @@ var uninstallCmd = &cobra.Command{
 
 Supported tools:
   - claude-code: Claude Code CLI
-  - cursor: Cursor IDE
-  - gemini-cli: Gemini CLI (also accepts "gemini")`,
+  - cursor:      Cursor IDE
+  - gemini-cli:  Gemini CLI (also accepts "gemini")
+  - codex:       OpenAI Codex CLI
+  - copilot:     GitHub Copilot CLI`,
 	Args: cobra.ExactArgs(1),
 	RunE: runUninstall,
 }
@@ -38,6 +40,10 @@ func runUninstall(cmd *cobra.Command, args []string) error {
 		return uninstallCursor()
 	case "gemini-cli", "gemini":
 		return uninstallGemini()
+	case "codex":
+		return uninstallCodex()
+	case "copilot":
+		return uninstallCopilot()
 	default:
 		return fmt.Errorf("uninstallation not implemented for: %s", toolName)
 	}
@@ -245,4 +251,86 @@ func containsPromptConduit(v interface{}) bool {
 		}
 	}
 	return false
+}
+
+func uninstallCodex() error {
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		return fmt.Errorf("failed to get home directory: %w", err)
+	}
+
+	settingsPath := filepath.Join(homeDir, ".codex", "hooks.json")
+
+	data, err := os.ReadFile(settingsPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			fmt.Println("No Codex CLI hooks file found - nothing to uninstall")
+			return nil
+		}
+		return fmt.Errorf("failed to read settings: %w", err)
+	}
+
+	var settings map[string]interface{}
+	if err := json.Unmarshal(data, &settings); err != nil {
+		return fmt.Errorf("failed to parse settings: %w", err)
+	}
+
+	hooks, ok := settings["hooks"].(map[string]interface{})
+	if !ok {
+		fmt.Println("No hooks found in Codex CLI settings")
+		return nil
+	}
+
+	removed := 0
+	for hookName, hookConfig := range hooks {
+		if containsPromptConduit(hookConfig) {
+			delete(hooks, hookName)
+			removed++
+		}
+	}
+
+	if removed == 0 {
+		fmt.Println("No PromptConduit hooks found in Codex CLI settings")
+		return nil
+	}
+
+	if len(hooks) == 0 {
+		delete(settings, "hooks")
+	}
+
+	data, err = json.MarshalIndent(settings, "", "  ")
+	if err != nil {
+		return fmt.Errorf("failed to marshal settings: %w", err)
+	}
+
+	if err := os.WriteFile(settingsPath, data, 0644); err != nil {
+		return fmt.Errorf("failed to write settings: %w", err)
+	}
+
+	fmt.Printf("Successfully removed %d PromptConduit hook(s) from Codex CLI\n", removed)
+	return nil
+}
+
+// uninstallCopilot removes our dedicated hooks file. Unlike the other
+// tools where we merge into a shared settings.json, Copilot reads every
+// *.json under ~/.copilot/hooks/, so our installer owns a single file and
+// uninstall is just a delete.
+func uninstallCopilot() error {
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		return fmt.Errorf("failed to get home directory: %w", err)
+	}
+
+	settingsPath := filepath.Join(homeDir, ".copilot", "hooks", CopilotHookFile)
+
+	if err := os.Remove(settingsPath); err != nil {
+		if os.IsNotExist(err) {
+			fmt.Println("No PromptConduit hooks file found for Copilot CLI - nothing to uninstall")
+			return nil
+		}
+		return fmt.Errorf("failed to remove hooks file: %w", err)
+	}
+
+	fmt.Printf("Successfully removed PromptConduit hooks from Copilot CLI (%s)\n", settingsPath)
+	return nil
 }

--- a/internal/envelope/envelope.go
+++ b/internal/envelope/envelope.go
@@ -172,13 +172,13 @@ func (e *RawEventEnvelope) ToJSON() ([]byte, error) {
 
 // SupportedTools returns a list of supported tool names
 func SupportedTools() []string {
-	return []string{"claude-code", "cursor", "gemini-cli"}
+	return []string{"claude-code", "cursor", "gemini-cli", "codex", "copilot"}
 }
 
 // IsValidTool checks if the given tool name is supported
 func IsValidTool(toolName string) bool {
 	switch toolName {
-	case "claude-code", "cursor", "gemini-cli", "gemini":
+	case "claude-code", "cursor", "gemini-cli", "gemini", "codex", "copilot":
 		return true
 	default:
 		return false


### PR DESCRIPTION
## Summary

Adds `promptconduit install codex` and `promptconduit install copilot` (plus matching uninstall), bringing live event capture to the two AI tools we already support transcript sync for. Closes the "tools we don't support at all" item from the session-running plan.

### Codex CLI — 6 events at `~/.codex/hooks.json`

Per [the canonical spec](https://developers.openai.com/codex/hooks):

| Event | Matcher | Notes |
| --- | --- | --- |
| `SessionStart` | `startup\|resume\|clear` | |
| `PreToolUse` | tool name (Bash, apply_patch, mcp__*) | |
| `PermissionRequest` | tool name | |
| `PostToolUse` | tool name | |
| `UserPromptSubmit` | — | no matcher support |
| `Stop` | — | no matcher support |

Claude-Code-style nested schema, but `timeout` is in **seconds** (not millis), and the spec has no `SessionEnd` event.

### Copilot CLI — 13 events at `~/.copilot/hooks/promptconduit.json`

Per [the canonical spec](https://docs.github.com/en/copilot/reference/copilot-cli-reference/cli-hooks-reference):

| Event | Matcher |
| --- | --- |
| `sessionStart` / `sessionEnd` | — |
| `userPromptSubmitted` | — |
| `preToolUse` | tool name |
| `postToolUse` / `postToolUseFailure` | — |
| `permissionRequest` | tool name |
| `agentStop` / `subagentStart` (agent name) / `subagentStop` | — / regex / — |
| `errorOccurred` | — |
| `preCompact` | `manual\|auto` |
| `notification` | notification type |

Different schema from the other tools: `{"version": 1, "hooks": {...}}`, `timeoutSec` not `timeout`, per-handler cross-platform `command` field (we use that single field rather than separate `bash`/`powershell`). Copilot loads every `*.json` under `~/.copilot/hooks/`, so we own a dedicated `promptconduit.json` — uninstall is just `rm`, no merge/strip dance.

### Critical wrinkle: tool detection

Codex's hook payload uses `hook_event_name` — the **same field name as Claude Code** — so the existing `detectTool` heuristic in `cmd/hook.go` would mistag Codex events as `"claude-code"`. Fix: add a `--tool <name>` flag to the hidden `hook` subcommand and have the install commands bake `--tool codex` / `--tool copilot` into the registered command line.

Precedence: `--tool` flag > `PROMPTCONDUIT_TOOL` env var > existing field-presence heuristic. Existing tools (Claude Code / Cursor / Gemini) are untouched — they continue to be auto-detected.

## Test plan

- [x] `go build ./... && go vet ./... && go test ./...` clean
- [x] Smoke: `install codex` against a fake `$HOME` writes 6 events to `~/.codex/hooks.json`, each command has `--tool codex`
- [x] Smoke: `install copilot` writes 13 events with `version: 1`, `timeoutSec: 30`, `--tool copilot` in every command
- [x] Smoke: `uninstall codex` removes 6 hooks; `uninstall copilot` deletes the file; second `uninstall copilot` returns cleanly on ENOENT
- [x] End-to-end: ran `hook --tool codex` with debug enabled, confirmed via `/tmp/promptconduit-hook.log` that `Detected tool: codex` and `Created envelope: tool=codex, event=UserPromptSubmit`
- [ ] Run against a real Codex CLI install and a real Copilot CLI install and confirm events arrive at the platform end-to-end

## Session running plan — status

1. ✅ Gemini CLI hook coverage (#50)
2. ✅ Claude Code `WorktreeCreate` — decided "skip it (status quo)" — no code change; observability still available via SessionStart's cwd
3. ✅ Codex CLI / Copilot CLI hooks ← **this PR**

That closes the hook-coverage epic for now.

https://claude.ai/code/session_019CWBC2E8pQuShejfsKYrvp

---
_Generated by [Claude Code](https://claude.ai/code/session_019CWBC2E8pQuShejfsKYrvp)_