### PR TITLE
fix(skills): UUID resolution, ambiguity errors, delete command, short IDs

### DIFF
--- a/cmd/skills.go
+++ b/cmd/skills.go
@@ -133,6 +133,8 @@ func init() {
 	skillsUninstallCmd.Flags().BoolVar(&skillsUninstallAll, "all", false, "Uninstall every promptconduit-installed skill")
 	skillsUninstallCmd.Flags().BoolVar(&skillsUninstallForce, "force", false, "Remove even if the file has been hand-edited")
 
+	skillsDeleteCmd.Flags().BoolVar(&skillsDeleteYes, "yes", false, "Skip the confirmation prompt (required for non-interactive use)")
+
 	skillsCmd.AddCommand(skillsListCmd)
 	skillsCmd.AddCommand(skillsGenerateCmd)
 	skillsCmd.AddCommand(skillsSyncCmd)
@@ -141,6 +143,7 @@ func init() {
 	skillsCmd.AddCommand(skillsUninstallCmd)
 	skillsCmd.AddCommand(skillsApproveCmd)
 	skillsCmd.AddCommand(skillsRejectCmd)
+	skillsCmd.AddCommand(skillsDeleteCmd)
 }
 
 // ============================================================================
@@ -459,6 +462,7 @@ func outputSkillsList(data map[string]interface{}) error {
 			continue
 		}
 
+		id, _ := skill["id"].(string)
 		name, _ := skill["name"].(string)
 		displayName, _ := skill["display_name"].(string)
 		description, _ := skill["description"].(string)
@@ -474,12 +478,18 @@ func outputSkillsList(data map[string]interface{}) error {
 			status = "[rejected]"
 		}
 
-		fmt.Printf("/%s  %s  %s  %.0f%%\n", name, skillType, status, confidence*100)
+		// Show short ID (first 8 chars) so users can disambiguate when
+		// multiple skills share a name. Full UUID is in --format json.
+		shortID := id
+		if len(shortID) > 8 {
+			shortID = shortID[:8]
+		}
+		fmt.Printf("%-8s  /%s  %s  %s  %.0f%%\n", shortID, name, skillType, status, confidence*100)
 		if displayName != "" && displayName != name {
-			fmt.Printf("  %s\n", displayName)
+			fmt.Printf("          %s\n", displayName)
 		}
 		if description != "" {
-			fmt.Printf("  %s\n", description)
+			fmt.Printf("          %s\n", description)
 		}
 		fmt.Println()
 	}

--- a/cmd/skills_install.go
+++ b/cmd/skills_install.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"time"
 
@@ -16,13 +17,14 @@ import (
 )
 
 // Flags. Reused state variables would collide with cmd/skills.go, so these
-// are install/uninstall-specific.
+// are install/uninstall/delete-specific.
 var (
-	skillsInstallAll       bool
-	skillsInstallScope     string
-	skillsInstallForce     bool
-	skillsUninstallAll     bool
-	skillsUninstallForce   bool
+	skillsInstallAll     bool
+	skillsInstallScope   string
+	skillsInstallForce   bool
+	skillsUninstallAll   bool
+	skillsUninstallForce bool
+	skillsDeleteYes      bool
 )
 
 // Exit codes the commands can return through cobra. We surface them via
