### PR TITLE
feat(skills): per-skill install/uninstall + approve/reject + list --filter

### DIFF
--- a/cmd/skills.go
+++ b/cmd/skills.go
@@ -13,6 +13,7 @@ import (
 
 var (
 	skillsApproved string
+	skillsFilter   string
 	skillsType     string
 	skillsLimit    int
 	skillsForce    bool
@@ -107,6 +108,7 @@ Requires the Anthropic API key to be configured on the platform.`,
 func init() {
 	skillsListCmd.Flags().StringP("format", "f", "text", "Output format (text, json)")
 	skillsListCmd.Flags().StringVar(&skillsApproved, "approved", "", "Filter by approval: true, false, or pending")
+	skillsListCmd.Flags().StringVar(&skillsFilter, "filter", "all", "Tab filter: new (unapproved), ready (approved), removed (rejected), all")
 	skillsListCmd.Flags().StringVar(&skillsType, "type", "", "Filter by type: workflow, command, template, checklist")
 	skillsListCmd.Flags().IntVarP(&skillsLimit, "limit", "l", 50, "Maximum number of skills to show")
 	skillsListCmd.Flags().StringVar(&skillsRepo, "repo", "", "Filter to a specific project (e.g. my-org/my-repo)")
@@ -124,10 +126,21 @@ func init() {
 	skillsPatternsCmd.Flags().StringP("format", "f", "text", "Output format (text, json)")
 	skillsPatternsCmd.Flags().StringVar(&skillsRepo, "repo", "", "Scope to a specific project (auto-detected if in a git repo)")
 
+	skillsInstallCmd.Flags().BoolVar(&skillsInstallAll, "all", false, "Install every approved skill")
+	skillsInstallCmd.Flags().StringVar(&skillsInstallScope, "scope", "", "Install scope: project (in current git repo) or global (~/.claude/skills)")
+	skillsInstallCmd.Flags().BoolVar(&skillsInstallForce, "force", false, "Overwrite local edits without prompting")
+
+	skillsUninstallCmd.Flags().BoolVar(&skillsUninstallAll, "all", false, "Uninstall every promptconduit-installed skill")
+	skillsUninstallCmd.Flags().BoolVar(&skillsUninstallForce, "force", false, "Remove even if the file has been hand-edited")
+
 	skillsCmd.AddCommand(skillsListCmd)
 	skillsCmd.AddCommand(skillsGenerateCmd)
 	skillsCmd.AddCommand(skillsSyncCmd)
 	skillsCmd.AddCommand(skillsPatternsCmd)
+	skillsCmd.AddCommand(skillsInstallCmd)
+	skillsCmd.AddCommand(skillsUninstallCmd)
+	skillsCmd.AddCommand(skillsApproveCmd)
+	skillsCmd.AddCommand(skillsRejectCmd)
 }
 
 // ============================================================================
@@ -140,12 +153,28 @@ func runSkillsList(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("API key not configured. Run: promptconduit config set --api-key=\"your-key\"")
 	}
 
-	// Translate --approved flag
+	// --filter mirrors the web UI tabs and takes precedence over --approved.
+	// The web tabs are pure client-side derivations of is_approved:
+	//   new=null, ready=true, removed=false, all=any.
+	// Server has an approved=true|false param; null requires a client-side pass.
 	approvedFilter := ""
-	if skillsApproved == "true" {
+	wantNullOnly := false
+	switch strings.ToLower(skillsFilter) {
+	case "ready":
 		approvedFilter = "true"
-	} else if skillsApproved == "false" || skillsApproved == "pending" {
+	case "removed":
 		approvedFilter = "false"
+	case "new":
+		wantNullOnly = true
+	case "all", "":
+		// honor legacy --approved when --filter is "all" (its default)
+		if skillsApproved == "true" {
+			approvedFilter = "true"
+		} else if skillsApproved == "false" || skillsApproved == "pending" {
+			approvedFilter = "false"
+		}
+	default:
+		return fmt.Errorf("invalid --filter %q (want new|ready|removed|all)", skillsFilter)
 	}
 
 	apiClient := client.NewClient(cfg, Version)
@@ -155,12 +184,39 @@ func runSkillsList(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("failed to list skills: %s", resp.Error)
 	}
 
+	if wantNullOnly {
+		filterUnapproved(resp.Data)
+	}
+
 	format, _ := cmd.Flags().GetString("format")
 	if format == "json" {
 		return outputJSON(resp.Data)
 	}
 
 	return outputSkillsList(resp.Data)
+}
+
+// filterUnapproved mutates the response data in place to retain only skills
+// whose is_approved is null/missing. Used by --filter new since the server
+// can't express "approval IS NULL" via its current query params.
+func filterUnapproved(data map[string]interface{}) {
+	list, ok := data["skills"].([]interface{})
+	if !ok {
+		return
+	}
+	kept := make([]interface{}, 0, len(list))
+	for _, s := range list {
+		m, ok := s.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		v, present := m["is_approved"]
+		if !present || v == nil {
+			kept = append(kept, s)
+		}
+	}
+	data["skills"] = kept
+	data["total"] = float64(len(kept))
 }
 
 func runSkillsGenerate(cmd *cobra.Command, args []string) error {

--- a/cmd/skills_install.go
+++ b/cmd/skills_install.go
@@ -1,0 +1,473 @@
+package cmd
+
+import (
+	"bufio"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/promptconduit/cli/internal/client"
+	skillspkg "github.com/promptconduit/cli/internal/skills"
+	"github.com/spf13/cobra"
+)
+
+// Flags. Reused state variables would collide with cmd/skills.go, so these
+// are install/uninstall-specific.
+var (
+	skillsInstallAll       bool
+	skillsInstallScope     string
+	skillsInstallForce     bool
+	skillsUninstallAll     bool
+	skillsUninstallForce   bool
+)
+
+// Exit codes the commands can return through cobra. We surface them via
+// fmt.Errorf — main.go currently exits 1 on any RunE error; richer exit
+// codes would require a wrapper around Execute(). Out of scope for Phase 1.
+
+// ============================================================================
+// install
+// ============================================================================
+
+var skillsInstallCmd = &cobra.Command{
+	Use:   "install [name]",
+	Short: "Install a skill into .claude/skills/<name>/SKILL.md",
+	Long: `Download a skill from the platform and write it to the Claude Code
+skills directory. Tracks the install in a local manifest so it can be
+safely uninstalled later.
+
+Examples:
+  promptconduit skills install shipping-features
+  promptconduit skills install shipping-features --scope project
+  promptconduit skills install --all
+  promptconduit skills install shipping-features --force   # overwrite local edits`,
+	RunE: runSkillsInstall,
+}
+
+// ============================================================================
+// uninstall
+// ============================================================================
+
+var skillsUninstallCmd = &cobra.Command{
+	Use:   "uninstall [name]",
+	Short: "Remove a previously installed skill",
+	Long: `Remove a skill that was installed via 'promptconduit skills install'.
+
+Refuses if the file on disk has been modified since install (sha mismatch),
+unless --force is given. Skills not tracked by the local manifest are
+never touched.
+
+Examples:
+  promptconduit skills uninstall shipping-features
+  promptconduit skills uninstall --all
+  promptconduit skills uninstall shipping-features --force`,
+	RunE: runSkillsUninstall,
+}
+
+// ============================================================================
+// approve / reject  (server-side state via PATCH /v1/skills/:id)
+// ============================================================================
+
+var skillsApproveCmd = &cobra.Command{
+	Use:   "approve [name]",
+	Short: "Mark a skill as approved on the platform (the Ready tab)",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return runApproveOrReject(args[0], true)
+	},
+}
+
+var skillsRejectCmd = &cobra.Command{
+	Use:   "reject [name]",
+	Short: "Mark a skill as rejected on the platform (the Removed tab)",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return runApproveOrReject(args[0], false)
+	},
+}
+
+// ============================================================================
+// implementations
+// ============================================================================
+
+func runSkillsInstall(cmd *cobra.Command, args []string) error {
+	if skillsInstallAll && len(args) > 0 {
+		return errors.New("--all is mutually exclusive with a positional skill name")
+	}
+	if !skillsInstallAll && len(args) != 1 {
+		return errors.New("expected a skill name or --all")
+	}
+
+	cfg := client.LoadConfig()
+	if !cfg.IsConfigured() {
+		return errors.New(`API key not configured. Run: promptconduit config set --api-key="your-key"`)
+	}
+
+	apiClient := client.NewClient(cfg, Version)
+
+	manifest, err := skillspkg.Load(client.ConfigDir())
+	if err != nil {
+		return fmt.Errorf("load manifest: %w", err)
+	}
+
+	// Resolve which skills to install: either the named one, or every
+	// approved skill on the server.
+	var targets []map[string]interface{}
+	if skillsInstallAll {
+		resp := apiClient.GetSkills("true", "", 100, "")
+		if !resp.Success {
+			return fmt.Errorf("fetch approved skills: %s", resp.Error)
+		}
+		list, _ := resp.Data["skills"].([]interface{})
+		for _, s := range list {
+			if m, ok := s.(map[string]interface{}); ok {
+				targets = append(targets, m)
+			}
+		}
+		if len(targets) == 0 {
+			cmd.Println("No approved skills to install.")
+			return nil
+		}
+	} else {
+		name := args[0]
+		if err := skillspkg.ValidateName(name); err != nil {
+			return err
+		}
+		skill, err := findSkillByName(apiClient, name)
+		if err != nil {
+			return err
+		}
+		targets = []map[string]interface{}{skill}
+	}
+
+	installed, skipped, failed := 0, 0, 0
+	for _, skill := range targets {
+		name, _ := skill["name"].(string)
+		switch err := installOne(cmd, apiClient, manifest, skill); {
+		case err == nil:
+			installed++
+		case errors.Is(err, errAlreadyCurrent):
+			cmd.Printf("  [SKIP] %s — already up to date\n", name)
+			skipped++
+		case errors.Is(err, errAbortLocalChanges):
+			cmd.Printf("  [SKIP] %s — local modifications, use --force to overwrite\n", name)
+			skipped++
+		default:
+			cmd.Printf("  [FAIL] %s: %v\n", name, err)
+			failed++
+		}
+	}
+
+	// Persist whatever we managed to record. Each installOne already
+	// updates the in-memory manifest; we save once at the end so a
+	// crash mid-batch doesn't leave a half-recorded state.
+	if err := skillspkg.Save(client.ConfigDir(), manifest); err != nil {
+		return fmt.Errorf("save manifest: %w", err)
+	}
+
+	cmd.Printf("\n%d installed, %d skipped, %d failed\n", installed, skipped, failed)
+	if failed > 0 {
+		return fmt.Errorf("%d skill(s) failed to install", failed)
+	}
+	return nil
+}
+
+// Sentinel errors for non-fatal install outcomes that the loop above
+// presents differently from real failures.
+var (
+	errAlreadyCurrent    = errors.New("already up to date")
+	errAbortLocalChanges = errors.New("local modifications present")
+)
+
+func installOne(cmd *cobra.Command, apiClient *client.Client, manifest *skillspkg.Manifest, skill map[string]interface{}) error {
+	id, _ := skill["id"].(string)
+	name, _ := skill["name"].(string)
+	repoName, _ := skill["repo_name"].(string)
+	if id == "" || name == "" {
+		return errors.New("skill record missing id or name")
+	}
+	if err := skillspkg.ValidateName(name); err != nil {
+		return err
+	}
+
+	cwd, _ := os.Getwd()
+	scope, base, err := skillspkg.ResolveScope(repoName, skillsInstallScope, cwd)
+	if err != nil {
+		return err
+	}
+
+	// Fetch the canonical SKILL.md body from the platform.
+	content, err := apiClient.GetSkillCommandFile(id)
+	if err != nil {
+		return fmt.Errorf("download: %w", err)
+	}
+	platformSHA := skillspkg.HashContent([]byte(content))
+
+	target := skillspkg.SkillFile(base, name)
+
+	// Idempotency check: if we already track this skill at the same sha,
+	// the file on disk almost certainly hasn't drifted — fast no-op.
+	if existing := manifest.Find(name); existing != nil {
+		if existing.PlatformSHA256 == platformSHA && fileExistsAtSha(target, platformSHA) {
+			return errAlreadyCurrent
+		}
+		// Drifted. Refuse unless --force.
+		if !skillsInstallForce && fileExists(target) {
+			diskSHA, _ := skillspkg.HashFile(target)
+			if diskSHA != "" && diskSHA != existing.PlatformSHA256 {
+				if !confirm(fmt.Sprintf("%s has local modifications — overwrite?", name)) {
+					return errAbortLocalChanges
+				}
+			}
+		}
+	}
+
+	if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+		return fmt.Errorf("create skill dir: %w", err)
+	}
+	if err := writeAtomic(target, []byte(content)); err != nil {
+		return fmt.Errorf("write SKILL.md: %w", err)
+	}
+
+	manifest.Add(skillspkg.Entry{
+		ID:             id,
+		Name:           name,
+		Scope:          scope,
+		InstalledAt:    time.Now().UTC(),
+		PlatformSHA256: platformSHA,
+		Files: []skillspkg.File{
+			{Path: target, SHA256: platformSHA},
+		},
+	})
+
+	cmd.Printf("  [OK]   %s → %s\n", name, target)
+	return nil
+}
+
+func runSkillsUninstall(cmd *cobra.Command, args []string) error {
+	if skillsUninstallAll && len(args) > 0 {
+		return errors.New("--all is mutually exclusive with a positional skill name")
+	}
+	if !skillsUninstallAll && len(args) != 1 {
+		return errors.New("expected a skill name or --all")
+	}
+
+	manifest, err := skillspkg.Load(client.ConfigDir())
+	if err != nil {
+		return fmt.Errorf("load manifest: %w", err)
+	}
+
+	var names []string
+	if skillsUninstallAll {
+		for _, e := range manifest.Skills {
+			names = append(names, e.Name)
+		}
+		if len(names) == 0 {
+			cmd.Println("No PromptConduit-installed skills to uninstall.")
+			return nil
+		}
+	} else {
+		names = []string{args[0]}
+	}
+
+	removed, skipped, failed := 0, 0, 0
+	for _, name := range names {
+		switch err := uninstallOne(cmd, manifest, name); {
+		case err == nil:
+			removed++
+		case errors.Is(err, errNotTracked):
+			cmd.Printf("  [SKIP] %s — not tracked by promptconduit\n", name)
+			skipped++
+		case errors.Is(err, errAbortLocalChanges):
+			cmd.Printf("  [SKIP] %s — local modifications, use --force\n", name)
+			skipped++
+		default:
+			cmd.Printf("  [FAIL] %s: %v\n", name, err)
+			failed++
+		}
+	}
+
+	if err := skillspkg.Save(client.ConfigDir(), manifest); err != nil {
+		return fmt.Errorf("save manifest: %w", err)
+	}
+
+	cmd.Printf("\n%d removed, %d skipped, %d failed\n", removed, skipped, failed)
+	if failed > 0 {
+		return fmt.Errorf("%d skill(s) failed to uninstall", failed)
+	}
+	return nil
+}
+
+var errNotTracked = errors.New("not tracked by manifest")
+
+func uninstallOne(cmd *cobra.Command, manifest *skillspkg.Manifest, name string) error {
+	entry := manifest.Find(name)
+	if entry == nil {
+		return errNotTracked
+	}
+
+	for _, f := range entry.Files {
+		// Hand-edit check (skip the sha verification with --force).
+		if !skillsUninstallForce && fileExists(f.Path) {
+			onDisk, _ := skillspkg.HashFile(f.Path)
+			if onDisk != "" && onDisk != f.SHA256 {
+				return errAbortLocalChanges
+			}
+		}
+		if err := os.Remove(f.Path); err != nil && !errors.Is(err, os.ErrNotExist) {
+			return fmt.Errorf("remove %s: %w", f.Path, err)
+		}
+		// Best-effort: clean up the skill's parent dir if empty.
+		_ = removeEmptyDir(filepath.Dir(f.Path))
+	}
+
+	manifest.Remove(name)
+	cmd.Printf("  [OK]   %s\n", name)
+	return nil
+}
+
+func runApproveOrReject(name string, approve bool) error {
+	cfg := client.LoadConfig()
+	if !cfg.IsConfigured() {
+		return errors.New(`API key not configured. Run: promptconduit config set --api-key="your-key"`)
+	}
+	apiClient := client.NewClient(cfg, Version)
+	skill, err := findSkillByName(apiClient, name)
+	if err != nil {
+		return err
+	}
+	id, _ := skill["id"].(string)
+	if id == "" {
+		return fmt.Errorf("skill %q has no id", name)
+	}
+	resp := apiClient.ApproveSkill(id, approve)
+	if !resp.Success {
+		verb := "approve"
+		if !approve {
+			verb = "reject"
+		}
+		return fmt.Errorf("%s %s: %s", verb, name, resp.Error)
+	}
+	verb := "approved"
+	if !approve {
+		verb = "rejected"
+	}
+	fmt.Printf("%s %s\n", verb, name)
+	return nil
+}
+
+// ============================================================================
+// helpers
+// ============================================================================
+
+// findSkillByName lists up to 100 skills (any approval state) and returns
+// the first one whose name matches. Returns a structured error when not
+// found. Used by install + approve + reject.
+func findSkillByName(c *client.Client, name string) (map[string]interface{}, error) {
+	resp := c.GetSkills("", "", 100, "")
+	if !resp.Success {
+		return nil, fmt.Errorf("list skills: %s", resp.Error)
+	}
+	list, _ := resp.Data["skills"].([]interface{})
+	for _, s := range list {
+		m, ok := s.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		if n, _ := m["name"].(string); n == name {
+			return m, nil
+		}
+	}
+	return nil, fmt.Errorf("skill %q not found on the platform", name)
+}
+
+// writeAtomic writes data to path via tempfile + rename in the same dir.
+// Same pattern as internal/skills/manifest.go's Save, but for arbitrary
+// content. Same dir is important for atomic rename across filesystems.
+func writeAtomic(path string, data []byte) error {
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return err
+	}
+	tmp, err := os.CreateTemp(dir, ".pc-skill-*.tmp")
+	if err != nil {
+		return err
+	}
+	tmpName := tmp.Name()
+	defer func() { _ = os.Remove(tmpName) }()
+
+	if _, err := tmp.Write(data); err != nil {
+		_ = tmp.Close()
+		return err
+	}
+	if err := tmp.Sync(); err != nil {
+		_ = tmp.Close()
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+	// Ensure 0644 explicitly — CreateTemp gives 0600.
+	if err := os.Chmod(tmpName, 0o644); err != nil {
+		return err
+	}
+	return os.Rename(tmpName, path)
+}
+
+func fileExists(path string) bool {
+	_, err := os.Stat(path)
+	return err == nil
+}
+
+func fileExistsAtSha(path, want string) bool {
+	got, err := skillspkg.HashFile(path)
+	return err == nil && got == want
+}
+
+// removeEmptyDir removes dir only if it's empty. Used to keep
+// ~/.claude/skills/<name>/ from lingering after we remove its SKILL.md.
+func removeEmptyDir(dir string) error {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return err
+	}
+	if len(entries) > 0 {
+		return nil
+	}
+	return os.Remove(dir)
+}
+
+// confirm prompts the user [Y/n]. Defaults to Y. On non-TTY (CI, piped
+// input) it returns false so the install/uninstall is treated as
+// "needs --force" rather than silently overwriting.
+func confirm(prompt string) bool {
+	if !stdinIsTerminal() {
+		return false
+	}
+	fmt.Printf("%s [Y/n] ", prompt)
+	reader := bufio.NewReader(os.Stdin)
+	line, err := reader.ReadString('\n')
+	if err != nil {
+		if errors.Is(err, io.EOF) {
+			return false
+		}
+		return false
+	}
+	answer := strings.TrimSpace(strings.ToLower(line))
+	return answer == "" || answer == "y" || answer == "yes"
+}
+
+// stdinIsTerminal reports whether stdin is a character device (e.g. a tty).
+// Stdlib-only check that avoids dragging in golang.org/x/term and its
+// Go-toolchain floor.
+func stdinIsTerminal() bool {
+	fi, err := os.Stdin.Stat()
+	if err != nil {
+		return false
+	}
+	return (fi.Mode() & os.ModeCharDevice) != 0
+}

