### PR TITLE
feat: `promptconduit collect` — local-first OTLP receiver + dashboard

### DIFF
--- a/cmd/collect.go
+++ b/cmd/collect.go
@@ -1,0 +1,73 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"os/signal"
+	"syscall"
+
+	"github.com/promptconduit/cli/internal/collect"
+	"github.com/spf13/cobra"
+)
+
+var (
+	collectOTLPAddr      string
+	collectDashboardAddr string
+	collectDir           string
+)
+
+var collectCmd = &cobra.Command{
+	Use:           "collect",
+	Short:         "Run a local OTLP receiver, store, and dashboard for agent traces",
+	SilenceUsage:  true,
+	SilenceErrors: true,
+	Long: `Start a local-first agent observability stack:
+
+  - An OTLP/HTTP receiver on 127.0.0.1:4318 (paths /v1/traces, /v1/logs).
+  - A newline-delimited JSON store under ~/.config/promptconduit/collect/.
+  - A read-only HTML+JSON dashboard on 127.0.0.1:4319.
+
+This is the "weekend dogfood" stack: zero infra, point any OTLP-emitting
+agent (Claude Code, Cursor on a recent build, anything using OpenInference
+or OpenLLMetry) at the receiver and watch traces accumulate. The receiver
+speaks OTLP/HTTP+JSON only — protobuf is on the roadmap.
+
+Pointing Claude Code at the local receiver:
+
+  export CLAUDE_CODE_ENABLE_TELEMETRY=1
+  export OTEL_EXPORTER_OTLP_PROTOCOL=http/json
+  export OTEL_EXPORTER_OTLP_ENDPOINT=http://127.0.0.1:4318
+
+Examples:
+  promptconduit collect                          # run with defaults
+  promptconduit collect --otlp :4318             # bind on all interfaces
+  promptconduit collect --dir /tmp/pc-traces     # store somewhere else`,
+	RunE: runCollect,
+}
+
+func init() {
+	collectCmd.Flags().StringVar(&collectOTLPAddr, "otlp", "127.0.0.1:4318", "address for the OTLP/HTTP receiver")
+	collectCmd.Flags().StringVar(&collectDashboardAddr, "dashboard", "127.0.0.1:4319", "address for the read-only dashboard")
+	collectCmd.Flags().StringVar(&collectDir, "dir", "", "directory for NDJSON span files (defaults to ~/.config/promptconduit/collect)")
+}
+
+func runCollect(cmd *cobra.Command, args []string) error {
+	ctx, cancel := signal.NotifyContext(cmd.Context(), os.Interrupt, syscall.SIGTERM)
+	defer cancel()
+
+	srv, err := collect.New(collect.Options{
+		OTLPAddr:      collectOTLPAddr,
+		DashboardAddr: collectDashboardAddr,
+		StoreDir:      collectDir,
+	})
+	if err != nil {
+		return fmt.Errorf("init collector: %w", err)
+	}
+
+	fmt.Fprintf(cmd.ErrOrStderr(), "OTLP receiver:  http://%s/v1/traces\n", collectOTLPAddr)
+	fmt.Fprintf(cmd.ErrOrStderr(), "Dashboard:      http://%s\n", collectDashboardAddr)
+	fmt.Fprintf(cmd.ErrOrStderr(), "Store:          %s\n", srv.StoreDir())
+	fmt.Fprintln(cmd.ErrOrStderr(), "Ctrl-C to stop.")
+
+	return srv.Run(ctx)
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -56,6 +56,7 @@ func init() {
 	rootCmd.AddCommand(debugCmd)
 	rootCmd.AddCommand(upgradeCmd)
 	rootCmd.AddCommand(watchCmd)
+	rootCmd.AddCommand(collectCmd)
 }
 
 var versionCmd = &cobra.Command{
@@ -188,17 +189,15 @@ func spawnBackgroundUpgrade() {
 
 // skipUpdateCheckFor returns true when the current command must not pay
 // the cost of (or output) an update check. Hooks run many times per
-// session and must stay fast; upgrade does its own checking.
+// session and must stay fast; upgrade does its own checking; long-running
+// loops shouldn't be interrupted with an update banner.
 func skipUpdateCheckFor(cmd *cobra.Command) bool {
 	if os.Getenv("PROMPTCONDUIT_AUTO_UPDATE_CHILD") == "1" {
 		return true
 	}
 	name := commandPathRoot(cmd)
 	switch name {
-	case "hook", "upgrade", "watch":
-		// hook is per-event and must stay fast; upgrade and watch
-		// drive their own long-running loops and shouldn't have a
-		// random update banner interrupt them.
+	case "hook", "upgrade", "watch", "collect":
 		return true
 	}
 	return false

--- a/internal/collect/dashboard.go
+++ b/internal/collect/dashboard.go
@@ -1,0 +1,74 @@
+package collect
+
+import (
+	_ "embed"
+	"encoding/json"
+	"net/http"
+	"strconv"
+)
+
+//go:embed ui/index.html
+var dashboardHTML []byte
+
+// mountDashboard registers the dashboard routes onto mux.
+//
+//	GET /              → embedded HTML
+//	GET /api/traces    → JSON list of recent traces (?limit=N)
+//	GET /api/spans     → JSON list of recent spans (?trace_id=..&limit=N)
+func mountDashboard(mux *http.ServeMux, store *Store) {
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/" {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		_, _ = w.Write(dashboardHTML)
+	})
+
+	mux.HandleFunc("/api/traces", func(w http.ResponseWriter, r *http.Request) {
+		limit := intParam(r, "limit", 50)
+		traces, err := store.ListTraces(limit)
+		writeJSON(w, traces, err)
+	})
+
+	mux.HandleFunc("/api/spans", func(w http.ResponseWriter, r *http.Request) {
+		limit := intParam(r, "limit", 500)
+		traceID := r.URL.Query().Get("trace_id")
+		spans, err := store.ReadSpans(limit, traceID)
+		writeJSON(w, spans, err)
+	})
+}
+
+func intParam(r *http.Request, name string, def int) int {
+	v := r.URL.Query().Get(name)
+	if v == "" {
+		return def
+	}
+	n, err := strconv.Atoi(v)
+	if err != nil || n <= 0 {
+		return def
+	}
+	return n
+}
+
+func writeJSON(w http.ResponseWriter, body any, err error) {
+	w.Header().Set("Content-Type", "application/json")
+	if err != nil {
+		w.WriteHeader(http.StatusInternalServerError)
+		_ = json.NewEncoder(w).Encode(map[string]string{"error": err.Error()})
+		return
+	}
+	switch v := body.(type) {
+	case []SpanRow:
+		if v == nil {
+			_, _ = w.Write([]byte("[]\n"))
+			return
+		}
+	case []TraceSummary:
+		if v == nil {
+			_, _ = w.Write([]byte("[]\n"))
+			return
+		}
+	}
+	_ = json.NewEncoder(w).Encode(body)
+}

--- a/internal/collect/otlp.go
+++ b/internal/collect/otlp.go
@@ -1,0 +1,311 @@
+package collect
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"strconv"
+	"time"
+)
+
+type signalKind string
+
+const (
+	signalTraces signalKind = "traces"
+	signalLogs   signalKind = "logs"
+)
+
+// otlpRequest is the minimal subset of the OTLP/HTTP+JSON request shape we
+// need to land traces and logs on disk. The OTLP spec is far larger; this
+// keeps just the fields the dashboard surfaces. Anything we don't model is
+// preserved at the attribute level (flattenKV handles arbitrary keys).
+type otlpRequest struct {
+	ResourceSpans []otlpResourceSpans `json:"resourceSpans,omitempty"`
+	ResourceLogs  []otlpResourceLogs  `json:"resourceLogs,omitempty"`
+}
+
+type otlpResourceSpans struct {
+	Resource   otlpResource     `json:"resource"`
+	ScopeSpans []otlpScopeSpans `json:"scopeSpans"`
+}
+
+type otlpScopeSpans struct {
+	Scope otlpScope  `json:"scope"`
+	Spans []otlpSpan `json:"spans"`
+}
+
+type otlpResourceLogs struct {
+	Resource  otlpResource    `json:"resource"`
+	ScopeLogs []otlpScopeLogs `json:"scopeLogs"`
+}
+
+type otlpScopeLogs struct {
+	Scope      otlpScope       `json:"scope"`
+	LogRecords []otlpLogRecord `json:"logRecords"`
+}
+
+type otlpResource struct {
+	Attributes []otlpKeyValue `json:"attributes"`
+}
+
+type otlpScope struct {
+	Name    string `json:"name,omitempty"`
+	Version string `json:"version,omitempty"`
+}
+
+type otlpSpan struct {
+	TraceID           string         `json:"traceId"`
+	SpanID            string         `json:"spanId"`
+	ParentSpanID      string         `json:"parentSpanId,omitempty"`
+	Name              string         `json:"name"`
+	Kind              int            `json:"kind,omitempty"`
+	StartTimeUnixNano any            `json:"startTimeUnixNano,omitempty"`
+	EndTimeUnixNano   any            `json:"endTimeUnixNano,omitempty"`
+	Attributes        []otlpKeyValue `json:"attributes,omitempty"`
+	Status            *otlpStatus    `json:"status,omitempty"`
+}
+
+type otlpLogRecord struct {
+	TimeUnixNano   any            `json:"timeUnixNano,omitempty"`
+	SeverityNumber int            `json:"severityNumber,omitempty"`
+	SeverityText   string         `json:"severityText,omitempty"`
+	Body           otlpAnyValue   `json:"body,omitempty"`
+	Attributes     []otlpKeyValue `json:"attributes,omitempty"`
+	TraceID        string         `json:"traceId,omitempty"`
+	SpanID         string         `json:"spanId,omitempty"`
+}
+
+type otlpStatus struct {
+	Code    int    `json:"code,omitempty"`
+	Message string `json:"message,omitempty"`
+}
+
+type otlpKeyValue struct {
+	Key   string       `json:"key"`
+	Value otlpAnyValue `json:"value"`
+}
+
+// otlpAnyValue mirrors OTLP's AnyValue oneof. We deserialize whichever
+// branch is present and flatten it to a Go scalar/slice/map for display.
+type otlpAnyValue struct {
+	StringValue *string         `json:"stringValue,omitempty"`
+	BoolValue   *bool           `json:"boolValue,omitempty"`
+	IntValue    *json.Number    `json:"intValue,omitempty"`
+	DoubleValue *float64        `json:"doubleValue,omitempty"`
+	ArrayValue  *otlpArrayValue `json:"arrayValue,omitempty"`
+	KVListValue *otlpKVList     `json:"kvlistValue,omitempty"`
+	BytesValue  *string         `json:"bytesValue,omitempty"`
+}
+
+type otlpArrayValue struct {
+	Values []otlpAnyValue `json:"values"`
+}
+
+type otlpKVList struct {
+	Values []otlpKeyValue `json:"values"`
+}
+
+// newOTLPHandler returns an http.Handler that accepts OTLP/HTTP+JSON for a
+// given signal and writes flattened rows to the store.
+func newOTLPHandler(store *Store, signal signalKind) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+		ct := r.Header.Get("Content-Type")
+		if ct != "" && ct != "application/json" {
+			// Protobuf is on the roadmap; be explicit so users can tell the
+			// local stack apart from the cloud one (which will accept both).
+			http.Error(w, "only application/json is accepted (set OTEL_EXPORTER_OTLP_PROTOCOL=http/json)", http.StatusUnsupportedMediaType)
+			return
+		}
+
+		body, err := io.ReadAll(io.LimitReader(r.Body, 16*1024*1024))
+		if err != nil {
+			http.Error(w, "read body: "+err.Error(), http.StatusBadRequest)
+			return
+		}
+		var req otlpRequest
+		if err := json.Unmarshal(body, &req); err != nil {
+			http.Error(w, "parse body: "+err.Error(), http.StatusBadRequest)
+			return
+		}
+
+		received := time.Now().UTC()
+		switch signal {
+		case signalTraces:
+			for _, rs := range req.ResourceSpans {
+				resourceAttrs := flattenKV(rs.Resource.Attributes)
+				for _, ss := range rs.ScopeSpans {
+					for _, s := range ss.Spans {
+						_ = store.AppendSpan(spanToRow(received, resourceAttrs, ss.Scope, s))
+					}
+				}
+			}
+		case signalLogs:
+			for _, rl := range req.ResourceLogs {
+				resourceAttrs := flattenKV(rl.Resource.Attributes)
+				for _, sl := range rl.ScopeLogs {
+					for _, lr := range sl.LogRecords {
+						_ = store.AppendLog(logRecordToRow(received, resourceAttrs, sl.Scope, lr))
+					}
+				}
+			}
+		}
+
+		// OTLP success response is an empty PartialSuccess.
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{}`))
+	}
+}
+
+// SpanRow is the on-disk shape for a single span. Kept flat so the
+// dashboard can render rows without re-walking nested structures.
+type SpanRow struct {
+	ReceivedAt        time.Time      `json:"received_at"`
+	TraceID           string         `json:"trace_id"`
+	SpanID            string         `json:"span_id"`
+	ParentSpanID      string         `json:"parent_span_id,omitempty"`
+	Name              string         `json:"name"`
+	Kind              int            `json:"kind,omitempty"`
+	StartTimeUnixNano uint64         `json:"start_unix_nano,omitempty"`
+	EndTimeUnixNano   uint64         `json:"end_unix_nano,omitempty"`
+	DurationMs        float64        `json:"duration_ms,omitempty"`
+	StatusCode        int            `json:"status_code,omitempty"`
+	StatusMessage     string         `json:"status_message,omitempty"`
+	ScopeName         string         `json:"scope_name,omitempty"`
+	ScopeVersion      string         `json:"scope_version,omitempty"`
+	ServiceName       string         `json:"service_name,omitempty"`
+	ResourceAttrs     map[string]any `json:"resource_attrs,omitempty"`
+	Attributes        map[string]any `json:"attributes,omitempty"`
+}
+
+// LogRow is the on-disk shape for a single log record.
+type LogRow struct {
+	ReceivedAt    time.Time      `json:"received_at"`
+	TimeUnixNano  uint64         `json:"time_unix_nano,omitempty"`
+	TraceID       string         `json:"trace_id,omitempty"`
+	SpanID        string         `json:"span_id,omitempty"`
+	SeverityText  string         `json:"severity_text,omitempty"`
+	SeverityNum   int            `json:"severity_num,omitempty"`
+	Body          any            `json:"body,omitempty"`
+	ScopeName     string         `json:"scope_name,omitempty"`
+	ScopeVersion  string         `json:"scope_version,omitempty"`
+	ServiceName   string         `json:"service_name,omitempty"`
+	ResourceAttrs map[string]any `json:"resource_attrs,omitempty"`
+	Attributes    map[string]any `json:"attributes,omitempty"`
+}
+
+func spanToRow(now time.Time, resourceAttrs map[string]any, scope otlpScope, s otlpSpan) SpanRow {
+	start := toNano(s.StartTimeUnixNano)
+	end := toNano(s.EndTimeUnixNano)
+	row := SpanRow{
+		ReceivedAt:        now,
+		TraceID:           s.TraceID,
+		SpanID:            s.SpanID,
+		ParentSpanID:      s.ParentSpanID,
+		Name:              s.Name,
+		Kind:              s.Kind,
+		StartTimeUnixNano: start,
+		EndTimeUnixNano:   end,
+		ScopeName:         scope.Name,
+		ScopeVersion:      scope.Version,
+		ResourceAttrs:     resourceAttrs,
+		Attributes:        flattenKV(s.Attributes),
+	}
+	if end > start && start > 0 {
+		row.DurationMs = float64(end-start) / 1e6
+	}
+	if v, ok := resourceAttrs["service.name"].(string); ok {
+		row.ServiceName = v
+	}
+	if s.Status != nil {
+		row.StatusCode = s.Status.Code
+		row.StatusMessage = s.Status.Message
+	}
+	return row
+}
+
+func logRecordToRow(now time.Time, resourceAttrs map[string]any, scope otlpScope, lr otlpLogRecord) LogRow {
+	row := LogRow{
+		ReceivedAt:    now,
+		TimeUnixNano:  toNano(lr.TimeUnixNano),
+		TraceID:       lr.TraceID,
+		SpanID:        lr.SpanID,
+		SeverityText:  lr.SeverityText,
+		SeverityNum:   lr.SeverityNumber,
+		Body:          anyValueToGo(lr.Body),
+		ScopeName:     scope.Name,
+		ScopeVersion:  scope.Version,
+		ResourceAttrs: resourceAttrs,
+		Attributes:    flattenKV(lr.Attributes),
+	}
+	if v, ok := resourceAttrs["service.name"].(string); ok {
+		row.ServiceName = v
+	}
+	return row
+}
+
+// toNano accepts the JSON encoding of a uint64 nanosecond timestamp, which
+// OTLP exporters serialize as either a string (the spec) or a number (some
+// emitters). Returns 0 when unparseable.
+func toNano(v any) uint64 {
+	switch t := v.(type) {
+	case string:
+		n, err := strconv.ParseUint(t, 10, 64)
+		if err != nil {
+			return 0
+		}
+		return n
+	case float64:
+		return uint64(t)
+	case json.Number:
+		n, err := strconv.ParseUint(t.String(), 10, 64)
+		if err != nil {
+			return 0
+		}
+		return n
+	}
+	return 0
+}
+
+func flattenKV(kvs []otlpKeyValue) map[string]any {
+	if len(kvs) == 0 {
+		return nil
+	}
+	out := make(map[string]any, len(kvs))
+	for _, kv := range kvs {
+		out[kv.Key] = anyValueToGo(kv.Value)
+	}
+	return out
+}
+
+func anyValueToGo(v otlpAnyValue) any {
+	switch {
+	case v.StringValue != nil:
+		return *v.StringValue
+	case v.BoolValue != nil:
+		return *v.BoolValue
+	case v.IntValue != nil:
+		s := v.IntValue.String()
+		if n, err := strconv.ParseInt(s, 10, 64); err == nil {
+			return n
+		}
+		return s
+	case v.DoubleValue != nil:
+		return *v.DoubleValue
+	case v.ArrayValue != nil:
+		out := make([]any, len(v.ArrayValue.Values))
+		for i, x := range v.ArrayValue.Values {
+			out[i] = anyValueToGo(x)
+		}
+		return out
+	case v.KVListValue != nil:
+		return flattenKV(v.KVListValue.Values)
+	case v.BytesValue != nil:
+		return *v.BytesValue
+	}
+	return nil
+}

--- a/internal/collect/otlp_test.go
+++ b/internal/collect/otlp_test.go
@@ -1,0 +1,129 @@
+package collect
+
+import (
+	"bytes"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+const sampleTraces = `{
+  "resourceSpans": [{
+    "resource": { "attributes": [
+      { "key": "service.name", "value": { "stringValue": "claude-code" } },
+      { "key": "claude_code.version", "value": { "stringValue": "1.0.0" } }
+    ]},
+    "scopeSpans": [{
+      "scope": { "name": "anthropic.claude-code", "version": "1.0.0" },
+      "spans": [{
+        "traceId": "0123456789abcdef0123456789abcdef",
+        "spanId": "0123456789abcdef",
+        "name": "tool.call",
+        "kind": 1,
+        "startTimeUnixNano": "1700000000000000000",
+        "endTimeUnixNano": "1700000000500000000",
+        "attributes": [
+          { "key": "tool.name", "value": { "stringValue": "Read" } },
+          { "key": "tokens.input", "value": { "intValue": "412" } }
+        ],
+        "status": { "code": 1 }
+      }]
+    }]
+  }]
+}`
+
+func TestOTLPTracesHandler(t *testing.T) {
+	dir, err := os.MkdirTemp("", "collect-test-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(dir)
+
+	store, err := OpenStore(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+
+	handler := newOTLPHandler(store, signalTraces)
+	req := httptest.NewRequest(http.MethodPost, "/v1/traces", bytes.NewReader([]byte(sampleTraces)))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	handler(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", rec.Code, rec.Body.String())
+	}
+
+	rows, err := store.ReadSpans(0, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("got %d rows, want 1", len(rows))
+	}
+	r := rows[0]
+	if r.TraceID != "0123456789abcdef0123456789abcdef" {
+		t.Errorf("trace_id = %q", r.TraceID)
+	}
+	if r.Name != "tool.call" {
+		t.Errorf("name = %q", r.Name)
+	}
+	if r.DurationMs != 500 {
+		t.Errorf("duration_ms = %v, want 500", r.DurationMs)
+	}
+	if v := r.ResourceAttrs["service.name"]; v != "claude-code" {
+		t.Errorf("service.name = %v", v)
+	}
+	if v := r.Attributes["tokens.input"]; v != int64(412) {
+		t.Errorf("tokens.input = %v (%T)", v, v)
+	}
+	if r.ServiceName != "claude-code" {
+		t.Errorf("ServiceName = %q", r.ServiceName)
+	}
+
+	if _, err := os.Stat(filepath.Join(dir, "spans.ndjson")); err != nil {
+		t.Errorf("spans.ndjson not written: %v", err)
+	}
+
+	traces, err := store.ListTraces(10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(traces) != 1 || traces[0].ServiceName != "claude-code" {
+		t.Errorf("traces = %+v", traces)
+	}
+}
+
+func TestOTLPRejectsNonJSON(t *testing.T) {
+	dir, _ := os.MkdirTemp("", "collect-test-*")
+	defer os.RemoveAll(dir)
+	store, _ := OpenStore(dir)
+	defer store.Close()
+
+	handler := newOTLPHandler(store, signalTraces)
+	req := httptest.NewRequest(http.MethodPost, "/v1/traces", bytes.NewReader([]byte{0x08, 0x01}))
+	req.Header.Set("Content-Type", "application/x-protobuf")
+	rec := httptest.NewRecorder()
+	handler(rec, req)
+	if rec.Code != http.StatusUnsupportedMediaType {
+		t.Errorf("status = %d", rec.Code)
+	}
+}
+
+func TestOTLPRejectsGET(t *testing.T) {
+	dir, _ := os.MkdirTemp("", "collect-test-*")
+	defer os.RemoveAll(dir)
+	store, _ := OpenStore(dir)
+	defer store.Close()
+
+	handler := newOTLPHandler(store, signalTraces)
+	req := httptest.NewRequest(http.MethodGet, "/v1/traces", nil)
+	rec := httptest.NewRecorder()
+	handler(rec, req)
+	if rec.Code != http.StatusMethodNotAllowed {
+		t.Errorf("status = %d", rec.Code)
+	}
+}

--- a/internal/collect/otlp_test.go
+++ b/internal/collect/otlp_test.go
@@ -2,6 +2,7 @@ package collect
 
 import (
 	"bytes"
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -77,8 +78,13 @@ func TestOTLPTracesHandler(t *testing.T) {
 	if v := r.ResourceAttrs["service.name"]; v != "claude-code" {
 		t.Errorf("service.name = %v", v)
 	}
-	if v := r.Attributes["tokens.input"]; v != int64(412) {
-		t.Errorf("tokens.input = %v (%T)", v, v)
+	// Round-tripping a SpanRow through NDJSON loses the int64-vs-float64
+	// distinction: encoding/json emits int64 as a bare JSON number, then
+	// decoding back into map[string]any (SpanRow.Attributes) rebuilds it as
+	// float64. The exact integer-typing guarantee from anyValueToGo before
+	// the round-trip is covered separately by TestAnyValueToGoTypes below.
+	if v := r.Attributes["tokens.input"]; v != float64(412) {
+		t.Errorf("tokens.input = %v (%T), want 412", v, v)
 	}
 	if r.ServiceName != "claude-code" {
 		t.Errorf("ServiceName = %q", r.ServiceName)
@@ -125,5 +131,36 @@ func TestOTLPRejectsGET(t *testing.T) {
 	handler(rec, req)
 	if rec.Code != http.StatusMethodNotAllowed {
 		t.Errorf("status = %d", rec.Code)
+	}
+}
+
+// TestAnyValueToGoTypes pins down the in-process Go types anyValueToGo emits
+// before the SpanRow is serialized to NDJSON. The round-trip in
+// TestOTLPTracesHandler asserts the post-decode shape (float64); this test
+// asserts the pre-encode shape, so a regression that returns the int as a
+// string or float64 directly out of anyValueToGo would still get caught.
+func TestAnyValueToGoTypes(t *testing.T) {
+	s := "hello"
+	b := true
+	d := 3.14
+	n := json.Number("42")
+	bs := "Ynl0ZXM="
+
+	cases := []struct {
+		name string
+		in   otlpAnyValue
+		want any
+	}{
+		{"string", otlpAnyValue{StringValue: &s}, "hello"},
+		{"bool", otlpAnyValue{BoolValue: &b}, true},
+		{"int-as-string", otlpAnyValue{IntValue: &n}, int64(42)},
+		{"double", otlpAnyValue{DoubleValue: &d}, 3.14},
+		{"bytes", otlpAnyValue{BytesValue: &bs}, "Ynl0ZXM="},
+	}
+	for _, c := range cases {
+		got := anyValueToGo(c.in)
+		if got != c.want {
+			t.Errorf("%s: got %v (%T), want %v (%T)", c.name, got, got, c.want, c.want)
+		}
 	}
 }

--- a/internal/collect/server.go
+++ b/internal/collect/server.go
@@ -1,0 +1,140 @@
+// Package collect implements a local-first OTLP/HTTP receiver with an
+// embedded NDJSON store and a read-only dashboard. It's the open-source
+// half of PromptConduit's agent-tracing stack: it works standalone, with
+// no platform backend required, and is intended for both dogfooding and
+// for users who want a self-hostable view of their agent traces.
+package collect
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"path/filepath"
+	"sync"
+	"time"
+
+	"github.com/promptconduit/cli/internal/client"
+)
+
+// Options configures a Collector.
+type Options struct {
+	// OTLPAddr is the listen address for the OTLP/HTTP receiver
+	// (e.g. "127.0.0.1:4318"). Required.
+	OTLPAddr string
+
+	// DashboardAddr is the listen address for the dashboard (HTML + JSON
+	// API). Required.
+	DashboardAddr string
+
+	// StoreDir is where NDJSON span/log files are written. Empty means
+	// ~/.config/promptconduit/collect/.
+	StoreDir string
+}
+
+// Collector ties the OTLP receiver, store, and dashboard together.
+type Collector struct {
+	store   *Store
+	otlpSrv *http.Server
+	dashSrv *http.Server
+}
+
+// New builds a Collector. Returns an error if the store can't be opened.
+func New(opts Options) (*Collector, error) {
+	if opts.OTLPAddr == "" {
+		return nil, errors.New("OTLPAddr is required")
+	}
+	if opts.DashboardAddr == "" {
+		return nil, errors.New("DashboardAddr is required")
+	}
+
+	dir := opts.StoreDir
+	if dir == "" {
+		dir = filepath.Join(client.ConfigDir(), "collect")
+	}
+
+	store, err := OpenStore(dir)
+	if err != nil {
+		return nil, fmt.Errorf("open store: %w", err)
+	}
+
+	otlpMux := http.NewServeMux()
+	otlpMux.HandleFunc("/v1/traces", newOTLPHandler(store, signalTraces))
+	otlpMux.HandleFunc("/v1/logs", newOTLPHandler(store, signalLogs))
+	// Accept-and-discard metrics for now so emitters that ship all three
+	// signals don't error out — we just don't expose them in the UI yet.
+	otlpMux.HandleFunc("/v1/metrics", okHandler)
+	otlpMux.HandleFunc("/", notFoundHandler)
+
+	dashMux := http.NewServeMux()
+	mountDashboard(dashMux, store)
+
+	return &Collector{
+		store: store,
+		otlpSrv: &http.Server{
+			Addr:              opts.OTLPAddr,
+			Handler:           otlpMux,
+			ReadHeaderTimeout: 5 * time.Second,
+		},
+		dashSrv: &http.Server{
+			Addr:              opts.DashboardAddr,
+			Handler:           dashMux,
+			ReadHeaderTimeout: 5 * time.Second,
+		},
+	}, nil
+}
+
+// StoreDir returns the directory the collector writes to.
+func (c *Collector) StoreDir() string { return c.store.Dir() }
+
+// Run starts the OTLP receiver and dashboard, blocking until ctx is
+// cancelled or one of them fails.
+func (c *Collector) Run(ctx context.Context) error {
+	errCh := make(chan error, 2)
+	var wg sync.WaitGroup
+
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		if err := c.otlpSrv.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
+			errCh <- fmt.Errorf("otlp: %w", err)
+		}
+	}()
+	go func() {
+		defer wg.Done()
+		if err := c.dashSrv.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
+			errCh <- fmt.Errorf("dashboard: %w", err)
+		}
+	}()
+
+	select {
+	case <-ctx.Done():
+	case err := <-errCh:
+		shutdown(c.otlpSrv, c.dashSrv)
+		wg.Wait()
+		_ = c.store.Close()
+		return err
+	}
+
+	shutdown(c.otlpSrv, c.dashSrv)
+	wg.Wait()
+	return c.store.Close()
+}
+
+func shutdown(servers ...*http.Server) {
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	for _, s := range servers {
+		_ = s.Shutdown(ctx)
+	}
+}
+
+func okHandler(w http.ResponseWriter, _ *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	_, _ = w.Write([]byte(`{}`))
+}
+
+func notFoundHandler(w http.ResponseWriter, _ *http.Request) {
+	http.Error(w, "not found", http.StatusNotFound)
+}

--- a/internal/collect/store.go
+++ b/internal/collect/store.go
@@ -1,0 +1,227 @@
+package collect
+
+import (
+	"bufio"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+	"sync"
+	"time"
+)
+
+const (
+	spansFile = "spans.ndjson"
+	logsFile  = "logs.ndjson"
+
+	// maxFileBytes is the soft cap before the file is rotated to .1. Keeps
+	// `collect` from filling a disk during a long-running session.
+	maxFileBytes int64 = 50 * 1024 * 1024
+)
+
+// Store is an append-only NDJSON store for spans and logs. One file each,
+// rotated to <name>.1 when they exceed maxFileBytes. Safe for concurrent
+// writers within a single process.
+type Store struct {
+	dir       string
+	mu        sync.Mutex
+	spans     *os.File
+	logs      *os.File
+	spansSize int64
+	logsSize  int64
+}
+
+// OpenStore opens (or creates) the spans/logs NDJSON files under dir.
+func OpenStore(dir string) (*Store, error) {
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return nil, fmt.Errorf("mkdir: %w", err)
+	}
+	s := &Store{dir: dir}
+	sp, spSize, err := openAppend(filepath.Join(dir, spansFile))
+	if err != nil {
+		return nil, err
+	}
+	lg, lgSize, err := openAppend(filepath.Join(dir, logsFile))
+	if err != nil {
+		_ = sp.Close()
+		return nil, err
+	}
+	s.spans, s.spansSize = sp, spSize
+	s.logs, s.logsSize = lg, lgSize
+	return s, nil
+}
+
+func openAppend(path string) (*os.File, int64, error) {
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644)
+	if err != nil {
+		return nil, 0, err
+	}
+	info, err := f.Stat()
+	if err != nil {
+		_ = f.Close()
+		return nil, 0, err
+	}
+	return f, info.Size(), nil
+}
+
+// Dir returns the directory the store writes to.
+func (s *Store) Dir() string { return s.dir }
+
+// Close flushes and closes the underlying files.
+func (s *Store) Close() error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	var err1, err2 error
+	if s.spans != nil {
+		err1 = s.spans.Close()
+		s.spans = nil
+	}
+	if s.logs != nil {
+		err2 = s.logs.Close()
+		s.logs = nil
+	}
+	return errors.Join(err1, err2)
+}
+
+// AppendSpan writes one span as a JSON line to spans.ndjson.
+func (s *Store) AppendSpan(row SpanRow) error {
+	data, err := json.Marshal(row)
+	if err != nil {
+		return err
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.writeLine(&s.spans, &s.spansSize, spansFile, data)
+}
+
+// AppendLog writes one log record as a JSON line to logs.ndjson.
+func (s *Store) AppendLog(row LogRow) error {
+	data, err := json.Marshal(row)
+	if err != nil {
+		return err
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.writeLine(&s.logs, &s.logsSize, logsFile, data)
+}
+
+func (s *Store) writeLine(fp **os.File, size *int64, name string, data []byte) error {
+	if *fp == nil {
+		f, sz, err := openAppend(filepath.Join(s.dir, name))
+		if err != nil {
+			return err
+		}
+		*fp = f
+		*size = sz
+	}
+	n, err := (*fp).Write(append(data, '\n'))
+	*size += int64(n)
+	if err != nil {
+		return err
+	}
+	if *size > maxFileBytes {
+		if err := (*fp).Close(); err != nil {
+			return err
+		}
+		*fp = nil
+		_ = os.Rename(filepath.Join(s.dir, name), filepath.Join(s.dir, name+".1"))
+		f, _, err := openAppend(filepath.Join(s.dir, name))
+		if err != nil {
+			return err
+		}
+		*fp = f
+		*size = 0
+	}
+	return nil
+}
+
+// ReadSpans returns up to limit recent spans, newest first. Only the active
+// (non-rotated) file is consulted — that's plenty for dogfooding and keeps
+// the dashboard cheap. If traceID is non-empty, only spans with that
+// trace_id are returned. limit <= 0 means no limit.
+func (s *Store) ReadSpans(limit int, traceID string) ([]SpanRow, error) {
+	path := filepath.Join(s.dir, spansFile)
+	f, err := os.Open(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	defer f.Close()
+
+	var rows []SpanRow
+	scanner := bufio.NewScanner(f)
+	scanner.Buffer(make([]byte, 0, 64*1024), 4*1024*1024)
+	for scanner.Scan() {
+		var r SpanRow
+		if err := json.Unmarshal(scanner.Bytes(), &r); err != nil {
+			continue
+		}
+		if traceID != "" && r.TraceID != traceID {
+			continue
+		}
+		rows = append(rows, r)
+	}
+	if err := scanner.Err(); err != nil && !errors.Is(err, io.EOF) {
+		return nil, err
+	}
+
+	sort.SliceStable(rows, func(i, j int) bool { return rows[i].ReceivedAt.After(rows[j].ReceivedAt) })
+	if limit > 0 && len(rows) > limit {
+		rows = rows[:limit]
+	}
+	return rows, nil
+}
+
+// TraceSummary is a compact view of one trace for the trace-list page.
+type TraceSummary struct {
+	TraceID     string    `json:"trace_id"`
+	ServiceName string    `json:"service_name,omitempty"`
+	RootName    string    `json:"root_name,omitempty"`
+	SpanCount   int       `json:"span_count"`
+	StartedAt   time.Time `json:"started_at"`
+	DurationMs  float64   `json:"duration_ms,omitempty"`
+	Status      int       `json:"status,omitempty"`
+}
+
+// ListTraces returns recent traces ordered by newest first, up to limit.
+func (s *Store) ListTraces(limit int) ([]TraceSummary, error) {
+	rows, err := s.ReadSpans(0, "")
+	if err != nil {
+		return nil, err
+	}
+	byTrace := map[string]*TraceSummary{}
+	for _, r := range rows {
+		t, ok := byTrace[r.TraceID]
+		if !ok {
+			t = &TraceSummary{
+				TraceID:     r.TraceID,
+				ServiceName: r.ServiceName,
+				StartedAt:   r.ReceivedAt,
+			}
+			byTrace[r.TraceID] = t
+		}
+		t.SpanCount++
+		if r.ReceivedAt.Before(t.StartedAt) {
+			t.StartedAt = r.ReceivedAt
+		}
+		if r.ParentSpanID == "" && r.Name != "" {
+			t.RootName = r.Name
+			t.DurationMs = r.DurationMs
+			t.Status = r.StatusCode
+		}
+	}
+	out := make([]TraceSummary, 0, len(byTrace))
+	for _, t := range byTrace {
+		out = append(out, *t)
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].StartedAt.After(out[j].StartedAt) })
+	if limit > 0 && len(out) > limit {
+		out = out[:limit]
+	}
+	return out, nil
+}

--- a/internal/collect/ui/index.html
+++ b/internal/collect/ui/index.html
@@ -1,0 +1,144 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<title>PromptConduit local agent traces</title>
+<style>
+  body { font: 13px/1.5 -apple-system, BlinkMacSystemFont, sans-serif; margin: 0; padding: 0; color: #111; background: #fff; }
+  header { padding: 12px 16px; border-bottom: 1px solid #ddd; display: flex; align-items: center; gap: 12px; }
+  header h1 { font-size: 14px; margin: 0; font-weight: 600; }
+  header .status { color: #888; font-size: 12px; }
+  main { display: flex; height: calc(100vh - 49px); }
+  .traces { width: 360px; border-right: 1px solid #ddd; overflow-y: auto; }
+  .trace { padding: 10px 12px; border-bottom: 1px solid #eee; cursor: pointer; }
+  .trace:hover { background: #f6f6f6; }
+  .trace.selected { background: #eef4ff; }
+  .trace .name { font-weight: 500; }
+  .trace .meta { color: #888; font-size: 11px; margin-top: 2px; }
+  .trace .tid { font-family: ui-monospace, Menlo, monospace; }
+  .spans { flex: 1; overflow-y: auto; padding: 8px 16px; }
+  .empty { color: #888; padding: 24px; }
+  .span { border-bottom: 1px solid #eee; padding: 8px 0; }
+  .span .head { display: flex; gap: 8px; align-items: baseline; }
+  .span .name { font-weight: 500; }
+  .span .dur { color: #888; font-size: 11px; }
+  .span .ind { color: #bbb; font-family: ui-monospace, Menlo, monospace; }
+  .attrs { color: #555; font-size: 11px; margin-top: 4px; font-family: ui-monospace, Menlo, monospace; white-space: pre-wrap; word-break: break-all; }
+  .status-err { color: #c44; }
+  @media (prefers-color-scheme: dark) {
+    body { background: #111; color: #eee; }
+    header, .traces, .span, .trace { border-color: #333; }
+    .trace:hover { background: #1c1c1c; }
+    .trace.selected { background: #1a2030; }
+    .trace .meta, .span .dur, .empty { color: #888; }
+    .attrs { color: #aaa; }
+  }
+</style>
+</head>
+<body>
+<header>
+  <h1>PromptConduit · local agent traces</h1>
+  <span class="status" id="status">loading…</span>
+</header>
+<main>
+  <div class="traces" id="traces"></div>
+  <div class="spans" id="spans"><div class="empty">Select a trace to view its spans.</div></div>
+</main>
+<script>
+let selectedTraceId = null;
+
+async function fetchJSON(path) {
+  const r = await fetch(path);
+  if (!r.ok) throw new Error(await r.text());
+  return r.json();
+}
+
+function fmtTime(iso) {
+  const d = new Date(iso);
+  return d.toLocaleTimeString();
+}
+
+function fmtMs(ms) {
+  if (!ms) return '';
+  if (ms < 1) return ms.toFixed(2) + 'ms';
+  if (ms < 1000) return ms.toFixed(0) + 'ms';
+  return (ms / 1000).toFixed(2) + 's';
+}
+
+function escapeHTML(s) {
+  return String(s == null ? '' : s).replace(/[&<>\"']/g, c => ({'&':'&amp;','<':'&lt;','>':'&gt;','\"':'&quot;',"'":'&#39;'}[c]));
+}
+
+async function renderTraces() {
+  try {
+    const traces = await fetchJSON('/api/traces?limit=100');
+    document.getElementById('status').textContent = traces.length + ' trace' + (traces.length === 1 ? '' : 's');
+    const list = document.getElementById('traces');
+    if (!traces.length) {
+      list.innerHTML = '<div class="empty">No traces yet. Point an OTLP-emitting agent at <code>http://127.0.0.1:4318</code>.</div>';
+      return;
+    }
+    list.innerHTML = traces.map(t => {
+      const errFlag = t.status === 2 ? ' <span class="status-err">!</span>' : '';
+      const tid = (t.trace_id || '').slice(0, 16);
+      return '<div class="trace ' + (t.trace_id === selectedTraceId ? 'selected' : '') + '" data-id="' + escapeHTML(t.trace_id) + '">' +
+        '<div class="name">' + escapeHTML(t.root_name || '(no root span yet)') + errFlag + '</div>' +
+        '<div class="meta">' + escapeHTML(t.service_name || 'unknown') + ' · ' + t.span_count + ' span' + (t.span_count === 1 ? '' : 's') + (t.duration_ms ? ' · ' + fmtMs(t.duration_ms) : '') + ' · ' + fmtTime(t.started_at) + '</div>' +
+        '<div class="meta tid">' + escapeHTML(tid) + '…</div>' +
+      '</div>';
+    }).join('');
+    list.querySelectorAll('.trace').forEach(el => {
+      el.addEventListener('click', () => {
+        selectedTraceId = el.dataset.id;
+        list.querySelectorAll('.trace').forEach(t => t.classList.toggle('selected', t.dataset.id === selectedTraceId));
+        renderSpans();
+      });
+    });
+  } catch (e) {
+    document.getElementById('status').textContent = 'error: ' + e.message;
+  }
+}
+
+async function renderSpans() {
+  if (!selectedTraceId) return;
+  try {
+    const spans = await fetchJSON('/api/spans?trace_id=' + encodeURIComponent(selectedTraceId) + '&limit=500');
+    spans.sort((a, b) => (a.start_unix_nano || 0) - (b.start_unix_nano || 0));
+    const byId = Object.fromEntries(spans.map(s => [s.span_id, s]));
+    const depth = {};
+    function d(s) {
+      if (depth[s.span_id] !== undefined) return depth[s.span_id];
+      if (!s.parent_span_id || !byId[s.parent_span_id]) { depth[s.span_id] = 0; return 0; }
+      depth[s.span_id] = d(byId[s.parent_span_id]) + 1;
+      return depth[s.span_id];
+    }
+    spans.forEach(d);
+    const root = document.getElementById('spans');
+    if (!spans.length) { root.innerHTML = '<div class="empty">No spans in this trace.</div>'; return; }
+    root.innerHTML = spans.map(s => {
+      const ind = '· '.repeat(depth[s.span_id] || 0);
+      const attrs = s.attributes ? Object.entries(s.attributes).map(([k, v]) => k + '=' + JSON.stringify(v)).join('  ') : '';
+      const errPart = s.status_code === 2 ? '<span class="status-err">' + escapeHTML(s.status_message || 'error') + '</span>' : '';
+      return '<div class="span">' +
+        '<div class="head">' +
+          '<span class="ind">' + ind + '</span>' +
+          '<span class="name">' + escapeHTML(s.name || '(unnamed)') + '</span>' +
+          '<span class="dur">' + fmtMs(s.duration_ms) + '</span>' +
+          errPart +
+        '</div>' +
+        (attrs ? '<div class="attrs">' + escapeHTML(attrs) + '</div>' : '') +
+      '</div>';
+    }).join('');
+  } catch (e) {
+    document.getElementById('spans').innerHTML = '<div class="empty">Error: ' + escapeHTML(e.message) + '</div>';
+  }
+}
+
+renderTraces();
+setInterval(() => {
+  renderTraces();
+  if (selectedTraceId) renderSpans();
+}, 2000);
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary

Scaffolds the open-source half of an agent-tracing stack so we can start dogfooding **today** without any cloud backend.

- New `promptconduit collect` command starts an OTLP/HTTP+JSON receiver on `127.0.0.1:4318` (`/v1/traces`, `/v1/logs`; `/v1/metrics` accepted-and-discarded).
- Append-only NDJSON store at `~/.config/promptconduit/collect/` with 50MB rotation.
- Embedded read-only dashboard at `127.0.0.1:4319` — single HTML/JS file served from `go:embed`, lists traces grouped by `trace_id` with parent/child indentation, 2s auto-refresh, dark mode.
- **Zero new go.mod dependencies** — stdlib only.

This is the public, open-source side of the open-core split. The cloud-side OTLP receiver lives in `promptconduit/platform` (companion PR) and accepts the same wire format, so the same agent can ship traces to either endpoint by swapping `OTEL_EXPORTER_OTLP_ENDPOINT`.

## Dogfood path

```bash
make build && ./promptconduit collect

# in another shell
export CLAUDE_CODE_ENABLE_TELEMETRY=1
export OTEL_EXPORTER_OTLP_PROTOCOL=http/json
export OTEL_EXPORTER_OTLP_ENDPOINT=http://127.0.0.1:4318

# use Claude Code, then open http://127.0.0.1:4319
```

## Files

- `cmd/collect.go` — cobra command
- `cmd/root.go` — register `collectCmd`, add it to the update-check skip list
- `internal/collect/server.go` — orchestrates OTLP receiver + dashboard + store
- `internal/collect/otlp.go` — minimal OTLP/HTTP+JSON parser + normalization
- `internal/collect/store.go` — NDJSON append store, span/log read & trace summaries
- `internal/collect/dashboard.go` — `/`, `/api/traces`, `/api/spans`
- `internal/collect/ui/index.html` — embedded single-file dashboard
- `internal/collect/otlp_test.go` — round-trip + 415 + 405 tests

## Test plan

- [ ] `make test` passes (3 new tests in `internal/collect`)
- [ ] `make build` produces a binary that links cleanly (no new deps)
- [ ] `./promptconduit collect` starts both servers, prints addresses, exits cleanly on Ctrl-C
- [ ] Send a sample OTLP/JSON POST via `curl` and confirm the dashboard shows it
- [ ] Point Claude Code at the local endpoint and watch real traces accumulate
- [ ] Sending `Content-Type: application/x-protobuf` returns 415 with the documented hint
- [ ] Hitting `/v1/metrics` returns 200 (accept-and-discard)
- [ ] After 50MB of spans, rotation produces `spans.ndjson.1`

## Out of scope (follow-ups)

- Protobuf support (only JSON for now).
- Optional upstream forwarding to the cloud platform.
- MCP server for in-IDE query of local traces.
- `promptconduit run <agent>` wrapper that auto-sets OTEL env vars.

https://claude.ai/code/session_01ECtvFtsTx4QMVWKttzMQW2

---
_Generated by [Claude Code](https://claude.ai/code/session_01ECtvFtsTx4QMVWKttzMQW2)_