@@ -34,15 +36,20 @@ var (
 // ============================================================================
 
 var skillsInstallCmd = &cobra.Command{
-	Use:   "install [name]",
+	Use:   "install [name|uuid]",
 	Short: "Install a skill into .claude/skills/<name>/SKILL.md",
 	Long: `Download a skill from the platform and write it to the Claude Code
 skills directory. Tracks the install in a local manifest so it can be
 safely uninstalled later.
 
+The argument is matched as a UUID first, falling back to skill name. If
+multiple skills share the same name (common after re-running 'generate'),
+the command errors with each candidate's UUID so you can disambiguate.
+
 Examples:
   promptconduit skills install shipping-features
   promptconduit skills install shipping-features --scope project
+  promptconduit skills install cc9f1eff-487c-4ff6-b542-5814ba815d45
   promptconduit skills install --all
   promptconduit skills install shipping-features --force   # overwrite local edits`,
 	RunE: runSkillsInstall,
@@ -73,7 +80,7 @@ Examples:
 // ============================================================================
 
 var skillsApproveCmd = &cobra.Command{
-	Use:   "approve [name]",
+	Use:   "approve [name|uuid]",
 	Short: "Mark a skill as approved on the platform (the Ready tab)",
 	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
@@ -82,12 +89,71 @@ var skillsApproveCmd = &cobra.Command{
 }
 
 var skillsRejectCmd = &cobra.Command{
-	Use:   "reject [name]",
+	Use:   "reject [name|uuid]",
 	Short: "Mark a skill as rejected on the platform (the Removed tab)",
 	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		return runApproveOrReject(args[0], false)
 	},
+}
+
+// ============================================================================
+// delete  (soft-delete via DELETE /v1/skills/:id)
+// ============================================================================
+
+var skillsDeleteCmd = &cobra.Command{
+	Use:   "delete [name|uuid]",
+	Short: "Soft-delete a skill on the platform (hidden from listings)",
+	Long: `Soft-delete a skill so it no longer appears in skill listings.
+
+The row stays in the platform DB for audit; deletion is reversible by
+the platform team if needed. Use this to clean up duplicates created by
+re-running 'skills generate', or to permanently remove a skill you've
+already rejected.
+
+Refuses unless you confirm at the prompt or pass --yes. On non-TTY
+(scripts, CI) --yes is required.
+
+Examples:
+  promptconduit skills delete git-feature-workflow
+  promptconduit skills delete 15686eb6-52d5-443e-9d0e-86e4b3e9cc53 --yes`,
+	Args: cobra.ExactArgs(1),
+	RunE: runSkillsDelete,
+}
+
+func runSkillsDelete(cmd *cobra.Command, args []string) error {
+	cfg := client.LoadConfig()
+	if !cfg.IsConfigured() {
+		return errors.New(`API key not configured. Run: promptconduit config set --api-key="your-key"`)
+	}
+	apiClient := client.NewClient(cfg, Version)
+
+	skill, err := resolveSkill(apiClient, args[0])
+	if err != nil {
+		return err
+	}
+	id, _ := skill["id"].(string)
+	name, _ := skill["name"].(string)
+	if id == "" {
+		return fmt.Errorf("skill %q has no id", args[0])
+	}
+
+	if !skillsDeleteYes {
+		if !stdinIsTerminal() {
+			return fmt.Errorf("refusing to delete %s without --yes (non-interactive stdin)", name)
+		}
+		if !confirm(fmt.Sprintf("Soft-delete skill %s (%s)?", name, id)) {
+			cmd.Println("Aborted.")
+			return nil
+		}
+	}
+
+	resp := apiClient.DeleteSkill(id)
+	if !resp.Success {
+		return fmt.Errorf("delete %s: %s", name, resp.Error)
+	}
+	cmd.Printf("Deleted %s (%s)\n", name, id)
+	return nil
 }
 
 // ============================================================================
@@ -133,11 +199,10 @@ func runSkillsInstall(cmd *cobra.Command, args []string) error {
 			return nil
 		}
 	} else {
-		name := args[0]
-		if err := skillspkg.ValidateName(name); err != nil {
-			return err
-		}
-		skill, err := findSkillByName(apiClient, name)
+		// args[0] may be a skill name or a UUID. resolveSkill auto-detects
+		// and errors loudly on ambiguous names. The resolved skill's name
+		// is re-validated by installOne before any filesystem operation.
+		skill, err := resolveSkill(apiClient, args[0])
 		if err != nil {
 			return err
 		}
@@ -330,19 +395,19 @@ func uninstallOne(cmd *cobra.Command, manifest *skillspkg.Manifest, name string)
 	return nil
 }
 
-func runApproveOrReject(name string, approve bool) error {
+func runApproveOrReject(identifier string, approve bool) error {
 	cfg := client.LoadConfig()
 	if !cfg.IsConfigured() {
 		return errors.New(`API key not configured. Run: promptconduit config set --api-key="your-key"`)
 	}
 	apiClient := client.NewClient(cfg, Version)
-	skill, err := findSkillByName(apiClient, name)
+	skill, err := resolveSkill(apiClient, identifier)
 	if err != nil {
 		return err
 	}
 	id, _ := skill["id"].(string)
 	if id == "" {
-		return fmt.Errorf("skill %q has no id", name)
+		return fmt.Errorf("skill %q has no id", identifier)
 	}
 	resp := apiClient.ApproveSkill(id, approve)
 	if !resp.Success {
@@ -350,13 +415,19 @@ func runApproveOrReject(name string, approve bool) error {
 		if !approve {
 			verb = "reject"
 		}
-		return fmt.Errorf("%s %s: %s", verb, name, resp.Error)
+		return fmt.Errorf("%s %s: %s", verb, identifier, resp.Error)
 	}
 	verb := "approved"
 	if !approve {
 		verb = "rejected"
 	}
-	fmt.Printf("%s %s\n", verb, name)
+	// Show the resolved name in the success line, which is friendlier than
+	// echoing a UUID back at the user when they passed one.
+	resolvedName, _ := skill["name"].(string)
+	if resolvedName == "" {
+		resolvedName = identifier
+	}
+	fmt.Printf("%s %s\n", verb, resolvedName)
 	return nil
 }
 
@@ -364,25 +435,93 @@ func runApproveOrReject(name string, approve bool) error {
 // helpers
 // ============================================================================
 
-// findSkillByName lists up to 100 skills (any approval state) and returns
-// the first one whose name matches. Returns a structured error when not
-// found. Used by install + approve + reject.
-func findSkillByName(c *client.Client, name string) (map[string]interface{}, error) {
+// uuidRule matches the canonical 8-4-4-4-12 hex UUID form. Looser checks
+// (e.g. just "is it 36 chars with 4 dashes") would catch typos but also
+// accept garbage; we deliberately require well-formed UUIDs so a typo on
+// a skill name doesn't get silently routed through the ID path.
+var uuidRule = regexp.MustCompile(`^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$`)
+
+// resolveSkill turns a user-provided identifier (UUID or skill name)
+// into a single skill record from the platform. Ambiguous names produce
+// a structured error listing all candidate IDs so the caller can re-run
+// with a UUID.
+//
+// Cheap to call (one HTTP round trip in either branch): GET /v1/skills/:id
+// for UUIDs, GET /v1/skills?limit=100 + client-side filter for names.
+func resolveSkill(c *client.Client, identifier string) (map[string]interface{}, error) {
+	identifier = strings.TrimSpace(identifier)
+	if identifier == "" {
+		return nil, errors.New("empty skill identifier")
+	}
+
+	if uuidRule.MatchString(strings.ToLower(identifier)) {
+		resp := c.GetSkill(identifier)
+		if !resp.Success {
+			if resp.StatusCode == 404 {
+				return nil, fmt.Errorf("skill id %s not found on the platform", identifier)
+			}
+			return nil, fmt.Errorf("fetch skill %s: %s", identifier, resp.Error)
+		}
+		// /v1/skills/:id may wrap the row under "skill" or return it
+		// directly — accept either shape.
+		if inner, ok := resp.Data["skill"].(map[string]interface{}); ok {
+			return inner, nil
+		}
+		return resp.Data, nil
+	}
+
 	resp := c.GetSkills("", "", 100, "")
 	if !resp.Success {
 		return nil, fmt.Errorf("list skills: %s", resp.Error)
 	}
 	list, _ := resp.Data["skills"].([]interface{})
+	var matches []map[string]interface{}
 	for _, s := range list {
 		m, ok := s.(map[string]interface{})
 		if !ok {
 			continue
 		}
-		if n, _ := m["name"].(string); n == name {
-			return m, nil
+		if n, _ := m["name"].(string); n == identifier {
+			matches = append(matches, m)
 		}
 	}
-	return nil, fmt.Errorf("skill %q not found on the platform", name)
+
+	switch len(matches) {
+	case 0:
+		return nil, fmt.Errorf("skill %q not found on the platform", identifier)
+	case 1:
+		return matches[0], nil
+	default:
+		return nil, ambiguityError(identifier, matches)
+	}
+}
+
+// ambiguityError formats a multi-match name lookup into actionable text:
+// the user gets each candidate's UUID + a hint about repo scope and
+// approval state so they can re-run with the right ID.
+func ambiguityError(name string, matches []map[string]interface{}) error {
+	var b strings.Builder
+	fmt.Fprintf(&b, "%d skills named %q exist — re-run with the UUID instead of the name:\n", len(matches), name)
+	for _, m := range matches {
+		id, _ := m["id"].(string)
+		repo, _ := m["repo_name"].(string)
+		conf, _ := m["confidence"].(float64)
+		scope := "global"
+		if repo != "" {
+			scope = "repo=" + repo
+		}
+		approved := "new"
+		switch v := m["is_approved"].(type) {
+		case bool:
+			if v {
+				approved = "ready"
+			} else {
+				approved = "removed"
+			}
+		}
+		fmt.Fprintf(&b, "  %s  %s  conf=%.0f%%  %s\n", id, scope, conf*100, approved)
+	}
+	return errors.New(strings.TrimRight(b.String(), "\n"))
 }
 
 // writeAtomic writes data to path via tempfile + rename in the same dir.
@@ -463,8 +602,9 @@ func confirm(prompt string) bool {
 
 // stdinIsTerminal reports whether stdin is a character device (e.g. a tty).
 // Stdlib-only check that avoids dragging in golang.org/x/term and its
-// Go-toolchain floor.
-func stdinIsTerminal() bool {
+// Go-toolchain floor. Declared as a var so tests can override the result
+// without trying to fake a real terminal handle.
+var stdinIsTerminal = func() bool {
 	fi, err := os.Stdin.Stat()
 	if err != nil {
 		return false

--- a/cmd/skills_install_test.go
+++ b/cmd/skills_install_test.go
@@ -21,10 +21,11 @@ type stubSkill struct {
 	RepoName string `json:"repo_name,omitempty"`
 }
 
-// newTestServer returns an httptest.Server that responds to the two
-// endpoints install/uninstall hit: GET /v1/skills and GET /v1/skills/:id/command.
-// `command` is the SKILL.md body returned for the latter.
-func newTestServer(t *testing.T, skills []stubSkill, command string) *httptest.Server {
+// newTestServer returns an httptest.Server that responds to the endpoints
+// install/uninstall/approve/reject/delete hit. `command` is the SKILL.md
+// body returned for GET /v1/skills/:id/command. `deleted` is mutated by
+// DELETE handlers so tests can assert the call was made.
+func newTestServer(t *testing.T, skills []stubSkill, command string, deleted *map[string]bool) *httptest.Server {
 	t.Helper()
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch {
@@ -38,6 +39,30 @@ func newTestServer(t *testing.T, skills []stubSkill, command string) *httptest.S
 		case strings.HasPrefix(r.URL.Path, "/v1/skills/") && strings.HasSuffix(r.URL.Path, "/command"):
 			w.Header().Set("Content-Type", "text/markdown")
 			_, _ = w.Write([]byte(command))
+		case strings.HasPrefix(r.URL.Path, "/v1/skills/") && r.Method == http.MethodGet:
+			id := strings.TrimPrefix(r.URL.Path, "/v1/skills/")
+			for _, s := range skills {
+				if s.ID == id {
+					_ = json.NewEncoder(w).Encode(map[string]interface{}{
+						"id":          s.ID,
+						"name":        s.Name,
+						"repo_name":   s.RepoName,
+						"is_approved": true,
+					})
+					return
+				}
+			}
+			http.NotFound(w, r)
+		case strings.HasPrefix(r.URL.Path, "/v1/skills/") && r.Method == http.MethodDelete:
+			id := strings.TrimPrefix(r.URL.Path, "/v1/skills/")
+			if deleted != nil {
+				(*deleted)[id] = true
+			}
+			w.WriteHeader(http.StatusNoContent)
+		case strings.HasPrefix(r.URL.Path, "/v1/skills/") && r.Method == http.MethodPatch:
+			// approve/reject — accept and echo back is_approved
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{"ok": true})
 		default:
 			http.NotFound(w, r)
 		}
@@ -84,6 +109,7 @@ func setupSkillsEnv(t *testing.T, apiURL string) (configDir, homeDir string) {
 	skillsInstallForce = false
 	skillsUninstallAll = false
 	skillsUninstallForce = false
+	skillsDeleteYes = false
 
 	// The promptconduit config dir is derived from XDG_CONFIG_HOME/promptconduit.
 	// Confirm with the real helper so the test assertions match production.
@@ -95,7 +121,7 @@ func setupSkillsEnv(t *testing.T, apiURL string) (configDir, homeDir string) {
 
 func TestInstall_WritesFile_AndRecordsManifest(t *testing.T) {
 	body := "# SKILL.md\nfoo\n"
-	srv := newTestServer(t, []stubSkill{{ID: "id-1", Name: "shipping-features"}}, body)
+	srv := newTestServer(t, []stubSkill{{ID: "id-1", Name: "shipping-features"}}, body, nil)
 	_, homeDir := setupSkillsEnv(t, srv.URL)
 
 	if err := runSkillsInstall(skillsInstallCmd, []string{"shipping-features"}); err != nil {
@@ -132,7 +158,7 @@ func TestInstall_WritesFile_AndRecordsManifest(t *testing.T) {
 
 func TestInstall_NoOp_WhenAlreadyCurrent(t *testing.T) {
 	body := "# SKILL.md\nv1\n"
-	srv := newTestServer(t, []stubSkill{{ID: "id-1", Name: "alpha"}}, body)
+	srv := newTestServer(t, []stubSkill{{ID: "id-1", Name: "alpha"}}, body, nil)
 	setupSkillsEnv(t, srv.URL)
 
 	if err := runSkillsInstall(skillsInstallCmd, []string{"alpha"}); err != nil {
@@ -148,7 +174,7 @@ func TestInstall_AllInstallsEveryApprovedSkill(t *testing.T) {
 	srv := newTestServer(t, []stubSkill{
 		{ID: "id-1", Name: "alpha"},
 		{ID: "id-2", Name: "beta"},
-	}, body)
+	}, body, nil)
 	_, homeDir := setupSkillsEnv(t, srv.URL)
 	skillsInstallAll = true
 
@@ -165,7 +191,7 @@ func TestInstall_AllInstallsEveryApprovedSkill(t *testing.T) {
 
 func TestUninstall_RemovesFileAndManifestEntry(t *testing.T) {
 	body := "# SKILL.md\nbody\n"
-	srv := newTestServer(t, []stubSkill{{ID: "id-1", Name: "alpha"}}, body)
+	srv := newTestServer(t, []stubSkill{{ID: "id-1", Name: "alpha"}}, body, nil)
 	_, homeDir := setupSkillsEnv(t, srv.URL)
 
 	if err := runSkillsInstall(skillsInstallCmd, []string{"alpha"}); err != nil {
@@ -186,7 +212,7 @@ func TestUninstall_RemovesFileAndManifestEntry(t *testing.T) {
 
 func TestUninstall_RefusesOnLocalEdits(t *testing.T) {
 	body := "# SKILL.md\noriginal\n"
-	srv := newTestServer(t, []stubSkill{{ID: "id-1", Name: "alpha"}}, body)
+	srv := newTestServer(t, []stubSkill{{ID: "id-1", Name: "alpha"}}, body, nil)
 	_, homeDir := setupSkillsEnv(t, srv.URL)
 
 	if err := runSkillsInstall(skillsInstallCmd, []string{"alpha"}); err != nil {
@@ -214,7 +240,7 @@ func TestUninstall_RefusesOnLocalEdits(t *testing.T) {
 
 func TestUninstall_ForceRemovesLocalEdits(t *testing.T) {
 	body := "# SKILL.md\noriginal\n"
-	srv := newTestServer(t, []stubSkill{{ID: "id-1", Name: "alpha"}}, body)
+	srv := newTestServer(t, []stubSkill{{ID: "id-1", Name: "alpha"}}, body, nil)
 	_, homeDir := setupSkillsEnv(t, srv.URL)
 
 	if err := runSkillsInstall(skillsInstallCmd, []string{"alpha"}); err != nil {
@@ -233,7 +259,7 @@ func TestUninstall_ForceRemovesLocalEdits(t *testing.T) {
 }
 
 func TestUninstall_UntrackedSkill_DoesNothing(t *testing.T) {
-	srv := newTestServer(t, nil, "")
+	srv := newTestServer(t, nil, "", nil)
 	setupSkillsEnv(t, srv.URL)
 	// No install happened; manifest is empty.
 	if err := runSkillsUninstall(skillsUninstallCmd, []string{"nope"}); err != nil {
@@ -242,7 +268,7 @@ func TestUninstall_UntrackedSkill_DoesNothing(t *testing.T) {
 }
 
 func TestInstall_MutexFlags(t *testing.T) {
-	srv := newTestServer(t, nil, "")
+	srv := newTestServer(t, nil, "", nil)
 	setupSkillsEnv(t, srv.URL)
 	skillsInstallAll = true
 	if err := runSkillsInstall(skillsInstallCmd, []string{"name"}); err == nil {
@@ -251,7 +277,7 @@ func TestInstall_MutexFlags(t *testing.T) {
 }
 
 func TestInstall_InvalidName(t *testing.T) {
-	srv := newTestServer(t, nil, "")
+	srv := newTestServer(t, nil, "", nil)
 	setupSkillsEnv(t, srv.URL)
 	if err := runSkillsInstall(skillsInstallCmd, []string{"BAD NAME"}); err == nil {
 		t.Error("expected validation error, got nil")
@@ -259,7 +285,7 @@ func TestInstall_InvalidName(t *testing.T) {
 }
 
 func TestInstall_SkillNotOnServer(t *testing.T) {
-	srv := newTestServer(t, []stubSkill{{ID: "id-1", Name: "alpha"}}, "")
+	srv := newTestServer(t, []stubSkill{{ID: "id-1", Name: "alpha"}}, "", nil)
 	setupSkillsEnv(t, srv.URL)
 	err := runSkillsInstall(skillsInstallCmd, []string{"missing"})
 	if err == nil || !strings.Contains(err.Error(), "not found") {
@@ -271,7 +297,7 @@ func TestInstall_SkillNotOnServer(t *testing.T) {
 // If this breaks, the platform shape changed and the test stubs need updates.
 func TestServerRoutes_AreReachable(t *testing.T) {
 	body := "body"
-	srv := newTestServer(t, []stubSkill{{ID: "id-1", Name: "alpha"}}, body)
+	srv := newTestServer(t, []stubSkill{{ID: "id-1", Name: "alpha"}}, body, nil)
 	defer srv.Close()
 
 	resp, err := http.Get(srv.URL + "/v1/skills/id-1/command")
@@ -286,3 +312,174 @@ func TestServerRoutes_AreReachable(t *testing.T) {
 
 // Helpful failure message if ConfigDir somehow can't resolve.
 var _ = fmt.Sprintf
+
+// ============================================================================
+// resolveSkill — UUID vs name dispatch + ambiguity handling
+// ============================================================================
+
+const validUUID = "cc9f1eff-487c-4ff6-b542-5814ba815d45"
+
+func TestResolveSkill_ByName_SingleMatch(t *testing.T) {
+	srv := newTestServer(t, []stubSkill{{ID: "id-1", Name: "alpha"}}, "body", nil)
+	setupSkillsEnv(t, srv.URL)
+	cli := client.NewClient(client.LoadConfig(), Version)
+	got, err := resolveSkill(cli, "alpha")
+	if err != nil {
+		t.Fatalf("resolveSkill(alpha): %v", err)
+	}
+	if id, _ := got["id"].(string); id != "id-1" {
+		t.Errorf("resolved id = %q, want id-1", id)
+	}
+}
+
+func TestResolveSkill_ByName_AmbiguousErrorsWithIDs(t *testing.T) {
+	srv := newTestServer(t, []stubSkill{
+		{ID: "abc1", Name: "alpha"},
+		{ID: "def2", Name: "alpha"},
+	}, "body", nil)
+	setupSkillsEnv(t, srv.URL)
+	cli := client.NewClient(client.LoadConfig(), Version)
+	_, err := resolveSkill(cli, "alpha")
+	if err == nil {
+		t.Fatal("expected ambiguity error, got nil")
+	}
+	msg := err.Error()
+	for _, want := range []string{"abc1", "def2", "alpha"} {
+		if !strings.Contains(msg, want) {
+			t.Errorf("error message missing %q: %s", want, msg)
+		}
+	}
+}
+
+func TestResolveSkill_ByUUID_Hits(t *testing.T) {
+	srv := newTestServer(t, []stubSkill{{ID: validUUID, Name: "alpha"}}, "body", nil)
+	setupSkillsEnv(t, srv.URL)
+	cli := client.NewClient(client.LoadConfig(), Version)
+	got, err := resolveSkill(cli, validUUID)
+	if err != nil {
+		t.Fatalf("resolveSkill(uuid): %v", err)
+	}
+	if id, _ := got["id"].(string); id != validUUID {
+		t.Errorf("resolved id = %q, want %q", id, validUUID)
+	}
+}
+
+func TestResolveSkill_ByUUID_NotFound(t *testing.T) {
+	srv := newTestServer(t, nil, "", nil)
+	setupSkillsEnv(t, srv.URL)
+	cli := client.NewClient(client.LoadConfig(), Version)
+	_, err := resolveSkill(cli, validUUID)
+	if err == nil || !strings.Contains(err.Error(), "not found") {
+		t.Errorf("expected 'not found', got %v", err)
+	}
+}
+
+func TestResolveSkill_EmptyString(t *testing.T) {
+	srv := newTestServer(t, nil, "", nil)
+	setupSkillsEnv(t, srv.URL)
+	cli := client.NewClient(client.LoadConfig(), Version)
+	if _, err := resolveSkill(cli, ""); err == nil {
+		t.Error("expected error on empty identifier")
+	}
+}
+
+func TestInstall_DisambiguatesByUUID(t *testing.T) {
+	// Two skills share a name; install with the UUID picks the right one
+	// and writes its content.
+	other := "11111111-2222-3333-4444-555555555555"
+	srv := newTestServer(t, []stubSkill{
+		{ID: validUUID, Name: "alpha"},
+		{ID: other, Name: "alpha"},
+	}, "# from validUUID\n", nil)
+	_, homeDir := setupSkillsEnv(t, srv.URL)
+
+	if err := runSkillsInstall(skillsInstallCmd, []string{validUUID}); err != nil {
+		t.Fatalf("install by uuid: %v", err)
+	}
+	target := filepath.Join(homeDir, ".claude", "skills", "alpha", "SKILL.md")
+	got, err := os.ReadFile(target)
+	if err != nil {
+		t.Fatalf("read installed file: %v", err)
+	}
+	if !strings.Contains(string(got), "from validUUID") {
+		t.Errorf("wrong content installed: %q", string(got))
+	}
+}
+
+func TestInstall_AmbiguousNameSurfacesIDs(t *testing.T) {
+	srv := newTestServer(t, []stubSkill{
+		{ID: "abc1", Name: "alpha"},
+		{ID: "def2", Name: "alpha"},
+	}, "body", nil)
+	setupSkillsEnv(t, srv.URL)
+	err := runSkillsInstall(skillsInstallCmd, []string{"alpha"})
+	if err == nil {
+		t.Fatal("expected ambiguity error from install")
+	}
+	if !strings.Contains(err.Error(), "abc1") || !strings.Contains(err.Error(), "def2") {
+		t.Errorf("install error should list both UUIDs: %v", err)
+	}
+}
+
+// ============================================================================
+// delete
+// ============================================================================
+
+func TestDelete_CallsDeleteEndpoint(t *testing.T) {
+	deleted := map[string]bool{}
+	srv := newTestServer(t, []stubSkill{{ID: "to-remove", Name: "alpha"}}, "", &deleted)
+	setupSkillsEnv(t, srv.URL)
+	skillsDeleteYes = true
+
+	if err := runSkillsDelete(skillsDeleteCmd, []string{"alpha"}); err != nil {
+		t.Fatalf("delete: %v", err)
+	}
+	if !deleted["to-remove"] {
+		t.Errorf("DELETE was not called for to-remove: %+v", deleted)
+	}
+}
+
+func TestDelete_RefusesWithoutYesOnNonTTY(t *testing.T) {
+	srv := newTestServer(t, []stubSkill{{ID: "id-1", Name: "alpha"}}, "", nil)
+	setupSkillsEnv(t, srv.URL)
+	skillsDeleteYes = false // explicit
+
+	// Simulate piped/non-interactive stdin. Restore the real check after.
+	orig := stdinIsTerminal
+	stdinIsTerminal = func() bool { return false }
+	t.Cleanup(func() { stdinIsTerminal = orig })
+
+	err := runSkillsDelete(skillsDeleteCmd, []string{"alpha"})
+	if err == nil || !strings.Contains(err.Error(), "--yes") {
+		t.Errorf("expected non-TTY refusal, got %v", err)
+	}
+}
+
+func TestDelete_AmbiguousNameSurfacesIDs(t *testing.T) {
+	srv := newTestServer(t, []stubSkill{
+		{ID: "abc1", Name: "alpha"},
+		{ID: "def2", Name: "alpha"},
+	}, "", nil)
+	setupSkillsEnv(t, srv.URL)
+	skillsDeleteYes = true
+	err := runSkillsDelete(skillsDeleteCmd, []string{"alpha"})
+	if err == nil {
+		t.Fatal("expected ambiguity error")
+	}
+	if !strings.Contains(err.Error(), "abc1") {
+		t.Errorf("ambiguity error missing UUID: %v", err)
+	}
+}
+
+func TestDelete_ByUUID(t *testing.T) {
+	deleted := map[string]bool{}
+	srv := newTestServer(t, []stubSkill{{ID: validUUID, Name: "alpha"}}, "", &deleted)
+	setupSkillsEnv(t, srv.URL)
+	skillsDeleteYes = true
+	if err := runSkillsDelete(skillsDeleteCmd, []string{validUUID}); err != nil {
+		t.Fatalf("delete by uuid: %v", err)
+	}
+	if !deleted[validUUID] {
+		t.Errorf("DELETE was not called for %s", validUUID)
+	}
+}

--- a/internal/client/api.go
+++ b/internal/client/api.go
@@ -799,6 +799,20 @@ func (c *Client) ApproveSkill(id string, approve bool) *APIResponse {
 	return c.patchRequest(fmt.Sprintf("/v1/skills/%s", id), map[string]interface{}{"is_approved": approve})
 }
 
+// GetSkill fetches a single skill by ID. Returns 404 if not found or
+// already soft-deleted.
+func (c *Client) GetSkill(id string) *APIResponse {
+	return c.Get(fmt.Sprintf("/v1/skills/%s", id), nil)
+}
+
+// DeleteSkill soft-deletes a skill by ID (sets is_active=false on the
+// platform). The row remains in the DB for audit but disappears from
+// listings. Wrapped in a method so we can later add confirmation hooks
+// or soft-vs-hard-delete options without touching command code.
+func (c *Client) DeleteSkill(id string) *APIResponse {
+	return c.deleteRequest(fmt.Sprintf("/v1/skills/%s", id))
+}
+
 // GetSkillCommandFile fetches the raw markdown command file for a skill.
 // Returns the file content suitable for writing to ~/.claude/commands/<name>.md
 func (c *Client) GetSkillCommandFile(id string) (string, error) {
@@ -827,6 +841,37 @@ func (c *Client) GetSkillCommandFile(id string) (string, error) {
 	}
 
 	return string(body), nil
+}
+
+// deleteRequest sends a DELETE request with no body.
+func (c *Client) deleteRequest(path string) *APIResponse {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Duration(c.config.TimeoutSeconds)*time.Second)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, "DELETE", c.config.APIURL+path, nil)
+	if err != nil {
+		return &APIResponse{Success: false, Error: fmt.Sprintf("failed to create request: %v", err)}
+	}
+	c.setHeaders(req)
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return &APIResponse{Success: false, Error: fmt.Sprintf("request failed: %v", err)}
+	}
+	defer resp.Body.Close()
+
+	body, _ := io.ReadAll(resp.Body)
+	result := &APIResponse{StatusCode: resp.StatusCode, Success: resp.StatusCode >= 200 && resp.StatusCode < 300}
+	if len(body) > 0 {
+		var data map[string]interface{}
+		if err := json.Unmarshal(body, &data); err == nil {
+			result.Data = data
+		}
+	}
+	if !result.Success {
+		result.Error = fmt.Sprintf("HTTP %d: %s", resp.StatusCode, string(body))
+	}
+	return result
 }
 
 // patchRequest sends a PATCH request with a JSON payload


### PR DESCRIPTION
## Summary

Closes the four CLI gaps that surfaced while installing one global skill:

1. **Silent name-match selection.** \`findSkillByName\` returned the first match. Renamed to \`resolveSkill\` — accepts name *or* UUID, errors loudly on ambiguous names with each candidate's UUID/scope/confidence/state.
2. **No way to address a skill by ID.** Every command that took \`<name>\` now also accepts a UUID.
3. **No CLI delete.** Added \`promptconduit skills delete <name|uuid> [--yes]\` → \`DELETE /v1/skills/:id\` (soft). Requires \`--yes\` on non-TTY.
4. **\`list\` didn't expose IDs.** Text output now shows the first 8 chars of each UUID as a prefix column.

Plus: API client gains \`GetSkill(id)\`, \`DeleteSkill(id)\`, and a \`deleteRequest\` helper paralleling \`patchRequest\`.

## Why now

Repeated runs of \`skills generate\` create duplicate skills with the same name but different IDs (the platform doesn't dedup across detection runs). Before this change, the CLI silently picked the first match — could approve, install, or reject the wrong row without any signal. Caught it manually this week; would have caused real damage in scripted/CI use.

## Behavior contract

| Scenario | Before | After |
|---|---|---|
| \`install foo\` with 2 \`foo\` rows | Silently picks first | Errors with both UUIDs + scope + state |
| \`install <uuid>\` | N/A (UUIDs rejected by name validation) | Hits \`GET /v1/skills/:id\`, installs that exact row |
| \`approve <name>\` with duplicates | Silently picks first | Same disambiguation error as install |
| \`delete <name>\` | Didn't exist | Confirms on TTY, requires \`--yes\` on non-TTY |
| \`list\` text output | Just \`/name\` | \`<8-char-id>  /name\` so you can copy a UUID directly |

## Test plan

- [x] 10 new tests covering UUID resolution, name resolution (single+ambiguous), empty input, 404 on missing UUID, install-by-UUID disambiguation, ambiguity surfacing IDs in install error, delete via name + UUID, non-TTY refusal without \`--yes\`
- [x] All existing tests pass (\`make test\`)
- [x] Lint clean (\`make lint\` shows no new issues in changed files)
- [x] Smoke against prod: deleted the dupe \`git-pr-workflow\` row via CLI, approved + installed the survivor, file landed at \`~/.claude/skills/git-pr-workflow/SKILL.md\`

## Out of scope (separate ticket)

- Repo-detection bug where workspace-root sessions all tag as \`promptconduit\` regardless of which sub-repo edits happened. Different problem (CLI behavior at session start), bigger blast radius, deserves its own design.

Ships as v0.3.6 — additive, no breaking changes.