--- a/cmd/skills_install_test.go
+++ b/cmd/skills_install_test.go
@@ -1,0 +1,288 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/promptconduit/cli/internal/client"
+	skillspkg "github.com/promptconduit/cli/internal/skills"
+)
+
+// stubSkill is the minimum shape installOne needs from the platform.
+type stubSkill struct {
+	ID       string `json:"id"`
+	Name     string `json:"name"`
+	RepoName string `json:"repo_name,omitempty"`
+}
+
+// newTestServer returns an httptest.Server that responds to the two
+// endpoints install/uninstall hit: GET /v1/skills and GET /v1/skills/:id/command.
+// `command` is the SKILL.md body returned for the latter.
+func newTestServer(t *testing.T, skills []stubSkill, command string) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/v1/skills" && r.Method == http.MethodGet:
+			out := map[string]interface{}{
+				"skills": toAnySlice(skills),
+				"total":  float64(len(skills)),
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(out)
+		case strings.HasPrefix(r.URL.Path, "/v1/skills/") && strings.HasSuffix(r.URL.Path, "/command"):
+			w.Header().Set("Content-Type", "text/markdown")
+			_, _ = w.Write([]byte(command))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+func toAnySlice(skills []stubSkill) []interface{} {
+	out := make([]interface{}, 0, len(skills))
+	for _, s := range skills {
+		// Marshal/unmarshal so the test server returns the same map shape
+		// production code expects (with is_approved missing → "new").
+		buf, _ := json.Marshal(map[string]interface{}{
+			"id":          s.ID,
+			"name":        s.Name,
+			"repo_name":   s.RepoName,
+			"is_approved": true, // tests assume approved set; install --all relies on it
+		})
+		var m map[string]interface{}
+		_ = json.Unmarshal(buf, &m)
+		out = append(out, m)
+	}
+	return out
+}
+
+// setupSkillsEnv redirects config, HOME, and the API URL into temp dirs
+// for the duration of the test. It also resets all package-level command
+// flag variables to their defaults so tests can be run in any order.
+func setupSkillsEnv(t *testing.T, apiURL string) (configDir, homeDir string) {
+	t.Helper()
+	configDir = t.TempDir()
+	homeDir = t.TempDir()
+
+	t.Setenv("XDG_CONFIG_HOME", configDir)
+	t.Setenv("HOME", homeDir)
+	t.Setenv(client.EnvAPIKey, "test-key")
+	t.Setenv(client.EnvAPIURL, apiURL)
+	t.Setenv(client.EnvAutoUpdate, "0")
+
+	// Reset flags so previous t.Run cases don't bleed state.
+	skillsInstallAll = false
+	skillsInstallScope = "global" // default to global in tests; project requires a git repo
+	skillsInstallForce = false
+	skillsUninstallAll = false
+	skillsUninstallForce = false
+
+	// The promptconduit config dir is derived from XDG_CONFIG_HOME/promptconduit.
+	// Confirm with the real helper so the test assertions match production.
+	if got := client.ConfigDir(); !strings.HasPrefix(got, configDir) {
+		t.Fatalf("ConfigDir = %q, expected to live under %q", got, configDir)
+	}
+	return configDir, homeDir
+}
+
+func TestInstall_WritesFile_AndRecordsManifest(t *testing.T) {
+	body := "# SKILL.md\nfoo\n"
+	srv := newTestServer(t, []stubSkill{{ID: "id-1", Name: "shipping-features"}}, body)
+	_, homeDir := setupSkillsEnv(t, srv.URL)
+
+	if err := runSkillsInstall(skillsInstallCmd, []string{"shipping-features"}); err != nil {
+		t.Fatalf("install: %v", err)
+	}
+
+	target := filepath.Join(homeDir, ".claude", "skills", "shipping-features", "SKILL.md")
+	got, err := os.ReadFile(target)
+	if err != nil {
+		t.Fatalf("read installed file: %v", err)
+	}
+	if string(got) != body {
+		t.Errorf("file contents = %q, want %q", string(got), body)
+	}
+
+	manifest, err := skillspkg.Load(client.ConfigDir())
+	if err != nil {
+		t.Fatalf("load manifest: %v", err)
+	}
+	entry := manifest.Find("shipping-features")
+	if entry == nil {
+		t.Fatalf("manifest missing entry for shipping-features: %+v", manifest)
+	}
+	if entry.Scope != skillspkg.ScopeGlobal {
+		t.Errorf("entry.Scope = %q, want global", entry.Scope)
+	}
+	if entry.PlatformSHA256 != skillspkg.HashContent([]byte(body)) {
+		t.Errorf("entry.PlatformSHA256 mismatch")
+	}
+	if len(entry.Files) != 1 || entry.Files[0].Path != target {
+		t.Errorf("entry.Files = %+v", entry.Files)
+	}
+}
+
+func TestInstall_NoOp_WhenAlreadyCurrent(t *testing.T) {
+	body := "# SKILL.md\nv1\n"
+	srv := newTestServer(t, []stubSkill{{ID: "id-1", Name: "alpha"}}, body)
+	setupSkillsEnv(t, srv.URL)
+
+	if err := runSkillsInstall(skillsInstallCmd, []string{"alpha"}); err != nil {
+		t.Fatalf("first install: %v", err)
+	}
+	if err := runSkillsInstall(skillsInstallCmd, []string{"alpha"}); err != nil {
+		t.Fatalf("second install (should be no-op): %v", err)
+	}
+}
+
+func TestInstall_AllInstallsEveryApprovedSkill(t *testing.T) {
+	body := "# SKILL.md\nbody\n"
+	srv := newTestServer(t, []stubSkill{
+		{ID: "id-1", Name: "alpha"},
+		{ID: "id-2", Name: "beta"},
+	}, body)
+	_, homeDir := setupSkillsEnv(t, srv.URL)
+	skillsInstallAll = true
+
+	if err := runSkillsInstall(skillsInstallCmd, nil); err != nil {
+		t.Fatalf("install --all: %v", err)
+	}
+	for _, name := range []string{"alpha", "beta"} {
+		p := filepath.Join(homeDir, ".claude", "skills", name, "SKILL.md")
+		if _, err := os.Stat(p); err != nil {
+			t.Errorf("missing %s: %v", p, err)
+		}
+	}
+}
+
+func TestUninstall_RemovesFileAndManifestEntry(t *testing.T) {
+	body := "# SKILL.md\nbody\n"
+	srv := newTestServer(t, []stubSkill{{ID: "id-1", Name: "alpha"}}, body)
+	_, homeDir := setupSkillsEnv(t, srv.URL)
+
+	if err := runSkillsInstall(skillsInstallCmd, []string{"alpha"}); err != nil {
+		t.Fatalf("install: %v", err)
+	}
+	if err := runSkillsUninstall(skillsUninstallCmd, []string{"alpha"}); err != nil {
+		t.Fatalf("uninstall: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(homeDir, ".claude", "skills", "alpha", "SKILL.md")); !os.IsNotExist(err) {
+		t.Errorf("file still present, err=%v", err)
+	}
+
+	m, _ := skillspkg.Load(client.ConfigDir())
+	if m.Find("alpha") != nil {
+		t.Errorf("manifest still has entry for alpha")
+	}
+}
+
+func TestUninstall_RefusesOnLocalEdits(t *testing.T) {
+	body := "# SKILL.md\noriginal\n"
+	srv := newTestServer(t, []stubSkill{{ID: "id-1", Name: "alpha"}}, body)
+	_, homeDir := setupSkillsEnv(t, srv.URL)
+
+	if err := runSkillsInstall(skillsInstallCmd, []string{"alpha"}); err != nil {
+		t.Fatalf("install: %v", err)
+	}
+	// Hand-edit the file
+	target := filepath.Join(homeDir, ".claude", "skills", "alpha", "SKILL.md")
+	if err := os.WriteFile(target, []byte("# I edited this\n"), 0o644); err != nil {
+		t.Fatalf("hand-edit: %v", err)
+	}
+
+	if err := runSkillsUninstall(skillsUninstallCmd, []string{"alpha"}); err != nil {
+		// runSkillsUninstall returns nil unless 1+ failed; refusal is a "skipped" path.
+		t.Fatalf("uninstall: %v", err)
+	}
+	if _, err := os.Stat(target); err != nil {
+		t.Errorf("file should still exist after refused uninstall, stat err=%v", err)
+	}
+
+	m, _ := skillspkg.Load(client.ConfigDir())
+	if m.Find("alpha") == nil {
+		t.Errorf("manifest should still have entry after refused uninstall")
+	}
+}
+
+func TestUninstall_ForceRemovesLocalEdits(t *testing.T) {
+	body := "# SKILL.md\noriginal\n"
+	srv := newTestServer(t, []stubSkill{{ID: "id-1", Name: "alpha"}}, body)
+	_, homeDir := setupSkillsEnv(t, srv.URL)
+
+	if err := runSkillsInstall(skillsInstallCmd, []string{"alpha"}); err != nil {
+		t.Fatalf("install: %v", err)
+	}
+	target := filepath.Join(homeDir, ".claude", "skills", "alpha", "SKILL.md")
+	_ = os.WriteFile(target, []byte("# edited\n"), 0o644)
+
+	skillsUninstallForce = true
+	if err := runSkillsUninstall(skillsUninstallCmd, []string{"alpha"}); err != nil {
+		t.Fatalf("uninstall --force: %v", err)
+	}
+	if _, err := os.Stat(target); !os.IsNotExist(err) {
+		t.Errorf("file should be gone, err=%v", err)
+	}
+}
+
+func TestUninstall_UntrackedSkill_DoesNothing(t *testing.T) {
+	srv := newTestServer(t, nil, "")
+	setupSkillsEnv(t, srv.URL)
+	// No install happened; manifest is empty.
+	if err := runSkillsUninstall(skillsUninstallCmd, []string{"nope"}); err != nil {
+		t.Fatalf("uninstall: %v", err)
+	}
+}
+
+func TestInstall_MutexFlags(t *testing.T) {
+	srv := newTestServer(t, nil, "")
+	setupSkillsEnv(t, srv.URL)
+	skillsInstallAll = true
+	if err := runSkillsInstall(skillsInstallCmd, []string{"name"}); err == nil {
+		t.Error("expected mutex error when --all + positional arg, got nil")
+	}
+}
+
+func TestInstall_InvalidName(t *testing.T) {
+	srv := newTestServer(t, nil, "")
+	setupSkillsEnv(t, srv.URL)
+	if err := runSkillsInstall(skillsInstallCmd, []string{"BAD NAME"}); err == nil {
+		t.Error("expected validation error, got nil")
+	}
+}
+
+func TestInstall_SkillNotOnServer(t *testing.T) {
+	srv := newTestServer(t, []stubSkill{{ID: "id-1", Name: "alpha"}}, "")
+	setupSkillsEnv(t, srv.URL)
+	err := runSkillsInstall(skillsInstallCmd, []string{"missing"})
+	if err == nil || !strings.Contains(err.Error(), "not found") {
+		t.Errorf("expected 'not found' error, got %v", err)
+	}
+}
+
+// Sanity: ensure the test server route patterns match what the client hits.
+// If this breaks, the platform shape changed and the test stubs need updates.
+func TestServerRoutes_AreReachable(t *testing.T) {
+	body := "body"
+	srv := newTestServer(t, []stubSkill{{ID: "id-1", Name: "alpha"}}, body)
+	defer srv.Close()
+
+	resp, err := http.Get(srv.URL + "/v1/skills/id-1/command")
+	if err != nil {
+		t.Fatalf("GET /command: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != 200 {
+		t.Errorf("status = %d", resp.StatusCode)
+	}
+}
+
+// Helpful failure message if ConfigDir somehow can't resolve.
+var _ = fmt.Sprintf

--- a/internal/skills/manifest.go
+++ b/internal/skills/manifest.go
@@ -1,0 +1,186 @@
+// Package skills manages locally installed PromptConduit skills.
+//
+// The manifest at ~/.config/promptconduit/skills-installed.json is the
+// source of truth for what we wrote to disk: who put the file there
+// (PromptConduit vs the user), when, and whether it's been hand-edited
+// since (sha256 comparison against the recorded value).
+//
+// Uninstall refuses to delete files whose on-disk sha doesn't match the
+// manifest entry, unless --force is passed.
+package skills
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+// ManifestVersion is the current on-disk schema version. Bump only on
+// backwards-incompatible changes; the array shape is already flexible enough
+// to absorb Phase 2 multi-file bundles without a version bump.
+const ManifestVersion = 1
+
+// ManifestFileName is the basename of the manifest file inside ConfigDir.
+const ManifestFileName = "skills-installed.json"
+
+// Scope identifies where a skill lives on disk. Stored verbatim so future
+// formats can extend without ambiguity.
+type Scope string
+
+const (
+	ScopeGlobal  Scope = "global"
+	ScopeProject Scope = "project"
+)
+
+// File describes a single file installed as part of a skill.
+type File struct {
+	// Path is the absolute path to the installed file.
+	Path string `json:"path"`
+	// SHA256 is the hex-encoded sha256 of the file contents at install time.
+	SHA256 string `json:"sha256"`
+}
+
+// Entry is one installed skill in the manifest.
+type Entry struct {
+	ID             string    `json:"id"`
+	Name           string    `json:"name"`
+	Scope          Scope     `json:"scope"`
+	InstalledAt    time.Time `json:"installed_at"`
+	PlatformSHA256 string    `json:"platform_sha256"`
+	Files          []File    `json:"files"`
+}
+
+// Manifest is the on-disk record of all PromptConduit-installed skills.
+type Manifest struct {
+	Version int     `json:"version"`
+	Skills  []Entry `json:"skills"`
+}
+
+// Path returns the manifest file path inside the given config dir.
+func Path(configDir string) string {
+	return filepath.Join(configDir, ManifestFileName)
+}
+
+// Load reads the manifest from configDir. Returns an empty manifest if the
+// file does not exist. A corrupted file returns an error — callers should
+// surface that rather than silently dropping recorded skills.
+func Load(configDir string) (*Manifest, error) {
+	path := Path(configDir)
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return &Manifest{Version: ManifestVersion}, nil
+		}
+		return nil, fmt.Errorf("read manifest %s: %w", path, err)
+	}
+	var m Manifest
+	if err := json.Unmarshal(data, &m); err != nil {
+		return nil, fmt.Errorf("parse manifest %s: %w", path, err)
+	}
+	if m.Version == 0 {
+		m.Version = ManifestVersion
+	}
+	return &m, nil
+}
+
+// Save writes the manifest atomically. The temp file is created in the same
+// directory so os.Rename is a same-filesystem atomic swap.
+func Save(configDir string, m *Manifest) error {
+	if m == nil {
+		return errors.New("nil manifest")
+	}
+	if m.Version == 0 {
+		m.Version = ManifestVersion
+	}
+
+	if err := os.MkdirAll(configDir, 0o755); err != nil {
+		return fmt.Errorf("ensure config dir: %w", err)
+	}
+
+	data, err := json.MarshalIndent(m, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal manifest: %w", err)
+	}
+
+	tmp, err := os.CreateTemp(configDir, ".skills-installed-*.json.tmp")
+	if err != nil {
+		return fmt.Errorf("create temp manifest: %w", err)
+	}
+	tmpName := tmp.Name()
+	// Best-effort cleanup if anything below fails before Rename succeeds.
+	defer func() { _ = os.Remove(tmpName) }()
+
+	if _, err := tmp.Write(data); err != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("write temp manifest: %w", err)
+	}
+	if err := tmp.Sync(); err != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("sync temp manifest: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		return fmt.Errorf("close temp manifest: %w", err)
+	}
+
+	if err := os.Rename(tmpName, Path(configDir)); err != nil {
+		return fmt.Errorf("rename manifest into place: %w", err)
+	}
+	return nil
+}
+
+// Find returns a pointer to the entry with the given name, or nil if not
+// tracked. Callers must not mutate the returned pointer's Files slice
+// without calling Add to persist; Find is intended for read-only inspection.
+func (m *Manifest) Find(name string) *Entry {
+	for i := range m.Skills {
+		if m.Skills[i].Name == name {
+			return &m.Skills[i]
+		}
+	}
+	return nil
+}
+
+// Add inserts or replaces the entry keyed by Name. Replacement matches the
+// semantics of "I just (re)installed this skill — record the new state."
+func (m *Manifest) Add(entry Entry) {
+	for i := range m.Skills {
+		if m.Skills[i].Name == entry.Name {
+			m.Skills[i] = entry
+			return
+		}
+	}
+	m.Skills = append(m.Skills, entry)
+}
+
+// Remove deletes the entry with the given name. Returns true if an entry
+// was removed, false if it wasn't tracked.
+func (m *Manifest) Remove(name string) bool {
+	for i := range m.Skills {
+		if m.Skills[i].Name == name {
+			m.Skills = append(m.Skills[:i], m.Skills[i+1:]...)
+			return true
+		}
+	}
+	return false
+}
+
+// HashContent returns the hex sha256 of data. Used at install time to
+// record what we wrote, and at uninstall time to detect hand edits.
+func HashContent(data []byte) string {
+	sum := sha256.Sum256(data)
+	return hex.EncodeToString(sum[:])
+}
+
+// HashFile returns the hex sha256 of the file at path.
+func HashFile(path string) (string, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return "", err
+	}
+	return HashContent(data), nil
+}

