### PR TITLE
feat: persistent error logging for hook events

### DIFF
--- a/cmd/hook.go
+++ b/cmd/hook.go
@@ -14,6 +14,7 @@ import (
 	"github.com/promptconduit/cli/internal/client"
 	"github.com/promptconduit/cli/internal/envelope"
 	"github.com/promptconduit/cli/internal/git"
+	"github.com/promptconduit/cli/internal/logger"
 	"github.com/promptconduit/cli/internal/sync"
 	"github.com/promptconduit/cli/internal/transcript"
 	"github.com/spf13/cobra"
@@ -53,19 +54,24 @@ func runHook(cmd *cobra.Command, args []string) error {
 func processHookEvent() error {
 	defer outputContinueResponse()
 
-	fileLog("Hook started")
+	// Load config first so we can set the debug flag for the logger before
+	// emitting any trace lines.
+	cfg := client.LoadConfig()
+	logger.SetDebug(cfg.Debug)
+
+	logger.Debug("Hook started")
 
 	// Read raw input from stdin
 	rawInput, err := io.ReadAll(os.Stdin)
 	if err != nil {
 		debugLog("Failed to read stdin: %v", err)
-		fileLog("Failed to read stdin: %v", err)
+		logger.Error("Failed to read stdin: %v", err)
 		return nil
 	}
 
 	if len(rawInput) == 0 {
 		debugLog("Empty input, skipping")
-		fileLog("Empty input, skipping")
+		logger.Debug("Empty input, skipping")
 		return nil
 	}
 
@@ -73,21 +79,19 @@ func processHookEvent() error {
 	if previewLen > 200 {
 		previewLen = 200
 	}
-	fileLog("Received %d bytes: %s", len(rawInput), string(rawInput[:previewLen]))
+	logger.Debug("Received %d bytes: %s", len(rawInput), string(rawInput[:previewLen]))
 
 	// Parse just enough to detect tool and event name
 	var nativeEvent map[string]interface{}
 	if err := json.Unmarshal(rawInput, &nativeEvent); err != nil {
 		debugLog("Failed to parse JSON: %v", err)
-		fileLog("Failed to parse JSON: %v", err)
+		logger.Error("Failed to parse JSON: %v (raw=%q)", err, string(rawInput[:previewLen]))
 		return nil
 	}
 
-	// Load config
-	cfg := client.LoadConfig()
 	if !cfg.IsConfigured() {
 		debugLog("API key not configured, skipping")
-		fileLog("API key not configured, skipping")
+		logger.Error("API key not configured — event dropped. Run `promptconduit config set --api-key=...`")
 		return nil
 	}
 
@@ -96,13 +100,13 @@ func processHookEvent() error {
 	hookEvent := getHookEventName(nativeEvent)
 	sessionID := getSessionID(nativeEvent)
 
-	fileLog("Detected tool: %s, hook event: %s", tool, hookEvent)
+	logger.Debug("Detected tool: %s, hook event: %s", tool, hookEvent)
 
 	// Build correlation IDs (W3C-compatible trace_id/span_id).
 	// Stable across hook fires within a session; best-effort, never blocks.
 	corr := buildCorrelation(tool, hookEvent, sessionID, nativeEvent)
 	if corr != nil {
-		fileLog("correlation: trace=%s span=%s parent=%s", corr.TraceID, corr.SpanID, corr.ParentSpanID)
+		logger.Debug("correlation: trace=%s span=%s parent=%s", corr.TraceID, corr.SpanID, corr.ParentSpanID)
 	}
 
 	// Extract git context from working directory
@@ -126,7 +130,7 @@ func processHookEvent() error {
 	if cwd != "" {
 		gitCtx = git.ExtractContext(cwd)
 		if gitCtx != nil {
-			fileLog("Extracted git context: repo=%s, branch=%s", gitCtx.RepoName, gitCtx.Branch)
+			logger.Debug("Extracted git context: repo=%s, branch=%s", gitCtx.RepoName, gitCtx.Branch)
 		}
 	}
 
@@ -139,12 +143,12 @@ func processHookEvent() error {
 	if hookEvent == "UserPromptSubmit" {
 		extractor := transcript.GetExtractor(tool)
 		if extractor.SupportsAttachments() {
-			fileLog("UserPromptSubmit: checking for attachments in current message")
+			logger.Debug("UserPromptSubmit: checking for attachments in current message")
 			attachments, _, err := extractor.ExtractAttachments(nativeEvent)
 			if err != nil {
-				fileLog("Error extracting attachments: %v", err)
+				logger.Error("Error extracting attachments: %v", err)
 			} else if len(attachments) > 0 {
-				fileLog("Found %d attachments in current message, sending with event", len(attachments))
+				logger.Debug("Found %d attachments in current message, sending with event", len(attachments))
 
 				// Build attachment metadata for envelope and binary data for multipart
 				envAttachments := make([]envelope.AttachmentMetadata, len(attachments))
@@ -165,7 +169,7 @@ func processHookEvent() error {
 						ContentType:  att.MediaType,
 						Data:         att.Data,
 					}
-					fileLog("Attachment %d: %s (%s, %d bytes)", i+1, att.Filename, att.MediaType, len(att.Data))
+					logger.Debug("Attachment %d: %s (%s, %d bytes)", i+1, att.Filename, att.MediaType, len(att.Data))
 				}
 
 				// Create envelope with attachment metadata
@@ -173,9 +177,9 @@ func processHookEvent() error {
 
 				// Send via multipart with binary attachments
 				if err := apiClient.SendEnvelopeWithAttachmentsAsync(env, attachmentData); err != nil {
-					fileLog("Failed to send envelope with attachments: %v", err)
+					logger.Error("Failed to send envelope with attachments (event=%s, tool=%s): %v", hookEvent, tool, err)
 				} else {
-					fileLog("UserPromptSubmit with %d attachments sent successfully", len(attachments))
+					logger.Debug("UserPromptSubmit with %d attachments sent successfully", len(attachments))
 				}
 				// Return here - we've sent the event with attachments, don't send again below
 				return nil
@@ -186,15 +190,15 @@ func processHookEvent() error {
 	// Create envelope with raw payload (no attachments case, or non-UserPromptSubmit events)
 	env := envelope.New(Version, tool, hookEvent, rawInput, enr)
 
-	fileLog("Created envelope: tool=%s, event=%s", tool, hookEvent)
+	logger.Debug("Created envelope: tool=%s, event=%s", tool, hookEvent)
 
 	// Send async
 	if err := apiClient.SendEnvelopeAsync(env); err != nil {
 		debugLog("Failed to send envelope async: %v", err)
-		fileLog("Failed to send envelope async: %v", err)
+		logger.Error("Failed to spawn async sender (event=%s, tool=%s): %v", hookEvent, tool, err)
 	}
 
-	fileLog("Envelope queued for async send")
+	logger.Debug("Envelope queued for async send")
 	return nil
 }
 
@@ -312,30 +316,32 @@ func getSessionID(event map[string]interface{}) string {
 
 // sendEnvelopeFromStdin sends envelope data directly (called by async subprocess)
 func sendEnvelopeFromStdin() error {
-	fileLog("Async subprocess started")
+	cfg := client.LoadConfig()
+	logger.SetDebug(cfg.Debug)
+
+	logger.Debug("Async subprocess started")
 
 	inputData, err := io.ReadAll(os.Stdin)
 	if err != nil {
-		fileLog("Async subprocess failed to read stdin: %v", err)
+		logger.Error("Async subprocess failed to read stdin: %v", err)
 		return fmt.Errorf("failed to read stdin: %w", err)
 	}
 
-	fileLog("Async subprocess received %d bytes", len(inputData))
+	logger.Debug("Async subprocess received %d bytes", len(inputData))
 
-	cfg := client.LoadConfig()
 	if !cfg.IsConfigured() {
-		fileLog("Async subprocess: API key not configured")
+		logger.Error("Async subprocess: API key not configured — envelope dropped")
 		return fmt.Errorf("API key not configured")
 	}
 
-	fileLog("Async subprocess sending to API: %s", cfg.APIURL)
+	logger.Debug("Async subprocess sending to API: %s", cfg.APIURL)
 	apiClient := client.NewClient(cfg, Version)
 	err = apiClient.SendEnvelopeDirect(inputData)
 	if err != nil {
-		fileLog("Async subprocess API error: %v", err)
+		logger.Error("Async subprocess API send failed (url=%s): %v", cfg.APIURL, err)
 		return err
 	}
-	fileLog("Async subprocess: envelope sent successfully")
+	logger.Debug("Async subprocess: envelope sent successfully")
 	return nil
 }
 
@@ -348,7 +354,9 @@ func outputContinueResponse() {
 	fmt.Println(string(data))
 }
 
-// debugLog logs a message only if debug mode is enabled
+// debugLog mirrors a debug-level message to stderr (real-time visibility
+// when the user runs with debug mode). The persistent log file is handled
+// separately by the logger package.
 func debugLog(format string, args ...interface{}) {
 	cfg := client.LoadConfig()
 	if cfg.Debug {
@@ -356,48 +364,32 @@ func debugLog(format string, args ...interface{}) {
 	}
 }
 
-// fileLog logs a message to a file (for debugging hook issues)
-func fileLog(format string, args ...interface{}) {
-	cfg := client.LoadConfig()
-	if !cfg.Debug {
-		return
-	}
-	logPath := filepath.Join(os.TempDir(), "promptconduit-hook.log")
-	f, err := os.OpenFile(logPath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
-	if err != nil {
-		return
-	}
-	defer f.Close()
-	msg := fmt.Sprintf(format, args...)
-	f.WriteString(fmt.Sprintf("[%s] %s\n", time.Now().Format(time.RFC3339), msg))
-}
-
 // triggerAutoSync triggers automatic transcript sync after SessionEnd or Stop events
 // Spawns a subprocess immediately to avoid being killed when the main process exits
 // Uses hash-based deduplication so frequent triggers are efficient (only syncs if file changed)
 func triggerAutoSync(sessionID string) {
-	fileLog("Auto-sync: triggered for session %s", sessionID)
+	logger.Debug("Auto-sync: triggered for session %s", sessionID)
 
 	// Find transcript file for this session (fast operation, do synchronously)
 	transcriptPath, err := sync.FindTranscriptBySessionID(sessionID)
 	if err != nil {
-		fileLog("Auto-sync: could not find transcript for session %s: %v", sessionID, err)
+		logger.Debug("Auto-sync: could not find transcript for session %s: %v", sessionID, err)
 		return
 	}
 
-	fileLog("Auto-sync: found transcript at %s", transcriptPath)
+	logger.Debug("Auto-sync: found transcript at %s", transcriptPath)
 
 	// Spawn async subprocess to sync this file
 	// Use --delay flag so the subprocess waits for transcript to be fully flushed
 	exe, err := os.Executable()
 	if err != nil {
-		fileLog("Auto-sync: failed to get executable path: %v", err)
+		logger.Debug("Auto-sync: failed to get executable path: %v", err)
 		return
 	}
 
 	cmd := exec.Command(exe, "sync", "--file", transcriptPath, "--delay", "1")
 	if err := cmd.Start(); err != nil {
-		fileLog("Auto-sync: failed to start sync subprocess: %v", err)
+		logger.Debug("Auto-sync: failed to start sync subprocess: %v", err)
 		return
 	}
 
@@ -406,7 +398,7 @@ func triggerAutoSync(sessionID string) {
 		_ = cmd.Process.Release()
 	}
 
-	fileLog("Auto-sync: sync subprocess started for session %s", sessionID)
+	logger.Debug("Auto-sync: sync subprocess started for session %s", sessionID)
 
 	// Also retry any previously failed syncs (spawn as separate subprocess)
 	go retryFailedSyncs(exe)
@@ -416,7 +408,7 @@ func triggerAutoSync(sessionID string) {
 func retryFailedSyncs(exe string) {
 	stateManager, err := sync.NewStateManager()
 	if err != nil {
-		fileLog("Auto-sync retry: failed to load state: %v", err)
+		logger.Debug("Auto-sync retry: failed to load state: %v", err)
 		return
 	}
 
@@ -425,18 +417,18 @@ func retryFailedSyncs(exe string) {
 		return
 	}
 
-	fileLog("Auto-sync retry: found %d failed syncs to retry", len(failedSyncs))
+	logger.Debug("Auto-sync retry: found %d failed syncs to retry", len(failedSyncs))
 
 	for _, failed := range failedSyncs {
 		// Max 3 retries per file
 		if failed.RetryCount >= 3 {
-			fileLog("Auto-sync retry: skipping %s (exceeded max retries)", failed.SessionID)
+			logger.Debug("Auto-sync retry: skipping %s (exceeded max retries)", failed.SessionID)
 			continue
 		}
 
 		cmd := exec.Command(exe, "sync", "--file", failed.FilePath)
 		if err := cmd.Start(); err != nil {
-			fileLog("Auto-sync retry: failed to start sync for %s: %v", failed.SessionID, err)
+			logger.Debug("Auto-sync retry: failed to start sync for %s: %v", failed.SessionID, err)
 			continue
 		}
 
@@ -444,7 +436,7 @@ func retryFailedSyncs(exe string) {
 			_ = cmd.Process.Release()
 		}
 
-		fileLog("Auto-sync retry: started retry for session %s", failed.SessionID)
+		logger.Debug("Auto-sync retry: started retry for session %s", failed.SessionID)
 	}
 }
 

--- a/cmd/logs.go
+++ b/cmd/logs.go
@@ -1,0 +1,136 @@
+package cmd
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"time"
+
+	"github.com/promptconduit/cli/internal/logger"
+	"github.com/spf13/cobra"
+)
+
+var (
+	logsTailN  int
+	logsFollow bool
+	logsPath   bool
+	logsClear  bool
+)
+
+var logsCmd = &cobra.Command{
+	Use:   "logs",
+	Short: "View the PromptConduit CLI log",
+	Long: `Show recent errors and trace lines from the CLI log file.
+
+Errors (failed sends, missing config, parse errors) are always recorded.
+Debug-level trace lines are only recorded when ` + "`debug: true`" + ` is set in the
+active environment of your config — see ` + "`promptconduit config show`" + `.
+
+Examples:
+  promptconduit logs              # last 50 lines
+  promptconduit logs -n 200       # last 200 lines
+  promptconduit logs --follow     # tail -f
+  promptconduit logs --path       # just print the log file path
+  promptconduit logs --clear      # truncate the log file`,
+	RunE: runLogs,
+}
+
+func init() {
+	logsCmd.Flags().IntVarP(&logsTailN, "tail", "n", 50, "Number of lines to show from the end of the log")
+	logsCmd.Flags().BoolVarP(&logsFollow, "follow", "f", false, "Tail the log file (like `tail -f`)")
+	logsCmd.Flags().BoolVar(&logsPath, "path", false, "Print only the log file path and exit")
+	logsCmd.Flags().BoolVar(&logsClear, "clear", false, "Truncate the log file and exit")
+}
+
+func runLogs(cmd *cobra.Command, args []string) error {
+	if logsPath {
+		cmd.Println(logger.Path())
+		return nil
+	}
+
+	if logsClear {
+		return clearLog(cmd)
+	}
+
+	if logsFollow {
+		return followLog(cmd)
+	}
+
+	out, err := logger.Tail(logsTailN)
+	if err != nil {
+		return fmt.Errorf("read log: %w", err)
+	}
+	if out == "" {
+		cmd.Printf("Log file is empty or does not exist yet.\n  Path: %s\n", logger.Path())
+		return nil
+	}
+	cmd.Print(out)
+	if out[len(out)-1] != '\n' {
+		cmd.Println()
+	}
+	return nil
+}
+
+func clearLog(cmd *cobra.Command) error {
+	path := logger.Path()
+	if _, err := os.Stat(path); os.IsNotExist(err) {
+		cmd.Printf("Nothing to clear: %s does not exist.\n", path)
+		return nil
+	}
+	if err := os.Truncate(path, 0); err != nil {
+		return fmt.Errorf("truncate log: %w", err)
+	}
+	cmd.Printf("Cleared %s\n", path)
+	return nil
+}
+
+// followLog shells out to `tail -f` when available (every supported
+// platform except Windows ships it), and falls back to a simple polling
+// loop otherwise. This keeps the implementation tiny while giving users
+// the canonical UX for tailing a log.
+func followLog(cmd *cobra.Command) error {
+	path := logger.Path()
+	// Ensure the file exists so tail/poll doesn't immediately fail.
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return fmt.Errorf("create log dir: %w", err)
+	}
+	if f, err := os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644); err == nil {
+		f.Close()
+	}
+
+	if tailPath, err := exec.LookPath("tail"); err == nil {
+		c := exec.Command(tailPath, "-n", fmt.Sprintf("%d", logsTailN), "-F", path)
+		c.Stdout = cmd.OutOrStdout()
+		c.Stderr = cmd.ErrOrStderr()
+		return c.Run()
+	}
+
+	return pollFollow(cmd, path)
+}
+
+func pollFollow(cmd *cobra.Command, path string) error {
+	if out, err := logger.Tail(logsTailN); err == nil {
+		cmd.Print(out)
+	}
+	var offset int64
+	if info, err := os.Stat(path); err == nil {
+		offset = info.Size()
+	}
+	for {
+		time.Sleep(500 * time.Millisecond)
+		f, err := os.Open(path)
+		if err != nil {
+			continue
+		}
+		if _, err := f.Seek(offset, io.SeekStart); err == nil {
+			data, _ := io.ReadAll(f)
+			if len(data) > 0 {
+				cmd.Print(string(data))
+				offset += int64(len(data))
+			}
+		}
+		f.Close()
+	}
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -57,6 +57,7 @@ func init() {
 	rootCmd.AddCommand(upgradeCmd)
 	rootCmd.AddCommand(watchCmd)
 	rootCmd.AddCommand(collectCmd)
+	rootCmd.AddCommand(logsCmd)
 }
 
 var versionCmd = &cobra.Command{

--- a/internal/client/api.go
+++ b/internal/client/api.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	"github.com/promptconduit/cli/internal/envelope"
+	"github.com/promptconduit/cli/internal/logger"
 	"github.com/promptconduit/cli/internal/outbound"
 )
 
@@ -209,19 +210,25 @@ func (c *Client) SendEnvelopeAsync(env *envelope.RawEventEnvelope) error {
 	return c.sendAsyncUnix(envJSON)
 }
 
-// sendAsyncUnix uses fork to send envelope without blocking
+// sendAsyncUnix uses fork to send envelope without blocking. The subprocess
+// inherits a file descriptor pointing at the persistent log file as stderr,
+// so any crash or panic — which the in-process logger can't catch — still
+// leaves a trace on disk. Previously stderr was discarded, which made
+// failed sends invisible.
 func (c *Client) sendAsyncUnix(envJSON []byte) error {
 	exe, err := os.Executable()
 	if err != nil {
+		logger.Error("async send: cannot resolve executable path: %v (falling back to blocking)", err)
 		return c.sendEnvelopeBlocking(envJSON)
 	}
 
 	cmd := exec.Command(exe, "hook", "--send-event")
 	cmd.Stdin = bytes.NewReader(envJSON)
 	cmd.Stdout = nil
-	cmd.Stderr = nil
+	cmd.Stderr = openLogForStderr()
 
 	if err := cmd.Start(); err != nil {
+		logger.Error("async send: cmd.Start failed: %v (falling back to blocking)", err)
 		return c.sendEnvelopeBlocking(envJSON)
 	}
 
@@ -236,13 +243,16 @@ func (c *Client) sendAsyncUnix(envJSON []byte) error {
 func (c *Client) sendAsyncWindows(envJSON []byte) error {
 	exe, err := os.Executable()
 	if err != nil {
+		logger.Error("async send: cannot resolve executable path: %v (falling back to blocking)", err)
 		return c.sendEnvelopeBlocking(envJSON)
 	}
 
 	cmd := exec.Command(exe, "hook", "--send-event")
 	cmd.Stdin = bytes.NewReader(envJSON)
+	cmd.Stderr = openLogForStderr()
 
 	if err := cmd.Start(); err != nil {
+		logger.Error("async send: cmd.Start failed: %v (falling back to blocking)", err)
 		return c.sendEnvelopeBlocking(envJSON)
 	}
 
@@ -251,6 +261,23 @@ func (c *Client) sendAsyncWindows(envJSON []byte) error {
 	}()
 
 	return nil
+}
+
+// openLogForStderr returns a file handle suitable to assign to cmd.Stderr.
+// The subprocess's runtime (panics, fatal errors that bypass the logger)
+// gets routed into the same persistent log so a crashed sender isn't
+// silent. Returns nil on any failure — exec then discards stderr, matching
+// the prior behavior, so we never make things worse than before.
+func openLogForStderr() *os.File {
+	dir := logger.Dir()
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return nil
+	}
+	f, err := os.OpenFile(logger.Path(), os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644)
+	if err != nil {
+		return nil
+	}
+	return f
 }
 
 // sendEnvelopeBlocking sends the envelope synchronously (fallback)

--- a/internal/logger/logger.go
+++ b/internal/logger/logger.go
@@ -1,0 +1,221 @@
+// Package logger provides a small, dependency-free logger for the CLI.
+//
+// Two levels:
+//
+//	Error — always written. Use for any failure path (HTTP error, config
+//	        missing, subprocess crash, etc.). Errors are the most important
+//	        signal when debugging "events aren't reaching the platform."
+//	Debug — written only when the active config has Debug=true. Use for
+//	        trace-level breadcrumbs.
+//
+// Logs live under the user's config dir at
+//
+//	~/.config/promptconduit/logs/promptconduit.log
+//
+// (or the equivalent XDG path). The file is rotated when it exceeds
+// MaxBytes — the current file is renamed to `.1` and a fresh one is
+// started. Only one backup is kept; older data is discarded. This keeps
+// total disk footprint bounded at ~2*MaxBytes per machine.
+package logger
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sync"
+	"time"
+)
+
+// MaxBytes is the soft size cap at which the active log file is rotated.
+// Tuned for "one or two days of activity for a typical user": large enough
+// to keep useful history, small enough that a tail/cat finishes instantly.
+const MaxBytes int64 = 1 << 20 // 1 MiB
+
+// dirOverride, when set, replaces the user-config-dir lookup. Used by tests
+// so we don't write into the real home directory.
+//
+// Two mutexes:
+//   - dirMu guards dirOverride (cheap RWMutex; Dir() is called from inside write())
+//   - writeMu serializes file open/append so concurrent writers don't interleave
+var (
+	dirOverride string
+	dirMu       sync.RWMutex
+	writeMu     sync.Mutex
+)
+
+// SetDirForTest overrides the log directory. Test-only. Pass "" to clear.
+func SetDirForTest(dir string) {
+	dirMu.Lock()
+	defer dirMu.Unlock()
+	dirOverride = dir
+}
+
+// Dir returns the directory where logs are written.
+func Dir() string {
+	dirMu.RLock()
+	d := dirOverride
+	dirMu.RUnlock()
+	if d != "" {
+		return d
+	}
+	if xdg := os.Getenv("XDG_CONFIG_HOME"); xdg != "" {
+		return filepath.Join(xdg, "promptconduit", "logs")
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return filepath.Join(os.TempDir(), "promptconduit-logs")
+	}
+	return filepath.Join(home, ".config", "promptconduit", "logs")
+}
+
+// Path returns the absolute path of the active log file.
+func Path() string {
+	return filepath.Join(Dir(), "promptconduit.log")
+}
+
+// BackupPath returns the path of the rotated backup file.
+func BackupPath() string {
+	return filepath.Join(Dir(), "promptconduit.log.1")
+}
+
+// Error writes an error-level line. Always recorded.
+func Error(format string, args ...interface{}) {
+	write("ERROR", format, args...)
+}
+
+// Debug writes a debug-level line. Recorded only when the caller has
+// signaled debug mode via SetDebug — typically the CLI sets this at startup
+// based on the loaded config. We accept the bool as a function rather than
+// reading config every call to avoid a circular dependency with the client
+// package and to keep the hot path cheap.
+func Debug(format string, args ...interface{}) {
+	if !debugEnabled() {
+		return
+	}
+	write("DEBUG", format, args...)
+}
+
+var (
+	debugMu  sync.RWMutex
+	debugOn  bool
+	debugSet bool
+)
+
+// SetDebug toggles debug-level output. Call once during startup. Until it
+// is called, Debug() is a no-op so we never accidentally spam the log from
+// a process that hasn't loaded config (e.g. unit tests).
+func SetDebug(on bool) {
+	debugMu.Lock()
+	debugOn = on
+	debugSet = true
+	debugMu.Unlock()
+}
+
+func debugEnabled() bool {
+	debugMu.RLock()
+	defer debugMu.RUnlock()
+	return debugSet && debugOn
+}
+
+func write(level, format string, args ...interface{}) {
+	writeMu.Lock()
+	defer writeMu.Unlock()
+
+	dir := Dir()
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		// Best-effort: if we can't even make the directory, drop the line
+		// rather than crash the host process (this is called from a hook
+		// that must never block or fail the AI tool).
+		return
+	}
+
+	path := Path()
+	rotateIfNeeded(path)
+
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644)
+	if err != nil {
+		return
+	}
+	defer f.Close()
+
+	msg := fmt.Sprintf(format, args...)
+	pid := os.Getpid()
+	line := fmt.Sprintf("%s %s pid=%d %s\n",
+		time.Now().UTC().Format(time.RFC3339Nano),
+		level,
+		pid,
+		msg,
+	)
+	_, _ = f.WriteString(line)
+}
+
+// rotateIfNeeded renames the active log to `.1` once it crosses MaxBytes.
+// Any prior `.1` is overwritten. Called with `writeMu` held.
+func rotateIfNeeded(path string) {
+	info, err := os.Stat(path)
+	if err != nil {
+		return
+	}
+	if info.Size() < MaxBytes {
+		return
+	}
+	_ = os.Remove(BackupPath())
+	_ = os.Rename(path, BackupPath())
+}
+
+// Tail returns up to maxLines lines from the end of the log (current file
+// only — backup is not read). Returns ("", nil) when the file doesn't
+// exist yet. Reads the whole file; not intended for unbounded logs (we
+// rotate at 1 MiB).
+func Tail(maxLines int) (string, error) {
+	path := Path()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return "", nil
+		}
+		return "", err
+	}
+	if maxLines <= 0 {
+		return string(data), nil
+	}
+	return lastLines(data, maxLines), nil
+}
+
+// CopyTo streams the active log file to w. Used by `promptconduit logs
+// --follow` and for piping into other tools.
+func CopyTo(w io.Writer) error {
+	path := Path()
+	f, err := os.Open(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return err
+	}
+	defer f.Close()
+	_, err = io.Copy(w, f)
+	return err
+}
+
+func lastLines(data []byte, n int) string {
+	if len(data) == 0 || n <= 0 {
+		return ""
+	}
+	count := 0
+	// Walk backwards until we've seen n newlines (or hit the start).
+	i := len(data) - 1
+	if data[i] == '\n' {
+		i--
+	}
+	for ; i >= 0; i-- {
+		if data[i] == '\n' {
+			count++
+			if count == n {
+				return string(data[i+1:])
+			}
+		}
+	}
+	return string(data)
+}

--- a/internal/logger/logger_test.go
+++ b/internal/logger/logger_test.go
@@ -1,0 +1,123 @@
+package logger
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func setup(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	SetDirForTest(dir)
+	SetDebug(false)
+	t.Cleanup(func() {
+		SetDirForTest("")
+	})
+	return dir
+}
+
+func TestError_AlwaysWrites(t *testing.T) {
+	dir := setup(t)
+
+	Error("boom: %s", "network down")
+
+	data, err := os.ReadFile(filepath.Join(dir, "promptconduit.log"))
+	if err != nil {
+		t.Fatalf("expected log file to exist: %v", err)
+	}
+	s := string(data)
+	if !strings.Contains(s, "ERROR") {
+		t.Errorf("expected ERROR level marker, got: %s", s)
+	}
+	if !strings.Contains(s, "boom: network down") {
+		t.Errorf("expected formatted message, got: %s", s)
+	}
+}
+
+func TestDebug_GatedOnSetDebug(t *testing.T) {
+	dir := setup(t)
+
+	Debug("trace-1")
+
+	if _, err := os.Stat(filepath.Join(dir, "promptconduit.log")); !os.IsNotExist(err) {
+		t.Errorf("expected no log file when Debug disabled (err=%v)", err)
+	}
+
+	SetDebug(true)
+	Debug("trace-2")
+
+	data, err := os.ReadFile(filepath.Join(dir, "promptconduit.log"))
+	if err != nil {
+		t.Fatalf("expected log file after enabling debug: %v", err)
+	}
+	s := string(data)
+	if strings.Contains(s, "trace-1") {
+		t.Errorf("trace-1 should not appear (debug off when written): %s", s)
+	}
+	if !strings.Contains(s, "trace-2") {
+		t.Errorf("trace-2 should appear: %s", s)
+	}
+}
+
+func TestRotation(t *testing.T) {
+	dir := setup(t)
+
+	path := filepath.Join(dir, "promptconduit.log")
+	// Seed the active file just over MaxBytes so the next write rotates.
+	big := strings.Repeat("x", int(MaxBytes)+1)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(big), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	Error("post-rotation line")
+
+	if _, err := os.Stat(filepath.Join(dir, "promptconduit.log.1")); err != nil {
+		t.Errorf("expected backup file after rotation: %v", err)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(data), "post-rotation line") {
+		t.Errorf("expected new file to start with post-rotation line: %s", string(data))
+	}
+	// The new file must be much smaller than the original (only the one new line).
+	if int64(len(data)) > MaxBytes/2 {
+		t.Errorf("new log file should be small after rotation, got %d bytes", len(data))
+	}
+}
+
+func TestTail(t *testing.T) {
+	setup(t)
+
+	for i := 0; i < 5; i++ {
+		Error("line-%d", i)
+	}
+
+	out, err := Tail(2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out, "line-3") || !strings.Contains(out, "line-4") {
+		t.Errorf("expected last two lines, got: %q", out)
+	}
+	if strings.Contains(out, "line-0") || strings.Contains(out, "line-2") {
+		t.Errorf("tail should not include earlier lines, got: %q", out)
+	}
+}
+
+func TestTail_MissingFile(t *testing.T) {
+	setup(t)
+	out, err := Tail(10)
+	if err != nil {
+		t.Fatalf("missing file should not error: %v", err)
+	}
+	if out != "" {
+		t.Errorf("expected empty output, got: %q", out)
+	}
+}


### PR DESCRIPTION
## The bug

Hook send-event failures were silent. `fileLog` (cmd/hook.go) early-returned unless `debug: true` was set, the async subprocess set `stderr = nil` (internal/client/api.go), and even the existing debug-only log went to `/tmp/promptconduit-hook.log` — a path that's blown away on reboot and confusingly collides with the macOS app's own log file.

Net effect: when events stopped reaching the platform (network blip, expired key, server 5xx), the user had no on-disk trace to diagnose from.

## The fix

New `internal/logger` package:

- `Error(format, args...)` — **always** written, regardless of config.
- `Debug(format, args...)` — only written after `SetDebug(true)` (the hook entry points call this from the loaded config).
- Lives at `~/.config/promptconduit/logs/promptconduit.log` (XDG-aware).
- Rotates at 1 MiB to a single `.log.1` backup; total footprint ≤ 2 MiB.
- Standalone — no dependency on `client` package, so it's safe to call from anywhere including the hot hook path.

Wiring:

- `cmd/hook.go`: every failure path now calls `logger.Error`; trace lines use `logger.Debug`; legacy `/tmp/promptconduit-hook.log` writer removed.
- `internal/client/api.go`: the async subprocess now inherits a fd pointing at the log file as `Stderr`, so a panic that escapes the in-process logger still leaves a trace.

Plus a new `promptconduit logs` command:

```
promptconduit logs              # last 50 lines
promptconduit logs -n 200       # last 200 lines
promptconduit logs --follow     # tail -f (uses /usr/bin/tail when available)
promptconduit logs --path       # just print the path
promptconduit logs --clear      # truncate
```

## Verification

End-to-end on macOS:

**Success path** (debug=true config):
```
DEBUG pid=84525 Hook started
DEBUG pid=84525 Detected tool: claude-code, hook event: PreToolUse
DEBUG pid=84537 Async subprocess: envelope sent successfully
```

**Failure path** (bad API URL, debug=false in config):
```
ERROR pid=85171 Async subprocess API send failed (url=http://127.0.0.1:1): dial tcp 127.0.0.1:1: connect: connection refused
```
Exactly one ERROR line, zero DEBUG noise. Goal achieved: silent failures are now loud, verbose tracing stays off unless explicitly enabled.

## Test plan

- [x] `go test ./internal/logger/` — 5 tests pass (Error always writes, Debug gated, rotation at MaxBytes, Tail returns last N lines, Tail handles missing file)
- [x] `make test` — full suite green
- [x] `go vet ./...` clean
- [x] Real hook with successful API send → DEBUG breadcrumbs in log
- [x] Real hook with unreachable API + debug=false → exactly one ERROR line in log
- [x] `promptconduit logs --path`, `--clear`, `-n`, `--follow` all work
- [ ] Windows: the `--follow` fallback to polling kicks in when `tail` is absent

🤖 Generated with [Claude Code](https://claude.com/claude-code)