--- a/internal/skills/manifest_test.go
+++ b/internal/skills/manifest_test.go
@@ -1,0 +1,193 @@
+package skills
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestLoad_MissingFile_ReturnsEmptyManifest(t *testing.T) {
+	dir := t.TempDir()
+	m, err := Load(dir)
+	if err != nil {
+		t.Fatalf("Load on empty dir: %v", err)
+	}
+	if m.Version != ManifestVersion {
+		t.Errorf("Version = %d, want %d", m.Version, ManifestVersion)
+	}
+	if len(m.Skills) != 0 {
+		t.Errorf("Skills = %v, want empty", m.Skills)
+	}
+}
+
+func TestSaveLoad_RoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	now := time.Now().UTC().Truncate(time.Second)
+
+	original := &Manifest{
+		Version: ManifestVersion,
+		Skills: []Entry{
+			{
+				ID:             "uuid-1",
+				Name:           "shipping-features",
+				Scope:          ScopeGlobal,
+				InstalledAt:    now,
+				PlatformSHA256: "abc",
+				Files: []File{
+					{Path: "/home/me/.claude/skills/shipping-features/SKILL.md", SHA256: "abc"},
+				},
+			},
+		},
+	}
+
+	if err := Save(dir, original); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	loaded, err := Load(dir)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if len(loaded.Skills) != 1 {
+		t.Fatalf("len(Skills) = %d, want 1", len(loaded.Skills))
+	}
+	got := loaded.Skills[0]
+	if got.ID != "uuid-1" || got.Name != "shipping-features" || got.Scope != ScopeGlobal {
+		t.Errorf("entry mismatch: %+v", got)
+	}
+	if !got.InstalledAt.Equal(now) {
+		t.Errorf("InstalledAt = %v, want %v", got.InstalledAt, now)
+	}
+	if got.PlatformSHA256 != "abc" || len(got.Files) != 1 || got.Files[0].SHA256 != "abc" {
+		t.Errorf("hashes/files mismatch: %+v", got)
+	}
+}
+
+func TestSave_IsAtomic_NoTempLeftover(t *testing.T) {
+	dir := t.TempDir()
+	m := &Manifest{Skills: []Entry{{Name: "x"}}}
+	if err := Save(dir, m); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("ReadDir: %v", err)
+	}
+	for _, e := range entries {
+		if e.Name() != ManifestFileName {
+			t.Errorf("leftover file in config dir: %s", e.Name())
+		}
+	}
+}
+
+func TestSave_OverwritesAtomically(t *testing.T) {
+	dir := t.TempDir()
+	m := &Manifest{Skills: []Entry{{Name: "first"}}}
+	if err := Save(dir, m); err != nil {
+		t.Fatalf("Save first: %v", err)
+	}
+	m.Skills = []Entry{{Name: "second"}}
+	if err := Save(dir, m); err != nil {
+		t.Fatalf("Save second: %v", err)
+	}
+	loaded, err := Load(dir)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if len(loaded.Skills) != 1 || loaded.Skills[0].Name != "second" {
+		t.Errorf("Skills = %+v, want [{second}]", loaded.Skills)
+	}
+}
+
+func TestFind_HitAndMiss(t *testing.T) {
+	m := &Manifest{
+		Skills: []Entry{
+			{Name: "alpha"}, {Name: "beta"},
+		},
+	}
+	if got := m.Find("alpha"); got == nil || got.Name != "alpha" {
+		t.Errorf("Find(alpha) = %+v, want entry", got)
+	}
+	if got := m.Find("missing"); got != nil {
+		t.Errorf("Find(missing) = %+v, want nil", got)
+	}
+}
+
+func TestAdd_InsertsThenReplaces(t *testing.T) {
+	m := &Manifest{}
+	m.Add(Entry{Name: "x", PlatformSHA256: "v1"})
+	m.Add(Entry{Name: "y", PlatformSHA256: "v1"})
+	m.Add(Entry{Name: "x", PlatformSHA256: "v2"})
+	if len(m.Skills) != 2 {
+		t.Fatalf("len = %d, want 2 (replace, not duplicate)", len(m.Skills))
+	}
+	got := m.Find("x")
+	if got == nil || got.PlatformSHA256 != "v2" {
+		t.Errorf("expected x at v2, got %+v", got)
+	}
+}
+
+func TestRemove_PresentAndAbsent(t *testing.T) {
+	m := &Manifest{
+		Skills: []Entry{{Name: "a"}, {Name: "b"}, {Name: "c"}},
+	}
+	if !m.Remove("b") {
+		t.Error("Remove(b) = false, want true")
+	}
+	if len(m.Skills) != 2 || m.Find("b") != nil {
+		t.Errorf("after Remove(b): %+v", m.Skills)
+	}
+	if m.Remove("missing") {
+		t.Error("Remove(missing) = true, want false")
+	}
+}
+
+func TestLoad_CorruptFile_Errors(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(Path(dir), []byte("not json"), 0o644); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	if _, err := Load(dir); err == nil {
+		t.Error("Load on corrupt file: want error, got nil")
+	}
+}
+
+func TestLoad_VersionZero_DefaultsToCurrent(t *testing.T) {
+	dir := t.TempDir()
+	raw, _ := json.Marshal(map[string]any{"skills": []any{}})
+	if err := os.WriteFile(Path(dir), raw, 0o644); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	m, err := Load(dir)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if m.Version != ManifestVersion {
+		t.Errorf("Version = %d, want %d", m.Version, ManifestVersion)
+	}
+}
+
+func TestHashContent_Stable(t *testing.T) {
+	want := "c3ab8ff13720e8ad9047dd39466b3c8974e592c2fa383d4a3960714caef0c4f2"
+	if got := HashContent([]byte("foobar")); got != want {
+		t.Errorf("HashContent(foobar) = %q, want %q", got, want)
+	}
+}
+
+func TestHashFile_RoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "f")
+	body := []byte("hello world")
+	if err := os.WriteFile(path, body, 0o644); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	got, err := HashFile(path)
+	if err != nil {
+		t.Fatalf("HashFile: %v", err)
+	}
+	if got != HashContent(body) {
+		t.Errorf("HashFile != HashContent for same bytes")
+	}
+}

--- a/internal/skills/paths.go
+++ b/internal/skills/paths.go
@@ -1,0 +1,103 @@
+package skills
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+)
+
+// nameRule matches Anthropic's SKILL.md name validation: lowercase letters,
+// digits, hyphens, 1–64 chars. Anything else gets rejected before we touch
+// the filesystem.
+var nameRule = regexp.MustCompile(`^[a-z0-9-]{1,64}$`)
+
+// ValidateName returns an error if name doesn't conform to the Anthropic
+// skill-name rule. Caller is expected to short-circuit before any I/O.
+func ValidateName(name string) error {
+	if name == "" {
+		return fmt.Errorf("skill name is empty")
+	}
+	if !nameRule.MatchString(name) {
+		return fmt.Errorf("skill name %q must match %s", name, nameRule.String())
+	}
+	return nil
+}
+
+// ResolveScope decides whether a skill should land in the project tree or
+// the user's home. Rules, applied in order:
+//
+//  1. If flag is "project" or "global", honor it.
+//  2. If repoName is set AND cwd is inside a git repo, use project.
+//  3. Otherwise, global.
+//
+// Returns the chosen scope and the base dir for that scope (the parent of
+// the skill bundle directory).
+func ResolveScope(repoName, flag, cwd string) (Scope, string, error) {
+	switch flag {
+	case string(ScopeProject):
+		gitRoot := DetectGitRoot(cwd)
+		if gitRoot == "" {
+			return "", "", fmt.Errorf("--scope=project but %s is not inside a git repo", cwd)
+		}
+		return ScopeProject, filepath.Join(gitRoot, ".claude", "skills"), nil
+	case string(ScopeGlobal):
+		base, err := globalBase()
+		if err != nil {
+			return "", "", err
+		}
+		return ScopeGlobal, base, nil
+	case "":
+		// Auto: prefer project if we're in a repo AND the skill is bound to
+		// one; otherwise global.
+		if repoName != "" {
+			if gitRoot := DetectGitRoot(cwd); gitRoot != "" {
+				return ScopeProject, filepath.Join(gitRoot, ".claude", "skills"), nil
+			}
+		}
+		base, err := globalBase()
+		if err != nil {
+			return "", "", err
+		}
+		return ScopeGlobal, base, nil
+	default:
+		return "", "", fmt.Errorf("invalid --scope %q (want project|global)", flag)
+	}
+}
+
+// SkillDir returns the directory for a named skill under the given base.
+// Layout: <base>/<name>/
+func SkillDir(base, name string) string {
+	return filepath.Join(base, name)
+}
+
+// SkillFile returns the canonical SKILL.md path for a named skill.
+func SkillFile(base, name string) string {
+	return filepath.Join(SkillDir(base, name), "SKILL.md")
+}
+
+// DetectGitRoot walks up from dir looking for a .git entry. Returns "" if
+// none found (e.g. caller is outside any repo).
+func DetectGitRoot(dir string) string {
+	if dir == "" {
+		return ""
+	}
+	for {
+		if _, err := os.Stat(filepath.Join(dir, ".git")); err == nil {
+			return dir
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			return ""
+		}
+		dir = parent
+	}
+}
+
+func globalBase() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("locate home directory: %w", err)
+	}
+	return filepath.Join(home, ".claude", "skills"), nil
+}

--- a/internal/skills/paths_test.go
+++ b/internal/skills/paths_test.go
@@ -1,0 +1,151 @@
+package skills
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestValidateName(t *testing.T) {
+	cases := []struct {
+		name    string
+		wantErr bool
+	}{
+		{"shipping-features", false},
+		{"a", false},
+		{"x9", false},
+		{strings.Repeat("a", 64), false},
+		{"", true},
+		{strings.Repeat("a", 65), true},
+		{"Shipping", true},
+		{"my_skill", true},
+		{"my.skill", true},
+		{"my skill", true},
+		{"my/skill", true},
+		{"../escape", true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := ValidateName(tc.name)
+			if tc.wantErr && err == nil {
+				t.Errorf("ValidateName(%q): want error, got nil", tc.name)
+			}
+			if !tc.wantErr && err != nil {
+				t.Errorf("ValidateName(%q): %v", tc.name, err)
+			}
+		})
+	}
+}
+
+func TestSkillPaths(t *testing.T) {
+	base := "/tmp/x"
+	if got := SkillDir(base, "foo"); got != "/tmp/x/foo" {
+		t.Errorf("SkillDir = %q", got)
+	}
+	if got := SkillFile(base, "foo"); got != "/tmp/x/foo/SKILL.md" {
+		t.Errorf("SkillFile = %q", got)
+	}
+}
+
+// makeGitRepo creates a directory with a .git marker so DetectGitRoot
+// returns it. We don't need a real repo.
+func makeGitRepo(t *testing.T) string {
+	t.Helper()
+	root := t.TempDir()
+	if err := os.Mkdir(filepath.Join(root, ".git"), 0o755); err != nil {
+		t.Fatalf("seed .git: %v", err)
+	}
+	return root
+}
+
+func TestDetectGitRoot(t *testing.T) {
+	root := makeGitRepo(t)
+	deep := filepath.Join(root, "a", "b", "c")
+	if err := os.MkdirAll(deep, 0o755); err != nil {
+		t.Fatalf("mkdir deep: %v", err)
+	}
+
+	if got := DetectGitRoot(deep); got != root {
+		t.Errorf("DetectGitRoot(deep) = %q, want %q", got, root)
+	}
+	if got := DetectGitRoot(root); got != root {
+		t.Errorf("DetectGitRoot(root) = %q, want %q", got, root)
+	}
+
+	// Outside any repo (using TempDir which has no .git ancestor) should
+	// eventually return "" — we can't easily test that without walking to
+	// the real filesystem root, but an empty input is a fast no.
+	if got := DetectGitRoot(""); got != "" {
+		t.Errorf("DetectGitRoot(\"\") = %q, want empty", got)
+	}
+}
+
+func TestResolveScope_ExplicitProject(t *testing.T) {
+	root := makeGitRepo(t)
+	scope, base, err := ResolveScope("any-repo", "project", root)
+	if err != nil {
+		t.Fatalf("ResolveScope: %v", err)
+	}
+	if scope != ScopeProject {
+		t.Errorf("scope = %q, want project", scope)
+	}
+	want := filepath.Join(root, ".claude", "skills")
+	if base != want {
+		t.Errorf("base = %q, want %q", base, want)
+	}
+}
+
+func TestResolveScope_ExplicitProject_NotInRepo(t *testing.T) {
+	dir := t.TempDir() // no .git
+	_, _, err := ResolveScope("any-repo", "project", dir)
+	if err == nil {
+		t.Error("expected error when --scope=project outside a repo, got nil")
+	}
+}
+
+func TestResolveScope_ExplicitGlobal(t *testing.T) {
+	scope, base, err := ResolveScope("any-repo", "global", "/anywhere")
+	if err != nil {
+		t.Fatalf("ResolveScope: %v", err)
+	}
+	if scope != ScopeGlobal {
+		t.Errorf("scope = %q, want global", scope)
+	}
+	if !strings.HasSuffix(base, filepath.Join(".claude", "skills")) {
+		t.Errorf("base %q should end in .claude/skills", base)
+	}
+}
+
+func TestResolveScope_Auto_RepoBoundInsideGit(t *testing.T) {
+	root := makeGitRepo(t)
+	scope, base, err := ResolveScope("some-repo", "", root)
+	if err != nil {
+		t.Fatalf("ResolveScope: %v", err)
+	}
+	if scope != ScopeProject {
+		t.Errorf("scope = %q, want project (auto)", scope)
+	}
+	if base != filepath.Join(root, ".claude", "skills") {
+		t.Errorf("base = %q", base)
+	}
+}
+
+func TestResolveScope_Auto_GlobalSkillFallback(t *testing.T) {
+	// Global-scoped skill (repoName empty) inside a repo → still global.
+	root := makeGitRepo(t)
+	scope, _, err := ResolveScope("", "", root)
+	if err != nil {
+		t.Fatalf("ResolveScope: %v", err)
+	}
+	if scope != ScopeGlobal {
+		t.Errorf("scope = %q, want global", scope)
+	}
+}
+
+func TestResolveScope_InvalidFlag(t *testing.T) {
+	_, _, err := ResolveScope("any", "user", "/tmp")
+	if err == nil {
+		t.Error("expected error for invalid --scope value")
+	}
+}


### PR DESCRIPTION
## Summary

Four new subcommands and a new `--filter` flag bring `promptconduit skills` to parity with the web UI's per-skill controls. Targets the **skill-bundle** path (`.claude/skills/<name>/SKILL.md`) which auto-loads via the Skill tool on trigger phrases — distinct from the slash-command path that bulk `sync` writes.

```
promptconduit skills install <name> [--scope project|global] [--force]
promptconduit skills install --all
promptconduit skills uninstall <name> [--force]
promptconduit skills uninstall --all
promptconduit skills approve <name>
promptconduit skills reject  <name>
promptconduit skills list --filter new|ready|removed|all
```

Backed by:
- New `internal/skills` package (Manifest, ResolveScope, ValidateName) — atomic file writes (CreateTemp + Rename), single source of truth at `~/.config/promptconduit/skills-installed.json`.
- Re-uses existing `client.GetSkills` / `client.ApproveSkill` / `client.GetSkillCommandFile` — no API client surface change.
- 11 cmd-level integration tests + 18 unit tests across the new package. 100% green.

## Why a separate skill-bundle path

The web UI explicitly says "Save each download to `.claude/skills/<name>/SKILL.md`" and the API returns `X-Skill-Suggested-Path` matching that. Existing `sync` writes the slash-command form at `.claude/commands/<name>.md`. Both are valid Claude Code features but address different UX (auto-trigger vs typed `/foo`). This PR adds the bundle form without changing `sync`.

## Behavior contract

| Scenario | Outcome |
|---|---|
| `install foo` when not on server | exit 1, `not found` |
| `install foo` fresh | atomic write + manifest entry |
| `install foo` at same sha | no-op, prints `already up to date` |
| `install foo` after hand-edit, no --force | prompts (or skips on non-TTY) |
| `install foo --force` over edits | overwrites |
| `install --all` | iterates approved set; per-file atomic |
| `uninstall foo` clean | rm file + cleanup empty parent + manifest remove |
| `uninstall foo` after hand-edit, no --force | refuses, prints `local modifications` |
| `uninstall foo --force` | always removes |
| `uninstall foo`, not in manifest | refuses, prints `not tracked` |
| `uninstall --all` | iterates manifest only; safety rules per file |
| `list --filter ready/removed/new/all` | mirrors web tabs (new=is_approved null) |

## Out of scope (deferred)

- Multi-file bundles (`reference/*.md`, `scripts/*`) — needs platform changes to bundle generation + R2 storage. Manifest array shape is forward-compatible.
- SessionStart hook for inline suggestions — Phase 3.
- Update-detection ("the skill you have is out of date on the server") — Phase 4.

## Test plan

- [x] `make test` — all packages green (29 new tests)
- [x] `make lint` — no new issues introduced by this PR
- [x] `make build` — clean
- [x] Smoke against prod: `approve` → `install` → file landed at correct path with manifest entry → `uninstall` → file gone, manifest cleared → `reject` to revert state

After merge: tag v0.3.5 (patch bump, additive). GoReleaser + homebrew-tap will auto-update.