### PR TITLE
Local-only realtime token-cost meter (`promptconduit cost`)

### DIFF
--- a/cmd/cost.go
+++ b/cmd/cost.go
@@ -1,11 +1,16 @@
 package cmd
 
 import (
+	"encoding/json"
 	"fmt"
+	"io"
 	"os"
 	"os/signal"
+	"path/filepath"
 	"sort"
+	"strings"
 	"syscall"
+	"time"
 
 	"github.com/promptconduit/cli/internal/cost"
 	"github.com/spf13/cobra"
@@ -27,13 +32,16 @@ a bundled rate table, and never sends any of your data to the PromptConduit
 platform or anywhere else.
 
 Subcommands:
-  watch     Stream cost events as your session runs (the editor extension's feed)
-  session   Print the current session's cost summary
-  history   Aggregate cost over the last N days
+  watch           Stream cost events as your session runs (the editor extension's feed)
+  session         Print the current session's cost summary
+  history         Aggregate cost over the last N days
+  install-hooks   Wire the local Cursor cost hook into ~/.cursor/hooks.json
+  uninstall-hooks Remove it
 
-Today this prices Claude Code sessions with exact token counts from the
-transcript. Cursor's native agent (estimate + reconcile) lands in a later
-milestone.`,
+Prices both Claude Code (exact token counts from the transcript) and Cursor
+(exact token counts from its agent hooks — run install-hooks first). Models
+not in the bundled rate table are reported with exact tokens but flagged
+unpriced rather than guessed.`,
 	SilenceUsage:  true,
 	SilenceErrors: true,
 }
@@ -62,6 +70,31 @@ var costHistoryCmd = &cobra.Command{
 	RunE:          runCostHistory,
 }
 
+var costHookCmd = &cobra.Command{
+	Use:           "hook",
+	Short:         "Record a Cursor agent hook payload's cost (local-only; for ~/.cursor/hooks.json)",
+	Hidden:        true,
+	SilenceUsage:  true,
+	SilenceErrors: true,
+	RunE:          runCostHook,
+}
+
+var costInstallHooksCmd = &cobra.Command{
+	Use:           "install-hooks",
+	Short:         "Wire the local Cursor cost hook into ~/.cursor/hooks.json",
+	SilenceUsage:  true,
+	SilenceErrors: true,
+	RunE:          runCostInstallHooks,
+}
+
+var costUninstallHooksCmd = &cobra.Command{
+	Use:           "uninstall-hooks",
+	Short:         "Remove the Cursor cost hook from ~/.cursor/hooks.json",
+	SilenceUsage:  true,
+	SilenceErrors: true,
+	RunE:          runCostUninstallHooks,
+}
+
 func init() {
 	costWatchCmd.Flags().StringVar(&costCwd, "cwd", "", "workspace directory to scope to (default: current directory)")
 	costWatchCmd.Flags().BoolVar(&costAll, "all", false, "watch every Claude Code project, not just the current workspace")
@@ -76,6 +109,9 @@ func init() {
 	costCmd.AddCommand(costWatchCmd)
 	costCmd.AddCommand(costSessionCmd)
 	costCmd.AddCommand(costHistoryCmd)
+	costCmd.AddCommand(costHookCmd)
+	costCmd.AddCommand(costInstallHooksCmd)
+	costCmd.AddCommand(costUninstallHooksCmd)
 }
 
 // resolveCwd returns the explicit --cwd or the process working directory.
@@ -114,14 +150,16 @@ func runCostWatch(cmd *cobra.Command, args []string) error {
 	ctx, cancel := signal.NotifyContext(cmd.Context(), os.Interrupt, syscall.SIGTERM)
 	defer cancel()
 
+	cursorFeeds := cost.CursorFeedPaths(resolveCwd(), costAll)
+
 	scope := "current workspace"
 	if costAll {
-		scope = "all Claude Code projects"
+		scope = "all projects"
 	}
-	fmt.Fprintf(cmd.ErrOrStderr(), "cost: watching %s — local only, Ctrl-C to stop.\n", scope)
+	fmt.Fprintf(cmd.ErrOrStderr(), "cost: watching %s (Claude Code + Cursor) — local only, Ctrl-C to stop.\n", scope)
 
 	w := cost.NewWatcher(table, store, cmd.OutOrStdout(), true)
-	return w.Run(ctx, dirs)
+	return w.Run(ctx, dirs, cursorFeeds)
 }
 
 func runCostSession(cmd *cobra.Command, args []string) error {
@@ -135,7 +173,153 @@ func runCostSession(cmd *cobra.Command, args []string) error {
 	}
 	w := cost.NewWatcher(table, nil, cmd.OutOrStdout(), false)
 	w.SeedNewest(dirs)
+	w.SeedCursorFeeds(cost.CursorFeedPaths(resolveCwd(), false))
+	w.EmitLatestSession()
 	return nil
+}
+
+func runCostHook(cmd *cobra.Command, args []string) error {
+	// Always tell the agent to continue, no matter what — a cost hook must
+	// never block or fail the editor.
+	defer fmt.Fprintln(cmd.OutOrStdout(), `{"continue": true}`)
+
+	raw, err := io.ReadAll(cmd.InOrStdin())
+	if err != nil || len(raw) == 0 {
+		return nil
+	}
+	table, err := cost.LoadBundledPriceTable()
+	if err != nil {
+		return nil
+	}
+	ev, cwd, ok := cost.ParseCursorHookPayload(raw, table)
+	if !ok {
+		return nil // not a token-bearing Cursor event — nothing to record
+	}
+	ev.Timestamp = time.Now().UTC().Format(time.RFC3339)
+	_ = cost.AppendCursorEvent(ev, cwd) // best-effort, local-only
+	return nil
+}
+
+// cursorCostHooks are the Cursor agent events the cost hook listens on. Both
+// carry identical per-generation tokens; the watcher dedups by generation_id,
+// so installing both is safe and resilient.
+var cursorCostHookEvents = []string{"afterAgentResponse", "stop"}
+
+func runCostInstallHooks(cmd *cobra.Command, args []string) error {
+	exe, err := osExecutable()
+	if err != nil {
+		return err
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return err
+	}
+	path := filepath.Join(home, ".cursor", "hooks.json")
+
+	settings := map[string]interface{}{}
+	if data, err := os.ReadFile(path); err == nil {
+		_ = json.Unmarshal(data, &settings)
+	}
+	hooks, _ := settings["hooks"].(map[string]interface{})
+	if hooks == nil {
+		hooks = map[string]interface{}{}
+	}
+
+	hookCmd := fmt.Sprintf("%s cost hook", exe)
+	for _, event := range cursorCostHookEvents {
+		entries, _ := hooks[event].([]interface{})
+		// Drop any prior cost-hook entry so re-install is idempotent.
+		kept := entries[:0:0]
+		for _, e := range entries {
+			if m, ok := e.(map[string]interface{}); ok {
+				if c, _ := m["command"].(string); containsCostHook(c) {
+					continue
+				}
+			}
+			kept = append(kept, e)
+		}
+		kept = append(kept, map[string]interface{}{"command": hookCmd})
+		hooks[event] = kept
+	}
+	settings["hooks"] = hooks
+	if settings["version"] == nil {
+		settings["version"] = 1
+	}
+
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return err
+	}
+	data, err := json.MarshalIndent(settings, "", "  ")
+	if err != nil {
+		return err
+	}
+	if err := os.WriteFile(path, data, 0o644); err != nil {
+		return err
+	}
+	fmt.Fprintf(cmd.OutOrStdout(), "Installed Cursor cost hooks (%v) in %s\n", cursorCostHookEvents, path)
+	fmt.Fprintln(cmd.OutOrStdout(), "Run `promptconduit cost watch` (or the editor extension) to see live cost.")
+	return nil
+}
+
+func runCostUninstallHooks(cmd *cobra.Command, args []string) error {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return err
+	}
+	path := filepath.Join(home, ".cursor", "hooks.json")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		fmt.Fprintln(cmd.OutOrStdout(), "No Cursor hooks file — nothing to remove.")
+		return nil
+	}
+	settings := map[string]interface{}{}
+	if err := json.Unmarshal(data, &settings); err != nil {
+		return err
+	}
+	if hooks, ok := settings["hooks"].(map[string]interface{}); ok {
+		for event, v := range hooks {
+			entries, _ := v.([]interface{})
+			kept := entries[:0:0]
+			for _, e := range entries {
+				if m, ok := e.(map[string]interface{}); ok {
+					if c, _ := m["command"].(string); containsCostHook(c) {
+						continue
+					}
+				}
+				kept = append(kept, e)
+			}
+			if len(kept) == 0 {
+				delete(hooks, event)
+			} else {
+				hooks[event] = kept
+			}
+		}
+	}
+	out, err := json.MarshalIndent(settings, "", "  ")
+	if err != nil {
+		return err
+	}
+	if err := os.WriteFile(path, out, 0o644); err != nil {
+		return err
+	}
+	fmt.Fprintf(cmd.OutOrStdout(), "Removed Cursor cost hooks from %s\n", path)
+	return nil
+}
+
+// containsCostHook reports whether a hook command string is our cost hook
+// (`<binary> cost hook`), so install/uninstall can find and replace just ours.
+func containsCostHook(command string) bool {
+	return strings.HasSuffix(command, "cost hook")
+}
+
+// osExecutable resolves the running binary's path (indirection kept tiny so the
+// install command reads cleanly).
+func osExecutable() (string, error) {
+	exe, err := os.Executable()
+	if err != nil {
+		return "", err
+	}
+	return filepath.EvalSymlinks(exe)
 }
 
 func runCostHistory(cmd *cobra.Command, args []string) error {

--- a/cmd/cost.go
+++ b/cmd/cost.go
@@ -1,0 +1,205 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"os/signal"
+	"sort"
+	"syscall"
+
+	"github.com/promptconduit/cli/internal/cost"
+	"github.com/spf13/cobra"
+)
+
+var (
+	costCwd  string
+	costAll  bool
+	costJSON bool
+	costDays int
+)
+
+var costCmd = &cobra.Command{
+	Use:   "cost",
+	Short: "Real-time AI token cost for your sessions (100% local)",
+	Long: `Compute what your AI coding sessions cost, in real time, entirely on
+your machine. The cost feature reads local transcripts, prices each turn against
+a bundled rate table, and never sends any of your data to the PromptConduit
+platform or anywhere else.
+
+Subcommands:
+  watch     Stream cost events as your session runs (the editor extension's feed)
+  session   Print the current session's cost summary
+  history   Aggregate cost over the last N days
+
+Today this prices Claude Code sessions with exact token counts from the
+transcript. Cursor's native agent (estimate + reconcile) lands in a later
+milestone.`,
+	SilenceUsage:  true,
+	SilenceErrors: true,
+}
+
+var costWatchCmd = &cobra.Command{
+	Use:           "watch",
+	Short:         "Stream real-time cost events (newline-delimited JSON)",
+	SilenceUsage:  true,
+	SilenceErrors: true,
+	RunE:          runCostWatch,
+}
+
+var costSessionCmd = &cobra.Command{
+	Use:           "session",
+	Short:         "Print the current session's cost summary",
+	SilenceUsage:  true,
+	SilenceErrors: true,
+	RunE:          runCostSession,
+}
+
+var costHistoryCmd = &cobra.Command{
+	Use:           "history",
+	Short:         "Aggregate cost over recent days from the local store",
+	SilenceUsage:  true,
+	SilenceErrors: true,
+	RunE:          runCostHistory,
+}
+
+func init() {
+	costWatchCmd.Flags().StringVar(&costCwd, "cwd", "", "workspace directory to scope to (default: current directory)")
+	costWatchCmd.Flags().BoolVar(&costAll, "all", false, "watch every Claude Code project, not just the current workspace")
+	costWatchCmd.Flags().BoolVar(&costJSON, "json", true, "emit newline-delimited JSON (the only format today)")
+
+	costSessionCmd.Flags().StringVar(&costCwd, "cwd", "", "workspace directory to scope to (default: current directory)")
+	costSessionCmd.Flags().BoolVar(&costJSON, "json", true, "emit JSON (the only format today)")
+
+	costHistoryCmd.Flags().IntVar(&costDays, "days", 7, "number of days to include")
+	costHistoryCmd.Flags().BoolVar(&costJSON, "json", false, "emit JSON instead of a table")
+
+	costCmd.AddCommand(costWatchCmd)
+	costCmd.AddCommand(costSessionCmd)
+	costCmd.AddCommand(costHistoryCmd)
+}
+
+// resolveCwd returns the explicit --cwd or the process working directory.
+func resolveCwd() string {
+	if costCwd != "" {
+		return costCwd
+	}
+	if wd, err := os.Getwd(); err == nil {
+		return wd
+	}
+	return ""
+}
+
+func runCostWatch(cmd *cobra.Command, args []string) error {
+	table, err := cost.LoadBundledPriceTable()
+	if err != nil {
+		return fmt.Errorf("load pricing table: %w", err)
+	}
+
+	dirs, err := cost.ResolveDirs(resolveCwd(), costAll)
+	if err != nil {
+		return fmt.Errorf("resolve transcript directories: %w", err)
+	}
+
+	// Persist to the local store best-effort; a store failure must never stop
+	// the live stream the extension depends on.
+	store, err := cost.OpenStore()
+	if err != nil {
+		fmt.Fprintf(cmd.ErrOrStderr(), "cost: local store unavailable (%v); continuing without history\n", err)
+		store = nil
+	}
+	if store != nil {
+		defer store.Close()
+	}
+
+	ctx, cancel := signal.NotifyContext(cmd.Context(), os.Interrupt, syscall.SIGTERM)
+	defer cancel()
+
+	scope := "current workspace"
+	if costAll {
+		scope = "all Claude Code projects"
+	}
+	fmt.Fprintf(cmd.ErrOrStderr(), "cost: watching %s — local only, Ctrl-C to stop.\n", scope)
+
+	w := cost.NewWatcher(table, store, cmd.OutOrStdout(), true)
+	return w.Run(ctx, dirs)
+}
+
+func runCostSession(cmd *cobra.Command, args []string) error {
+	table, err := cost.LoadBundledPriceTable()
+	if err != nil {
+		return fmt.Errorf("load pricing table: %w", err)
+	}
+	dirs, err := cost.ResolveDirs(resolveCwd(), false)
+	if err != nil {
+		return fmt.Errorf("resolve transcript directories: %w", err)
+	}
+	w := cost.NewWatcher(table, nil, cmd.OutOrStdout(), false)
+	w.SeedNewest(dirs)
+	return nil
+}
+
+func runCostHistory(cmd *cobra.Command, args []string) error {
+	events, err := cost.ReadEvents()
+	if err != nil {
+		return fmt.Errorf("read cost history: %w", err)
+	}
+
+	// Group by calendar day (the YYYY-MM-DD prefix of the RFC3339 timestamp).
+	type dayTotal struct {
+		day  string
+		cost float64
+		in   int64
+		out  int64
+	}
+	byDay := map[string]*dayTotal{}
+	for _, e := range events {
+		day := e.Timestamp
+		if len(day) >= 10 {
+			day = day[:10]
+		}
+		dt := byDay[day]
+		if dt == nil {
+			dt = &dayTotal{day: day}
+			byDay[day] = dt
+		}
+		dt.cost += e.Cost.Total
+		dt.in += e.Tokens.Input
+		dt.out += e.Tokens.Output
+	}
+
+	days := make([]*dayTotal, 0, len(byDay))
+	for _, dt := range byDay {
+		days = append(days, dt)
+	}
+	sort.Slice(days, func(i, j int) bool { return days[i].day > days[j].day })
+	if costDays > 0 && len(days) > costDays {
+		days = days[:costDays]
+	}
+
+	out := cmd.OutOrStdout()
+	if costJSON {
+		fmt.Fprint(out, "[")
+		for i, dt := range days {
+			if i > 0 {
+				fmt.Fprint(out, ",")
+			}
+			fmt.Fprintf(out, `{"day":%q,"cost_total":%.6f,"input":%d,"output":%d,"currency":%q}`,
+				dt.day, dt.cost, dt.in, dt.out, cost.Currency)
+		}
+		fmt.Fprintln(out, "]")
+		return nil
+	}
+
+	if len(days) == 0 {
+		fmt.Fprintln(out, "No cost history yet. Run `promptconduit cost watch` during a session.")
+		return nil
+	}
+	fmt.Fprintf(out, "%-12s %12s %12s %12s\n", "DAY", "COST (USD)", "INPUT", "OUTPUT")
+	var total float64
+	for _, dt := range days {
+		fmt.Fprintf(out, "%-12s %12.4f %12d %12d\n", dt.day, dt.cost, dt.in, dt.out)
+		total += dt.cost
+	}
+	fmt.Fprintf(out, "%-12s %12.4f\n", "TOTAL", total)
+	return nil
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -58,6 +58,7 @@ func init() {
 	rootCmd.AddCommand(watchCmd)
 	rootCmd.AddCommand(collectCmd)
 	rootCmd.AddCommand(logsCmd)
+	rootCmd.AddCommand(costCmd)
 }
 
 var versionCmd = &cobra.Command{
@@ -198,7 +199,7 @@ func skipUpdateCheckFor(cmd *cobra.Command) bool {
 	}
 	name := commandPathRoot(cmd)
 	switch name {
-	case "hook", "upgrade", "watch", "collect":
+	case "hook", "upgrade", "watch", "collect", "cost":
 		return true
 	}
 	return false

--- a/internal/cost/claudecode.go
+++ b/internal/cost/claudecode.go
@@ -1,0 +1,247 @@
+package cost
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+// claudeProjectsDir is where Claude Code stores per-project transcript folders.
+func claudeProjectsDir(homeDir string) string {
+	return filepath.Join(homeDir, ".claude", "projects")
+}
+
+// ResolveDirs returns the transcript directories to watch. When all is true it
+// returns every Claude Code project folder; otherwise just the folder for cwd.
+func ResolveDirs(cwd string, all bool) ([]string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return nil, err
+	}
+	root := claudeProjectsDir(home)
+	if all {
+		entries, err := os.ReadDir(root)
+		if err != nil {
+			if os.IsNotExist(err) {
+				return nil, nil
+			}
+			return nil, err
+		}
+		var dirs []string
+		for _, e := range entries {
+			if e.IsDir() {
+				dirs = append(dirs, filepath.Join(root, e.Name()))
+			}
+		}
+		return dirs, nil
+	}
+	return []string{projectDirForCwd(home, cwd)}, nil
+}
+
+// encodeProjectPath mirrors Claude Code's project-folder naming: every
+// non-alphanumeric character in the absolute cwd becomes a dash. e.g.
+// /Users/x/GitHub/tolken -> -Users-x-GitHub-tolken. Used to scope the watcher
+// to a single workspace without reading every transcript.
+func encodeProjectPath(p string) string {
+	var b strings.Builder
+	b.Grow(len(p))
+	for _, r := range p {
+		switch {
+		case r >= 'a' && r <= 'z', r >= 'A' && r <= 'Z', r >= '0' && r <= '9':
+			b.WriteRune(r)
+		default:
+			b.WriteRune('-')
+		}
+	}
+	return b.String()
+}
+
+// projectDirForCwd resolves the transcript directory for a workspace. It tries
+// the deterministic encoding first; if that folder doesn't exist (an edge case
+// in Claude Code's encoding), it falls back to scanning every project folder
+// and matching the cwd recorded inside a transcript.
+func projectDirForCwd(homeDir, cwd string) string {
+	root := claudeProjectsDir(homeDir)
+	encoded := filepath.Join(root, encodeProjectPath(cwd))
+	if fi, err := os.Stat(encoded); err == nil && fi.IsDir() {
+		return encoded
+	}
+	if match := scanForCwd(root, cwd); match != "" {
+		return match
+	}
+	return encoded // best-effort: return the computed path even if absent yet
+}
+
+// scanForCwd walks project folders and returns the one whose newest transcript
+// records the given cwd. Bounded I/O — reads only the first line of the newest
+// transcript per folder.
+func scanForCwd(root, cwd string) string {
+	entries, err := os.ReadDir(root)
+	if err != nil {
+		return ""
+	}
+	for _, e := range entries {
+		if !e.IsDir() {
+			continue
+		}
+		dir := filepath.Join(root, e.Name())
+		files := jsonlFiles(dir)
+		if len(files) == 0 {
+			continue
+		}
+		if firstLineCwd(files[0]) == cwd {
+			return dir
+		}
+	}
+	return ""
+}
+
+// firstLineCwd reads the cwd field from the first JSON line of a transcript.
+func firstLineCwd(path string) string {
+	f, err := os.Open(path)
+	if err != nil {
+		return ""
+	}
+	defer f.Close()
+	buf := make([]byte, 8192)
+	n, _ := f.Read(buf)
+	line := buf[:n]
+	if idx := indexByte(line, '\n'); idx >= 0 {
+		line = line[:idx]
+	}
+	var probe struct {
+		Cwd string `json:"cwd"`
+	}
+	_ = json.Unmarshal(line, &probe)
+	return probe.Cwd
+}
+
+func indexByte(b []byte, c byte) int {
+	for i, x := range b {
+		if x == c {
+			return i
+		}
+	}
+	return -1
+}
+
+// jsonlFiles returns the .jsonl files in dir sorted newest-first by mtime.
+func jsonlFiles(dir string) []string {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return nil
+	}
+	type fileMod struct {
+		path string
+		mod  int64
+	}
+	var fms []fileMod
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), ".jsonl") {
+			continue
+		}
+		info, err := e.Info()
+		if err != nil {
+			continue
+		}
+		fms = append(fms, fileMod{filepath.Join(dir, e.Name()), info.ModTime().UnixNano()})
+	}
+	sort.Slice(fms, func(i, j int) bool { return fms[i].mod > fms[j].mod })
+	out := make([]string, len(fms))
+	for i, fm := range fms {
+		out[i] = fm.path
+	}
+	return out
+}
+
+// ccLine is the subset of a Claude Code transcript line the cost watcher reads.
+type ccLine struct {
+	Type      string `json:"type"`
+	RequestID string `json:"requestId"`
+	UUID      string `json:"uuid"`
+	SessionID string `json:"sessionId"`
+	Timestamp string `json:"timestamp"`
+	Cwd       string `json:"cwd"`
+	Message   struct {
+		Model string `json:"model"`
+		Usage struct {
+			InputTokens              int64 `json:"input_tokens"`
+			OutputTokens             int64 `json:"output_tokens"`
+			CacheReadInputTokens     int64 `json:"cache_read_input_tokens"`
+			CacheCreationInputTokens int64 `json:"cache_creation_input_tokens"`
+			CacheCreation            struct {
+				Ephemeral1h int64 `json:"ephemeral_1h_input_tokens"`
+				Ephemeral5m int64 `json:"ephemeral_5m_input_tokens"`
+			} `json:"cache_creation"`
+		} `json:"usage"`
+	} `json:"message"`
+}
+
+// parseClaudeCodeLine turns one transcript line into a priced CostEvent. The
+// returned dedupKey (requestId, falling back to uuid) lets the caller skip
+// re-reads. ok is false for non-assistant lines, lines without usage, or
+// zero-token lines (which carry no cost).
+func parseClaudeCodeLine(line []byte, table *PriceTable, sessionFallback string) (ev CostEvent, dedupKey string, ok bool) {
+	var l ccLine
+	if err := json.Unmarshal(line, &l); err != nil {
+		return CostEvent{}, "", false
+	}
+	if l.Type != "assistant" {
+		return CostEvent{}, "", false
+	}
+	u := l.Message.Usage
+	if u.InputTokens == 0 && u.OutputTokens == 0 && u.CacheReadInputTokens == 0 && u.CacheCreationInputTokens == 0 {
+		return CostEvent{}, "", false
+	}
+
+	dedupKey = l.RequestID
+	if dedupKey == "" {
+		dedupKey = l.UUID
+	}
+
+	usage := Usage{
+		InputTokens:          u.InputTokens,
+		OutputTokens:         u.OutputTokens,
+		CacheReadInputTokens: u.CacheReadInputTokens,
+		CacheCreationInput:   u.CacheCreationInputTokens,
+		Ephemeral5mTokens:    u.CacheCreation.Ephemeral5m,
+		Ephemeral1hTokens:    u.CacheCreation.Ephemeral1h,
+	}
+
+	mp, priced := table.ResolvePrice(l.Message.Model)
+	c, cacheWriteTokens := CostForUsage(usage, mp)
+
+	sessionID := l.SessionID
+	if sessionID == "" {
+		sessionID = sessionFallback
+	}
+
+	ev = CostEvent{
+		V:           SchemaVersion,
+		Kind:        "cost_event",
+		Tool:        ToolClaudeCode,
+		SessionID:   sessionID,
+		RequestID:   dedupKey,
+		Timestamp:   l.Timestamp,
+		Model:       l.Message.Model,
+		ModelPriced: priced,
+		Source:      SourceExact,
+		Tokens: Tokens{
+			Input:      u.InputTokens,
+			Output:     u.OutputTokens,
+			CacheRead:  u.CacheReadInputTokens,
+			CacheWrite: cacheWriteTokens,
+		},
+		Cost:    c,
+		CwdBase: filepath.Base(l.Cwd),
+	}
+	return ev, dedupKey, true
+}
+
+// sessionIDFromPath derives the session id from a transcript filename
+// (Claude Code names files <session-uuid>.jsonl).
+func sessionIDFromPath(path string) string {
+	return strings.TrimSuffix(filepath.Base(path), ".jsonl")
+}

--- a/internal/cost/cost_test.go
+++ b/internal/cost/cost_test.go
@@ -118,6 +118,54 @@ func TestParseClaudeCodeLine(t *testing.T) {
 	}
 }
 
+// TestParseCursorHookPayload uses the real Cursor hook shape captured from the
+// M0 probe: top-level token fields, model, conversation/generation ids.
+func TestParseCursorHookPayload(t *testing.T) {
+	tbl := mustTable(t)
+
+	// composer-* is a Cursor-proprietary model not in the rate table: exact
+	// tokens, but unpriced (cost 0, flagged) rather than a guessed rate.
+	composer := []byte(`{"hook_event_name":"afterAgentResponse","model":"composer-2.5-fast","conversation_id":"conv1","generation_id":"gen1","session_id":"conv1","input_tokens":17072,"output_tokens":92,"cache_read_tokens":6048,"cache_write_tokens":0,"workspace_roots":["/Users/x/tolken"]}`)
+	ev, cwd, ok := ParseCursorHookPayload(composer, tbl)
+	if !ok {
+		t.Fatal("afterAgentResponse with tokens should parse")
+	}
+	if ev.Tool != ToolCursor || ev.SessionID != "conv1" || ev.RequestID != "gen1" {
+		t.Fatalf("unexpected cursor event: %+v", ev)
+	}
+	if ev.ModelPriced {
+		t.Fatal("composer-2.5-fast should be unpriced")
+	}
+	if ev.Cost.Total != 0 {
+		t.Fatalf("unpriced model cost should be 0, got %v", ev.Cost.Total)
+	}
+	if ev.Tokens.Input != 17072 || ev.Tokens.Output != 92 || ev.Tokens.CacheRead != 6048 {
+		t.Fatalf("tokens not read exactly: %+v", ev.Tokens)
+	}
+	if cwd != "/Users/x/tolken" || ev.CwdBase != "tolken" {
+		t.Fatalf("cwd handling wrong: cwd=%q base=%q", cwd, ev.CwdBase)
+	}
+
+	// A known passthrough model prices exactly.
+	known := []byte(`{"hook_event_name":"stop","model":"claude-opus-4-8","conversation_id":"c2","generation_id":"g2","input_tokens":1000,"output_tokens":500,"cache_read_tokens":2000,"cache_write_tokens":0,"workspace_roots":["/p"]}`)
+	ev2, _, ok := ParseCursorHookPayload(known, tbl)
+	if !ok || !ev2.ModelPriced {
+		t.Fatal("known model should parse and be priced")
+	}
+	const want = 1000*5e-6 + 500*25e-6 + 2000*0.5e-6 // 0.0185
+	if math.Abs(ev2.Cost.Total-want) > 1e-9 {
+		t.Fatalf("priced cursor cost = %v, want %v", ev2.Cost.Total, want)
+	}
+
+	// Non-token events and zero-token payloads are skipped.
+	if _, _, ok := ParseCursorHookPayload([]byte(`{"hook_event_name":"beforeSubmitPrompt","prompt":"hi"}`), tbl); ok {
+		t.Fatal("non-token event should be skipped")
+	}
+	if _, _, ok := ParseCursorHookPayload([]byte(`{"hook_event_name":"stop","model":"x","input_tokens":0,"output_tokens":0,"cache_read_tokens":0,"cache_write_tokens":0}`), tbl); ok {
+		t.Fatal("zero-token payload should be skipped")
+	}
+}
+
 func TestEncodeProjectPath(t *testing.T) {
 	got := encodeProjectPath("/Users/scotthavird/Documents/GitHub/scotthavird/tolken")
 	want := "-Users-scotthavird-Documents-GitHub-scotthavird-tolken"

--- a/internal/cost/cost_test.go
+++ b/internal/cost/cost_test.go
@@ -1,6 +1,8 @@
 package cost
 
 import (
+	"bytes"
+	"encoding/json"
 	"math"
 	"os"
 	"path/filepath"
@@ -31,6 +33,23 @@ func TestResolvePrice(t *testing.T) {
 	if _, ok := tbl.ResolvePrice("claude-3-5-haiku-20241022"); !ok {
 		t.Fatal("aliased haiku id should resolve")
 	}
+	// Cursor's own models resolve, and the -fast variant must NOT collapse to
+	// the cheaper Standard rate via prefix-trim (the exact key takes priority).
+	fast, ok := tbl.ResolvePrice("composer-2.5-fast")
+	if !ok {
+		t.Fatal("composer-2.5-fast should resolve")
+	}
+	std, ok := tbl.ResolvePrice("composer-2.5")
+	if !ok {
+		t.Fatal("composer-2.5 should resolve")
+	}
+	if fast.Input != 0.000003 || std.Input != 0.0000005 {
+		t.Fatalf("composer rates wrong: fast input=%v (want 3e-6), std input=%v (want 5e-7)", fast.Input, std.Input)
+	}
+	if fast.Input == std.Input {
+		t.Fatal("composer-2.5-fast must not resolve to the Standard rate")
+	}
+
 	// Unknown model must report not-priced, not panic or guess.
 	if _, ok := tbl.ResolvePrice("some-other-llm-9"); ok {
 		t.Fatal("unknown model should not resolve")
@@ -123,8 +142,8 @@ func TestParseClaudeCodeLine(t *testing.T) {
 func TestParseCursorHookPayload(t *testing.T) {
 	tbl := mustTable(t)
 
-	// composer-* is a Cursor-proprietary model not in the rate table: exact
-	// tokens, but unpriced (cost 0, flagged) rather than a guessed rate.
+	// composer-2.5-fast is priced from Cursor's published input/output rates
+	// ($3/$15 per M); Cursor publishes no cache rate, so cache_read is priced 0.
 	composer := []byte(`{"hook_event_name":"afterAgentResponse","model":"composer-2.5-fast","conversation_id":"conv1","generation_id":"gen1","session_id":"conv1","input_tokens":17072,"output_tokens":92,"cache_read_tokens":6048,"cache_write_tokens":0,"workspace_roots":["/Users/x/tolken"]}`)
 	ev, cwd, ok := ParseCursorHookPayload(composer, tbl)
 	if !ok {
@@ -133,17 +152,29 @@ func TestParseCursorHookPayload(t *testing.T) {
 	if ev.Tool != ToolCursor || ev.SessionID != "conv1" || ev.RequestID != "gen1" {
 		t.Fatalf("unexpected cursor event: %+v", ev)
 	}
-	if ev.ModelPriced {
-		t.Fatal("composer-2.5-fast should be unpriced")
+	if !ev.ModelPriced {
+		t.Fatal("composer-2.5-fast should be priced")
 	}
-	if ev.Cost.Total != 0 {
-		t.Fatalf("unpriced model cost should be 0, got %v", ev.Cost.Total)
+	const wantComposer = 17072*3e-6 + 92*15e-6 // cache_read priced at 0 (no Cursor cache rate)
+	if math.Abs(ev.Cost.Total-wantComposer) > 1e-9 {
+		t.Fatalf("composer cost = %v, want %v", ev.Cost.Total, wantComposer)
 	}
 	if ev.Tokens.Input != 17072 || ev.Tokens.Output != 92 || ev.Tokens.CacheRead != 6048 {
 		t.Fatalf("tokens not read exactly: %+v", ev.Tokens)
 	}
 	if cwd != "/Users/x/tolken" || ev.CwdBase != "tolken" {
 		t.Fatalf("cwd handling wrong: cwd=%q base=%q", cwd, ev.CwdBase)
+	}
+
+	// A genuinely unknown model is reported with exact tokens but unpriced
+	// (cost 0, flagged) rather than guessed.
+	unknown := []byte(`{"hook_event_name":"stop","model":"totally-unknown-model","conversation_id":"c3","generation_id":"g3","input_tokens":10,"output_tokens":5,"cache_read_tokens":0,"cache_write_tokens":0,"workspace_roots":["/p"]}`)
+	evU, _, ok := ParseCursorHookPayload(unknown, tbl)
+	if !ok {
+		t.Fatal("unknown-model payload should still parse")
+	}
+	if evU.ModelPriced || evU.Cost.Total != 0 {
+		t.Fatalf("unknown model should be unpriced with cost 0, got priced=%v cost=%v", evU.ModelPriced, evU.Cost.Total)
 	}
 
 	// A known passthrough model prices exactly.
@@ -163,6 +194,64 @@ func TestParseCursorHookPayload(t *testing.T) {
 	}
 	if _, _, ok := ParseCursorHookPayload([]byte(`{"hook_event_name":"stop","model":"x","input_tokens":0,"output_tokens":0,"cache_read_tokens":0,"cache_write_tokens":0}`), tbl); ok {
 		t.Fatal("zero-token payload should be skipped")
+	}
+}
+
+// TestWatcherCursorAggregationDedup is the end-to-end check for the behavior
+// verified by hand against real payloads: a watcher ingesting Cursor cost
+// events dedups stop + afterAgentResponse (same generation_id, identical
+// tokens) to one billable unit, sums across generations, and prices composer.
+func TestWatcherCursorAggregationDedup(t *testing.T) {
+	tbl := mustTable(t)
+	var buf bytes.Buffer
+	w := NewWatcher(tbl, nil, &buf, true)
+
+	// Two generations; each fires afterAgentResponse + stop with identical
+	// tokens and the same generation_id, exactly as real Cursor does.
+	payloads := []string{
+		`{"hook_event_name":"afterAgentResponse","model":"composer-2.5-fast","conversation_id":"c","generation_id":"g1","input_tokens":100,"output_tokens":10,"cache_read_tokens":0,"cache_write_tokens":0,"workspace_roots":["/p"]}`,
+		`{"hook_event_name":"stop","model":"composer-2.5-fast","conversation_id":"c","generation_id":"g1","input_tokens":100,"output_tokens":10,"cache_read_tokens":0,"cache_write_tokens":0,"workspace_roots":["/p"]}`,
+		`{"hook_event_name":"afterAgentResponse","model":"composer-2.5-fast","conversation_id":"c","generation_id":"g2","input_tokens":200,"output_tokens":20,"cache_read_tokens":0,"cache_write_tokens":0,"workspace_roots":["/p"]}`,
+		`{"hook_event_name":"stop","model":"composer-2.5-fast","conversation_id":"c","generation_id":"g2","input_tokens":200,"output_tokens":20,"cache_read_tokens":0,"cache_write_tokens":0,"workspace_roots":["/p"]}`,
+	}
+	for _, p := range payloads {
+		ev, _, ok := ParseCursorHookPayload([]byte(p), tbl)
+		if !ok {
+			t.Fatal("payload should parse")
+		}
+		data, _ := json.Marshal(ev)
+		w.streamCostEventLine(data)
+	}
+
+	// Parse the last session_summary emitted and assert the deduped totals.
+	var last *SessionSummary
+	for _, line := range bytes.Split(buf.Bytes(), []byte{'\n'}) {
+		if len(line) == 0 {
+			continue
+		}
+		var probe struct {
+			Kind string `json:"kind"`
+		}
+		if json.Unmarshal(line, &probe) == nil && probe.Kind == "session_summary" {
+			var s SessionSummary
+			if json.Unmarshal(line, &s) == nil {
+				last = &s
+			}
+		}
+	}
+	if last == nil {
+		t.Fatal("expected at least one session_summary")
+	}
+	// g1 (100/10) + g2 (200/20), each counted once despite the stop duplicate.
+	if last.Totals.Input != 300 || last.Totals.Output != 30 {
+		t.Fatalf("deduped totals wrong: input=%d output=%d, want 300/30", last.Totals.Input, last.Totals.Output)
+	}
+	const wantCost = 300*3e-6 + 30*15e-6 // composer-2.5-fast: 0.0009 + 0.00045
+	if math.Abs(last.Totals.CostTotal-wantCost) > 1e-9 {
+		t.Fatalf("cost = %v, want %v", last.Totals.CostTotal, wantCost)
+	}
+	if last.Source != SourceExact || last.Tool != ToolCursor {
+		t.Fatalf("unexpected source/tool: %s/%s", last.Source, last.Tool)
 	}
 }
 

--- a/internal/cost/cost_test.go
+++ b/internal/cost/cost_test.go
@@ -1,0 +1,164 @@
+package cost
+
+import (
+	"math"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func mustTable(t *testing.T) *PriceTable {
+	t.Helper()
+	tbl, err := LoadBundledPriceTable()
+	if err != nil {
+		t.Fatalf("load bundled table: %v", err)
+	}
+	return tbl
+}
+
+func TestResolvePrice(t *testing.T) {
+	tbl := mustTable(t)
+
+	if _, ok := tbl.ResolvePrice("claude-opus-4-8"); !ok {
+		t.Fatal("exact key claude-opus-4-8 should resolve")
+	}
+	// Dated/suffixed variant should collapse to the base model via prefix trim.
+	if _, ok := tbl.ResolvePrice("claude-opus-4-8-20260101"); !ok {
+		t.Fatal("dated variant should resolve to base model")
+	}
+	// Alias map.
+	if _, ok := tbl.ResolvePrice("claude-3-5-haiku-20241022"); !ok {
+		t.Fatal("aliased haiku id should resolve")
+	}
+	// Unknown model must report not-priced, not panic or guess.
+	if _, ok := tbl.ResolvePrice("some-other-llm-9"); ok {
+		t.Fatal("unknown model should not resolve")
+	}
+	if _, ok := tbl.ResolvePrice(""); ok {
+		t.Fatal("empty model should not resolve")
+	}
+}
+
+// TestCostForUsage_RealBlock checks the exact dollar math against a real
+// Claude Code usage block captured from a live transcript:
+//
+//	input 72, output 3674, cache_read 132405, cache_creation 19640 (all 1h),
+//	model claude-opus-4-8.
+//
+// At Opus 4.8 rates (in $5, out $25, cache-read $0.50, cache-write-1h $10 per
+// 1M) the total is $0.3548125 — and the 1h tier is what makes it right; pricing
+// those 19,640 tokens at the 5m rate ($6.25/1M) would undercount.
+func TestCostForUsage_RealBlock(t *testing.T) {
+	tbl := mustTable(t)
+	mp, ok := tbl.ResolvePrice("claude-opus-4-8")
+	if !ok {
+		t.Fatal("opus-4-8 must resolve")
+	}
+	u := Usage{
+		InputTokens:          72,
+		OutputTokens:         3674,
+		CacheReadInputTokens: 132405,
+		CacheCreationInput:   19640,
+		Ephemeral1hTokens:    19640,
+		Ephemeral5mTokens:    0,
+	}
+	c, cacheWriteTokens := CostForUsage(u, mp)
+
+	if cacheWriteTokens != 19640 {
+		t.Fatalf("cache-write tokens = %d, want 19640", cacheWriteTokens)
+	}
+	const want = 0.00036 + 0.09185 + 0.0662025 + 0.1964 // = 0.3548125
+	if math.Abs(c.Total-want) > 1e-9 {
+		t.Fatalf("total cost = %.10f, want %.10f", c.Total, want)
+	}
+	// The 1h cache-write component specifically must use the 2x rate.
+	if math.Abs(c.CacheWrite-0.1964) > 1e-9 {
+		t.Fatalf("cache-write cost = %.10f, want 0.1964 (1h rate)", c.CacheWrite)
+	}
+}
+
+func TestCostForUsage_NoSplitFallsBackTo5m(t *testing.T) {
+	tbl := mustTable(t)
+	mp, _ := tbl.ResolvePrice("claude-opus-4-8")
+	// No ephemeral split provided -> lumped total priced at the 5m rate.
+	u := Usage{CacheCreationInput: 1000}
+	c, tokens := CostForUsage(u, mp)
+	if tokens != 1000 {
+		t.Fatalf("tokens = %d, want 1000", tokens)
+	}
+	if math.Abs(c.CacheWrite-0.00625) > 1e-12 { // 1000 * $6.25/1M
+		t.Fatalf("cache-write = %.12f, want 0.00625 (5m rate)", c.CacheWrite)
+	}
+}
+
+func TestParseClaudeCodeLine(t *testing.T) {
+	tbl := mustTable(t)
+	line := []byte(`{"type":"assistant","requestId":"req_abc","sessionId":"sess_1","timestamp":"2026-06-13T12:00:00Z","cwd":"/Users/x/tolken","message":{"model":"claude-opus-4-8","usage":{"input_tokens":72,"output_tokens":3674,"cache_read_input_tokens":132405,"cache_creation_input_tokens":19640,"cache_creation":{"ephemeral_1h_input_tokens":19640,"ephemeral_5m_input_tokens":0}}}}`)
+	ev, key, ok := parseClaudeCodeLine(line, tbl, "fallback")
+	if !ok {
+		t.Fatal("assistant line with usage should parse")
+	}
+	if key != "req_abc" {
+		t.Fatalf("dedup key = %q, want req_abc", key)
+	}
+	if ev.SessionID != "sess_1" || ev.Model != "claude-opus-4-8" || !ev.ModelPriced {
+		t.Fatalf("unexpected event: %+v", ev)
+	}
+	if ev.CwdBase != "tolken" {
+		t.Fatalf("cwd_base = %q, want tolken (basename only)", ev.CwdBase)
+	}
+	if ev.Tokens.Output != 3674 {
+		t.Fatalf("output tokens = %d, want 3674", ev.Tokens.Output)
+	}
+
+	// A user line (no usage) must be skipped.
+	if _, _, ok := parseClaudeCodeLine([]byte(`{"type":"user","message":{"content":"hi"}}`), tbl, "fallback"); ok {
+		t.Fatal("user line should not parse as a cost event")
+	}
+}
+
+func TestEncodeProjectPath(t *testing.T) {
+	got := encodeProjectPath("/Users/scotthavird/Documents/GitHub/scotthavird/tolken")
+	want := "-Users-scotthavird-Documents-GitHub-scotthavird-tolken"
+	if got != want {
+		t.Fatalf("encodeProjectPath = %q, want %q", got, want)
+	}
+	// Dots in repo names also become dashes (e.g. havoptic.com).
+	if got := encodeProjectPath("/a/havoptic.com"); got != "-a-havoptic-com" {
+		t.Fatalf("dot encoding = %q, want -a-havoptic-com", got)
+	}
+}
+
+// TestPrivacy_NoPlatformSendInCostPackage is the load-bearing privacy
+// guarantee: the cost package must never reference the platform send path. If
+// any of these symbols appear in a non-test .go file here, the feature could
+// exfiltrate data and this test fails.
+func TestPrivacy_NoPlatformSendInCostPackage(t *testing.T) {
+	forbidden := []string{
+		"SendEnvelope",
+		"DefaultAPIURL",
+		"client.NewClient",
+		"apiClient",
+		"api_url",
+	}
+	entries, err := os.ReadDir(".")
+	if err != nil {
+		t.Fatalf("read package dir: %v", err)
+	}
+	for _, e := range entries {
+		name := e.Name()
+		if !strings.HasSuffix(name, ".go") || strings.HasSuffix(name, "_test.go") {
+			continue
+		}
+		data, err := os.ReadFile(filepath.Join(".", name))
+		if err != nil {
+			t.Fatalf("read %s: %v", name, err)
+		}
+		for _, sym := range forbidden {
+			if strings.Contains(string(data), sym) {
+				t.Errorf("%s references forbidden platform-send symbol %q — the cost feature must stay local-only", name, sym)
+			}
+		}
+	}
+}

--- a/internal/cost/cursor.go
+++ b/internal/cost/cursor.go
@@ -1,0 +1,154 @@
+package cost
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+)
+
+// Cursor turns out to be an EXACT source, not an estimated one: its `stop` and
+// `afterAgentResponse` hooks carry `input_tokens`, `output_tokens`,
+// `cache_read_tokens`, `cache_write_tokens`, and `model` directly (verified
+// 2026-06-13 via the M0 probe). So there's no tokenizer or usage-API
+// reconciliation — Cursor cost is computed the same exact way as Claude Code,
+// just sourced from a hook payload instead of a transcript line.
+//
+// Both `stop` and `afterAgentResponse` fire per generation with the SAME
+// generation_id and identical final tokens, so dedup by generation_id collapses
+// them to one billable unit regardless of which hook(s) are installed.
+
+const cursorFeedSubdir = "cursor"
+
+// cursorHookPayload is the subset of a Cursor agent-hook payload the cost
+// feature reads. Token counts live at the top level.
+type cursorHookPayload struct {
+	HookEventName    string   `json:"hook_event_name"`
+	Model            string   `json:"model"`
+	ConversationID   string   `json:"conversation_id"`
+	GenerationID     string   `json:"generation_id"`
+	SessionID        string   `json:"session_id"`
+	InputTokens      int64    `json:"input_tokens"`
+	OutputTokens     int64    `json:"output_tokens"`
+	CacheReadTokens  int64    `json:"cache_read_tokens"`
+	CacheWriteTokens int64    `json:"cache_write_tokens"`
+	WorkspaceRoots   []string `json:"workspace_roots"`
+}
+
+// ParseCursorHookPayload turns a Cursor hook payload into a priced CostEvent.
+// It accepts the token-bearing events (`stop`, `afterAgentResponse`); other
+// events and zero-token payloads return ok=false. The returned cwd is the
+// workspace root (used to route the event to the right per-workspace feed
+// file); the CostEvent itself stores only the basename. Timestamp is left empty
+// for the caller to stamp.
+func ParseCursorHookPayload(raw []byte, table *PriceTable) (ev CostEvent, cwd string, ok bool) {
+	var p cursorHookPayload
+	if err := json.Unmarshal(raw, &p); err != nil {
+		return CostEvent{}, "", false
+	}
+	switch p.HookEventName {
+	case "stop", "afterAgentResponse":
+		// token-bearing events
+	default:
+		return CostEvent{}, "", false
+	}
+	if p.InputTokens == 0 && p.OutputTokens == 0 && p.CacheReadTokens == 0 && p.CacheWriteTokens == 0 {
+		return CostEvent{}, "", false
+	}
+
+	dedupKey := p.GenerationID
+	if dedupKey == "" {
+		dedupKey = p.ConversationID
+	}
+	sessionID := p.ConversationID
+	if sessionID == "" {
+		sessionID = p.SessionID
+	}
+	if len(p.WorkspaceRoots) > 0 {
+		cwd = p.WorkspaceRoots[0]
+	}
+
+	usage := Usage{
+		InputTokens:          p.InputTokens,
+		OutputTokens:         p.OutputTokens,
+		CacheReadInputTokens: p.CacheReadTokens,
+		CacheCreationInput:   p.CacheWriteTokens, // Cursor reports no TTL split -> 5m rate
+	}
+	mp, priced := table.ResolvePrice(p.Model)
+	c, cacheWriteTokens := CostForUsage(usage, mp)
+
+	ev = CostEvent{
+		V:           SchemaVersion,
+		Kind:        "cost_event",
+		Tool:        ToolCursor,
+		SessionID:   sessionID,
+		RequestID:   dedupKey,
+		Model:       p.Model,
+		ModelPriced: priced,
+		Source:      SourceExact,
+		Tokens: Tokens{
+			Input:      p.InputTokens,
+			Output:     p.OutputTokens,
+			CacheRead:  p.CacheReadTokens,
+			CacheWrite: cacheWriteTokens,
+		},
+		Cost:    c,
+		CwdBase: filepath.Base(cwd),
+	}
+	return ev, cwd, true
+}
+
+// CursorFeedDir is where per-workspace Cursor cost feeds live
+// (~/.config/promptconduit/cost/cursor/). The `cost hook` command appends to
+// these; `cost watch` tails them.
+func CursorFeedDir() string {
+	return filepath.Join(StoreDir(), cursorFeedSubdir)
+}
+
+// CursorFeedPath returns the feed file for a workspace, named by the same
+// encoding Claude Code uses for project folders so `cost watch --cwd` can find
+// it deterministically.
+func CursorFeedPath(cwd string) string {
+	return filepath.Join(CursorFeedDir(), encodeProjectPath(cwd)+".ndjson")
+}
+
+// AppendCursorEvent appends a CostEvent to the per-workspace Cursor feed. This
+// is a local-only write — the cost feature never sends Cursor data anywhere.
+func AppendCursorEvent(ev CostEvent, cwd string) error {
+	dir := CursorFeedDir()
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return err
+	}
+	data, err := json.Marshal(ev)
+	if err != nil {
+		return err
+	}
+	f, err := os.OpenFile(CursorFeedPath(cwd), os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	_, err = f.Write(append(data, '\n'))
+	return err
+}
+
+// CursorFeedPaths returns the feed files to watch: the one for cwd, or every
+// feed when all is true.
+func CursorFeedPaths(cwd string, all bool) []string {
+	if all {
+		entries, err := os.ReadDir(CursorFeedDir())
+		if err != nil {
+			return nil
+		}
+		var out []string
+		for _, e := range entries {
+			if !e.IsDir() && filepath.Ext(e.Name()) == ".ndjson" {
+				out = append(out, filepath.Join(CursorFeedDir(), e.Name()))
+			}
+		}
+		return out
+	}
+	if cwd == "" {
+		return nil
+	}
+	return []string{CursorFeedPath(cwd)}
+}

--- a/internal/cost/cursor.go
+++ b/internal/cost/cursor.go
@@ -113,6 +113,12 @@ func CursorFeedPath(cwd string) string {
 
 // AppendCursorEvent appends a CostEvent to the per-workspace Cursor feed. This
 // is a local-only write — the cost feature never sends Cursor data anywhere.
+//
+// The feed stores the already-priced CostEvent (token counts + cost), never the
+// hook payload's response `text`. Two consequences: (1) no prompt/response
+// content is ever persisted, and (2) Cursor turns are priced at capture time —
+// a later pricing-table change does not retroactively reprice old feed entries
+// (unlike Claude Code, where transcripts are re-parsed and re-priced each run).
 func AppendCursorEvent(ev CostEvent, cwd string) error {
 	dir := CursorFeedDir()
 	if err := os.MkdirAll(dir, 0o755); err != nil {

--- a/internal/cost/event.go
+++ b/internal/cost/event.go
@@ -1,0 +1,99 @@
+// Package cost computes real-time token-spend for AI coding sessions entirely
+// on-device. It is a deliberate exception to the CLI's "wrap raw events, let
+// the platform normalize" design (see internal/envelope): all transcript
+// parsing and pricing happen here in Go, and nothing this package produces is
+// ever sent to the PromptConduit platform. The watcher tails local transcripts,
+// prices each assistant turn against a bundled rate table, and emits cost
+// events the editor extension renders in the status bar.
+package cost
+
+const (
+	// SchemaVersion is stamped on every emitted record so the extension can
+	// reject shapes it doesn't understand rather than mis-render them.
+	SchemaVersion = 1
+
+	// Currency is the only currency v1 prices in; the pricing table is in USD.
+	Currency = "USD"
+
+	// Tool identifiers, matching the CLI's existing tool naming (see
+	// cmd/hook.go detectTool).
+	ToolClaudeCode = "claude-code"
+	ToolCursor     = "cursor"
+
+	// Source describes how the token counts were obtained, so the UI can
+	// label a session's accuracy.
+	SourceExact      = "exact"      // read verbatim from a transcript usage block
+	SourceEstimate   = "estimate"   // tokenized locally (Cursor native agent)
+	SourceReconciled = "reconciled" // estimate corrected against a provider usage API
+)
+
+// Tokens is the per-turn token breakdown. Field names mirror the Claude Code
+// transcript usage object so the mapping stays obvious.
+type Tokens struct {
+	Input      int64 `json:"input"`
+	Output     int64 `json:"output"`
+	CacheRead  int64 `json:"cache_read"`
+	CacheWrite int64 `json:"cache_write"` // total cache-creation (5m + 1h)
+}
+
+// Cost is the dollar breakdown for one turn (or a session total). Each field
+// is the cost of the corresponding Tokens field; CacheWrite folds the 5m and
+// 1h creation costs together since they're priced at different rates.
+type Cost struct {
+	Input      float64 `json:"input"`
+	Output     float64 `json:"output"`
+	CacheRead  float64 `json:"cache_read"`
+	CacheWrite float64 `json:"cache_write"`
+	Total      float64 `json:"total"`
+	Currency   string  `json:"currency"`
+}
+
+// CostEvent is emitted once per priced assistant turn — the "request cost" the
+// status bar shows. It carries only counts, costs, and identifiers; the
+// transcript text that produced the counts is never included.
+type CostEvent struct {
+	V           int    `json:"v"`
+	Kind        string `json:"kind"` // always "cost_event"
+	Tool        string `json:"tool"`
+	SessionID   string `json:"session_id"`
+	RequestID   string `json:"request_id"` // dedup key (Claude Code requestId)
+	Timestamp   string `json:"ts"`
+	Model       string `json:"model"`
+	ModelPriced bool   `json:"model_priced"` // false => unknown model, cost is 0
+	Source      string `json:"source"`
+	Tokens      Tokens `json:"tokens"`
+	Cost        Cost   `json:"cost"`
+	CwdBase     string `json:"cwd_base"` // basename only — never the full path or prompt
+}
+
+// ModelTotal is one model's contribution to a session.
+type ModelTotal struct {
+	Model     string  `json:"model"`
+	Tokens    Tokens  `json:"tokens"`
+	CostTotal float64 `json:"cost_total"`
+}
+
+// SessionSummary is the rolling per-session aggregate — the "session cost" the
+// status bar shows. Emitted on startup (seeded from the transcript) and after
+// each new cost event.
+type SessionSummary struct {
+	V         int          `json:"v"`
+	Kind      string       `json:"kind"` // always "session_summary"
+	SessionID string       `json:"session_id"`
+	Tool      string       `json:"tool"`
+	Source    string       `json:"source"` // worst-case across the session's events
+	StartedAt string       `json:"started_at"`
+	UpdatedAt string       `json:"updated_at"`
+	Totals    SessionTotal `json:"totals"`
+	ByModel   []ModelTotal `json:"by_model"`
+}
+
+// SessionTotal is the flattened token+cost total for a session.
+type SessionTotal struct {
+	Input      int64   `json:"input"`
+	Output     int64   `json:"output"`
+	CacheRead  int64   `json:"cache_read"`
+	CacheWrite int64   `json:"cache_write"`
+	CostTotal  float64 `json:"cost_total"`
+	Currency   string  `json:"currency"`
+}

--- a/internal/cost/event.go
+++ b/internal/cost/event.go
@@ -66,11 +66,15 @@ type CostEvent struct {
 	CwdBase     string `json:"cwd_base"` // basename only — never the full path or prompt
 }
 
-// ModelTotal is one model's contribution to a session.
+// ModelTotal is one model's contribution to a session. ModelPriced is false
+// when the model isn't in the rate table (e.g. Cursor's `composer-*`): tokens
+// are still exact, but the cost is 0 and the UI should say "unpriced" rather
+// than imply the work was free.
 type ModelTotal struct {
-	Model     string  `json:"model"`
-	Tokens    Tokens  `json:"tokens"`
-	CostTotal float64 `json:"cost_total"`
+	Model       string  `json:"model"`
+	ModelPriced bool    `json:"model_priced"`
+	Tokens      Tokens  `json:"tokens"`
+	CostTotal   float64 `json:"cost_total"`
 }
 
 // SessionSummary is the rolling per-session aggregate — the "session cost" the

--- a/internal/cost/pricing.go
+++ b/internal/cost/pricing.go
@@ -1,0 +1,142 @@
+package cost
+
+import (
+	_ "embed"
+	"encoding/json"
+	"strings"
+)
+
+//go:embed pricing_data.json
+var bundledPricingJSON []byte
+
+// ModelPrice is one model's per-token USD rates. Field tags match the LiteLLM
+// model_prices table so the bundled snapshot (or an upstream refresh) parses
+// directly; CacheCreation1h is our addition for Anthropic's 1-hour cache TTL.
+type ModelPrice struct {
+	Input           float64 `json:"input_cost_per_token"`
+	Output          float64 `json:"output_cost_per_token"`
+	CacheCreation   float64 `json:"cache_creation_input_token_cost"`    // 5-minute TTL (1.25x input)
+	CacheCreation1h float64 `json:"cache_creation_input_token_cost_1h"` // 1-hour TTL (2x input)
+	CacheRead       float64 `json:"cache_read_input_token_cost"`
+}
+
+// Usage is the token breakdown read from a transcript turn. The Ephemeral*
+// fields capture Claude Code's split of cache-creation tokens by TTL; when a
+// transcript omits the split, CacheCreation is priced wholly at the 5m rate
+// (matching LiteLLM's single-rate behavior).
+type Usage struct {
+	InputTokens          int64
+	OutputTokens         int64
+	CacheReadInputTokens int64
+	CacheCreationInput   int64 // total, used when the TTL split is absent
+	Ephemeral5mTokens    int64
+	Ephemeral1hTokens    int64
+}
+
+// PriceTable holds the resolved per-model rates plus the alias map that maps
+// transcript model strings (often short aliases like "claude-opus-4-8" or
+// dated variants) onto table keys.
+type PriceTable struct {
+	models map[string]ModelPrice
+}
+
+// modelAliases maps transcript model strings that don't match a table key
+// directly onto one that does. Kept small on purpose — ResolvePrice also does
+// suffix-stripping and prefix matching, so this only needs the genuinely
+// irregular cases.
+var modelAliases = map[string]string{
+	"claude-3-5-haiku-20241022": "claude-3-5-haiku",
+	"claude-3-5-haiku-latest":   "claude-3-5-haiku",
+}
+
+// LoadBundledPriceTable parses the embedded snapshot. It never fails on a
+// well-formed build — the JSON is compiled in — but returns an error so a
+// future on-disk override path can share the signature.
+func LoadBundledPriceTable() (*PriceTable, error) {
+	return parsePriceTable(bundledPricingJSON)
+}
+
+func parsePriceTable(data []byte) (*PriceTable, error) {
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return nil, err
+	}
+	models := make(map[string]ModelPrice, len(raw))
+	for key, val := range raw {
+		if strings.HasPrefix(key, "_") {
+			continue // skip "_comment" and other metadata keys
+		}
+		var mp ModelPrice
+		if err := json.Unmarshal(val, &mp); err != nil {
+			continue // tolerate a malformed entry rather than fail the whole table
+		}
+		models[key] = mp
+	}
+	return &PriceTable{models: models}, nil
+}
+
+// ResolvePrice looks up a model's rates. Resolution order: exact key, alias
+// map, then progressively shorter dash-delimited prefixes (so a dated or
+// suffixed variant like "claude-opus-4-8-20260101" still resolves to
+// "claude-opus-4-8"). The bool is false when nothing matches — callers should
+// flag the event ModelPriced=false and charge zero rather than guess.
+func (t *PriceTable) ResolvePrice(model string) (ModelPrice, bool) {
+	if model == "" {
+		return ModelPrice{}, false
+	}
+	if mp, ok := t.models[model]; ok {
+		return mp, true
+	}
+	if canonical, ok := modelAliases[model]; ok {
+		if mp, ok := t.models[canonical]; ok {
+			return mp, true
+		}
+	}
+	// Strip trailing dash-delimited segments one at a time and retry, so dated
+	// or speed-suffixed IDs collapse to their base model key.
+	for trimmed := model; ; {
+		idx := strings.LastIndex(trimmed, "-")
+		if idx <= 0 {
+			break
+		}
+		trimmed = trimmed[:idx]
+		if mp, ok := t.models[trimmed]; ok {
+			return mp, true
+		}
+	}
+	return ModelPrice{}, false
+}
+
+// CostForUsage prices a usage block. It returns the dollar breakdown and the
+// total cache-creation token count (5m + 1h) folded for the Tokens struct.
+// When the 5m/1h split is present it prices each tier at its own rate;
+// otherwise it prices the whole CacheCreationInput total at the 5m rate.
+func CostForUsage(u Usage, mp ModelPrice) (Cost, int64) {
+	var cacheWriteTokens, cacheWriteCost = cacheWriteCostFor(u, mp)
+
+	c := Cost{
+		Input:      float64(u.InputTokens) * mp.Input,
+		Output:     float64(u.OutputTokens) * mp.Output,
+		CacheRead:  float64(u.CacheReadInputTokens) * mp.CacheRead,
+		CacheWrite: cacheWriteCost,
+		Currency:   Currency,
+	}
+	c.Total = c.Input + c.Output + c.CacheRead + c.CacheWrite
+	return c, cacheWriteTokens
+}
+
+// cacheWriteCostFor returns the total cache-creation token count and its cost,
+// honoring the 5m/1h split when the transcript provides it.
+func cacheWriteCostFor(u Usage, mp ModelPrice) (tokens int64, cost float64) {
+	rate1h := mp.CacheCreation1h
+	if rate1h == 0 {
+		rate1h = mp.CacheCreation // fall back to the 5m rate if 1h isn't priced
+	}
+	if u.Ephemeral5mTokens > 0 || u.Ephemeral1hTokens > 0 {
+		tokens = u.Ephemeral5mTokens + u.Ephemeral1hTokens
+		cost = float64(u.Ephemeral5mTokens)*mp.CacheCreation + float64(u.Ephemeral1hTokens)*rate1h
+		return tokens, cost
+	}
+	// No split available — price the lumped total at the 5m rate.
+	return u.CacheCreationInput, float64(u.CacheCreationInput) * mp.CacheCreation
+}

--- a/internal/cost/pricing_data.json
+++ b/internal/cost/pricing_data.json
@@ -90,5 +90,14 @@
     "cache_creation_input_token_cost": 0.000001,
     "cache_creation_input_token_cost_1h": 0.0000016,
     "cache_read_input_token_cost": 0.00000008
+  },
+  "_cursor_comment": "Cursor's own Composer models, from cursor.com/changelog/composer-2-5 (input/output only — Cursor publishes no separate cache rate, so cache tokens are reported but priced at 0). The exact -fast key must precede the prefix-trim fallback so it doesn't resolve to the cheaper Standard rate.",
+  "composer-2.5-fast": {
+    "input_cost_per_token": 0.000003,
+    "output_cost_per_token": 0.000015
+  },
+  "composer-2.5": {
+    "input_cost_per_token": 0.0000005,
+    "output_cost_per_token": 0.0000025
   }
 }

--- a/internal/cost/pricing_data.json
+++ b/internal/cost/pricing_data.json
@@ -1,0 +1,94 @@
+{
+  "_comment": "Curated USD per-token price snapshot, LiteLLM-compatible shape (github.com/BerriAI/litellm model_prices_and_context_window.json) with an added cache_creation_input_token_cost_1h field for Anthropic's 1-hour cache TTL. Cache rates follow Anthropic's documented multipliers: 5m write = 1.25x input, 1h write = 2x input, read = 0.1x input. To refresh, replace this file or fetch the upstream table; the resolver tolerates missing fields.",
+  "claude-fable-5": {
+    "input_cost_per_token": 0.00001,
+    "output_cost_per_token": 0.00005,
+    "cache_creation_input_token_cost": 0.0000125,
+    "cache_creation_input_token_cost_1h": 0.00002,
+    "cache_read_input_token_cost": 0.000001
+  },
+  "claude-mythos-5": {
+    "input_cost_per_token": 0.00001,
+    "output_cost_per_token": 0.00005,
+    "cache_creation_input_token_cost": 0.0000125,
+    "cache_creation_input_token_cost_1h": 0.00002,
+    "cache_read_input_token_cost": 0.000001
+  },
+  "claude-opus-4-8": {
+    "input_cost_per_token": 0.000005,
+    "output_cost_per_token": 0.000025,
+    "cache_creation_input_token_cost": 0.00000625,
+    "cache_creation_input_token_cost_1h": 0.00001,
+    "cache_read_input_token_cost": 0.0000005
+  },
+  "claude-opus-4-7": {
+    "input_cost_per_token": 0.000005,
+    "output_cost_per_token": 0.000025,
+    "cache_creation_input_token_cost": 0.00000625,
+    "cache_creation_input_token_cost_1h": 0.00001,
+    "cache_read_input_token_cost": 0.0000005
+  },
+  "claude-opus-4-6": {
+    "input_cost_per_token": 0.000005,
+    "output_cost_per_token": 0.000025,
+    "cache_creation_input_token_cost": 0.00000625,
+    "cache_creation_input_token_cost_1h": 0.00001,
+    "cache_read_input_token_cost": 0.0000005
+  },
+  "claude-opus-4-5": {
+    "input_cost_per_token": 0.000005,
+    "output_cost_per_token": 0.000025,
+    "cache_creation_input_token_cost": 0.00000625,
+    "cache_creation_input_token_cost_1h": 0.00001,
+    "cache_read_input_token_cost": 0.0000005
+  },
+  "claude-opus-4-1": {
+    "input_cost_per_token": 0.000015,
+    "output_cost_per_token": 0.000075,
+    "cache_creation_input_token_cost": 0.00001875,
+    "cache_creation_input_token_cost_1h": 0.00003,
+    "cache_read_input_token_cost": 0.0000015
+  },
+  "claude-opus-4-0": {
+    "input_cost_per_token": 0.000015,
+    "output_cost_per_token": 0.000075,
+    "cache_creation_input_token_cost": 0.00001875,
+    "cache_creation_input_token_cost_1h": 0.00003,
+    "cache_read_input_token_cost": 0.0000015
+  },
+  "claude-sonnet-4-6": {
+    "input_cost_per_token": 0.000003,
+    "output_cost_per_token": 0.000015,
+    "cache_creation_input_token_cost": 0.00000375,
+    "cache_creation_input_token_cost_1h": 0.000006,
+    "cache_read_input_token_cost": 0.0000003
+  },
+  "claude-sonnet-4-5": {
+    "input_cost_per_token": 0.000003,
+    "output_cost_per_token": 0.000015,
+    "cache_creation_input_token_cost": 0.00000375,
+    "cache_creation_input_token_cost_1h": 0.000006,
+    "cache_read_input_token_cost": 0.0000003
+  },
+  "claude-sonnet-4-0": {
+    "input_cost_per_token": 0.000003,
+    "output_cost_per_token": 0.000015,
+    "cache_creation_input_token_cost": 0.00000375,
+    "cache_creation_input_token_cost_1h": 0.000006,
+    "cache_read_input_token_cost": 0.0000003
+  },
+  "claude-haiku-4-5": {
+    "input_cost_per_token": 0.000001,
+    "output_cost_per_token": 0.000005,
+    "cache_creation_input_token_cost": 0.00000125,
+    "cache_creation_input_token_cost_1h": 0.000002,
+    "cache_read_input_token_cost": 0.0000001
+  },
+  "claude-3-5-haiku": {
+    "input_cost_per_token": 0.0000008,
+    "output_cost_per_token": 0.000004,
+    "cache_creation_input_token_cost": 0.000001,
+    "cache_creation_input_token_cost_1h": 0.0000016,
+    "cache_read_input_token_cost": 0.00000008
+  }
+}

--- a/internal/cost/store.go
+++ b/internal/cost/store.go
@@ -1,0 +1,166 @@
+package cost
+
+import (
+	"bufio"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sync"
+
+	"github.com/promptconduit/cli/internal/client"
+)
+
+// Modeled on internal/collect/store.go: an append-only NDJSON file that rotates
+// to <name>.1 past a size cap. This store is strictly local — it is the cost
+// feature's durable history and is never read by any code that talks to the
+// platform API.
+const (
+	costDirName    = "cost"
+	eventsFileName = "events.ndjson"
+	maxFileBytes   = int64(50 * 1024 * 1024)
+)
+
+// Store appends cost events to a local NDJSON file. Safe for concurrent
+// writers within a process.
+type Store struct {
+	path string
+	mu   sync.Mutex
+	f    *os.File
+	size int64
+}
+
+// StoreDir returns the on-disk directory the cost store lives in
+// (~/.config/promptconduit/cost), reusing the CLI's existing config-dir logic.
+func StoreDir() string {
+	return filepath.Join(client.ConfigDir(), costDirName)
+}
+
+// OpenStore opens (creating if needed) the cost events file under StoreDir.
+func OpenStore() (*Store, error) {
+	dir := StoreDir()
+	if dir == "" {
+		return nil, errors.New("cost: could not resolve config dir")
+	}
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return nil, fmt.Errorf("cost: mkdir store dir: %w", err)
+	}
+	path := filepath.Join(dir, eventsFileName)
+	f, size, err := openAppend(path)
+	if err != nil {
+		return nil, err
+	}
+	return &Store{path: path, f: f, size: size}, nil
+}
+
+func openAppend(path string) (*os.File, int64, error) {
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644)
+	if err != nil {
+		return nil, 0, err
+	}
+	info, err := f.Stat()
+	if err != nil {
+		_ = f.Close()
+		return nil, 0, err
+	}
+	return f, info.Size(), nil
+}
+
+// AppendEvent marshals and appends one cost event as a JSON line.
+func (s *Store) AppendEvent(e CostEvent) error {
+	data, err := json.Marshal(e)
+	if err != nil {
+		return err
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.writeLine(data)
+}
+
+func (s *Store) writeLine(data []byte) error {
+	if s.f == nil {
+		f, sz, err := openAppend(s.path)
+		if err != nil {
+			return err
+		}
+		s.f, s.size = f, sz
+	}
+	n, err := s.f.Write(append(data, '\n'))
+	s.size += int64(n)
+	if err != nil {
+		return err
+	}
+	if s.size > maxFileBytes {
+		if err := s.f.Close(); err != nil {
+			return err
+		}
+		s.f = nil
+		_ = os.Rename(s.path, s.path+".1")
+		f, _, err := openAppend(s.path)
+		if err != nil {
+			return err
+		}
+		s.f, s.size = f, 0
+	}
+	return nil
+}
+
+// Close flushes and closes the underlying file.
+func (s *Store) Close() error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.f == nil {
+		return nil
+	}
+	err := s.f.Close()
+	s.f = nil
+	return err
+}
+
+// ReadEvents returns every cost event in the active (non-rotated) file. Used by
+// `cost history`/`cost session` for aggregation. Malformed lines are skipped.
+func ReadEvents() ([]CostEvent, error) {
+	dir := StoreDir()
+	if dir == "" {
+		return nil, nil
+	}
+	f, err := os.Open(filepath.Join(dir, eventsFileName))
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	defer f.Close()
+
+	// Dedup by request id: separate `cost watch` runs each re-seed and re-append
+	// a session's turns, so the same request can appear many times on disk.
+	// Request ids are globally unique, so first-seen-wins yields correct totals
+	// regardless of how often the watcher ran.
+	var out []CostEvent
+	seen := make(map[string]bool)
+	scanner := bufio.NewScanner(f)
+	scanner.Buffer(make([]byte, 0, 64*1024), 4*1024*1024)
+	for scanner.Scan() {
+		var e CostEvent
+		if err := json.Unmarshal(scanner.Bytes(), &e); err != nil {
+			continue
+		}
+		if e.Kind != "cost_event" {
+			continue
+		}
+		if e.RequestID != "" {
+			if seen[e.RequestID] {
+				continue
+			}
+			seen[e.RequestID] = true
+		}
+		out = append(out, e)
+	}
+	if err := scanner.Err(); err != nil && !errors.Is(err, io.EOF) {
+		return nil, err
+	}
+	return out, nil
+}

--- a/internal/cost/watcher.go
+++ b/internal/cost/watcher.go
@@ -1,0 +1,305 @@
+package cost
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"io"
+	"os"
+	"sort"
+	"sync"
+	"time"
+
+	"github.com/promptconduit/cli/internal/outbound"
+)
+
+// rescanInterval is how often the watcher looks for newly-created or recently
+// touched transcripts (a new or resumed session) to start tailing.
+const rescanInterval = 3 * time.Second
+
+// recentWindow bounds which not-yet-tailed transcripts a rescan picks up: only
+// those modified within this window count as "live" sessions worth tailing.
+const recentWindow = 2 * time.Minute
+
+// Watcher aggregates priced turns into per-session running totals and emits
+// CostEvent + SessionSummary records. It owns all dedup and accumulation state;
+// the file-tailing orchestration lives in Run.
+type Watcher struct {
+	table *PriceTable
+	store *Store    // optional; nil disables on-disk persistence
+	out   io.Writer // newline-delimited JSON sink (e.g. stdout)
+	emit  bool      // emit per-turn CostEvents (false => summaries only)
+
+	mu       sync.Mutex
+	seen     map[string]bool
+	sessions map[string]*sessionState
+}
+
+type sessionState struct {
+	summary SessionSummary
+	byModel map[string]*ModelTotal
+}
+
+// NewWatcher builds a watcher. Pass emitEvents=false for one-shot summaries
+// (e.g. `cost session`), true for the live `cost watch` stream.
+func NewWatcher(table *PriceTable, store *Store, out io.Writer, emitEvents bool) *Watcher {
+	return &Watcher{
+		table:    table,
+		store:    store,
+		out:      out,
+		emit:     emitEvents,
+		seen:     make(map[string]bool),
+		sessions: make(map[string]*sessionState),
+	}
+}
+
+// Run seeds the newest transcript per directory (to populate session totals
+// without flooding the stream), tails it for new turns, and periodically
+// rescans for new/resumed sessions. Returns when ctx is cancelled.
+func (w *Watcher) Run(ctx context.Context, dirs []string) error {
+	var wg sync.WaitGroup
+	tailed := make(map[string]bool)
+	var tmu sync.Mutex
+
+	startTail := func(path string) {
+		tmu.Lock()
+		if tailed[path] {
+			tmu.Unlock()
+			return
+		}
+		tailed[path] = true
+		tmu.Unlock()
+
+		sessionID := sessionIDFromPath(path)
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for raw := range outbound.Tail(ctx, path, 0) { // start at current end
+				w.streamLine(raw, sessionID)
+			}
+		}()
+	}
+
+	// Initial pass: seed + tail the newest transcript in each directory.
+	for _, dir := range dirs {
+		files := jsonlFiles(dir)
+		if len(files) == 0 {
+			continue
+		}
+		w.seedFile(files[0])
+		startTail(files[0])
+	}
+
+	// Rescan loop: pick up newly-created or recently-modified transcripts.
+	ticker := time.NewTicker(rescanInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			wg.Wait()
+			return nil
+		case <-ticker.C:
+			cutoff := nowUnixNano() - int64(recentWindow)
+			for _, dir := range dirs {
+				for _, path := range jsonlFiles(dir) {
+					tmu.Lock()
+					already := tailed[path]
+					tmu.Unlock()
+					if already {
+						continue
+					}
+					if info, err := os.Stat(path); err == nil && info.ModTime().UnixNano() >= cutoff {
+						startTail(path)
+					}
+				}
+			}
+		}
+	}
+}
+
+// SeedNewest seeds the single newest transcript across the given directories
+// and emits its SessionSummary. Used by the one-shot `cost session` command.
+func (w *Watcher) SeedNewest(dirs []string) {
+	var newest string
+	var newestMod int64
+	for _, dir := range dirs {
+		files := jsonlFiles(dir)
+		if len(files) == 0 {
+			continue
+		}
+		if info, err := os.Stat(files[0]); err == nil && info.ModTime().UnixNano() > newestMod {
+			newestMod = info.ModTime().UnixNano()
+			newest = files[0]
+		}
+	}
+	if newest != "" {
+		w.seedFile(newest)
+	}
+}
+
+// seedFile fully parses one transcript, accumulating its turns into the session
+// aggregate without emitting per-turn events, then emits one SessionSummary.
+func (w *Watcher) seedFile(path string) {
+	f, err := os.Open(path)
+	if err != nil {
+		return
+	}
+	defer f.Close()
+
+	sessionFallback := sessionIDFromPath(path)
+	scanner := bufio.NewScanner(f)
+	scanner.Buffer(make([]byte, 0, 64*1024), 100*1024*1024)
+
+	var lastSession string
+	for scanner.Scan() {
+		ev, _, ok := parseClaudeCodeLine(scanner.Bytes(), w.table, sessionFallback)
+		if !ok {
+			continue
+		}
+		if w.apply(ev) {
+			lastSession = ev.SessionID
+			if w.store != nil {
+				_ = w.store.AppendEvent(ev)
+			}
+		}
+	}
+	if lastSession != "" {
+		w.emitSummary(lastSession)
+	}
+}
+
+// streamLine handles one newly-appended transcript line: parse, dedup,
+// aggregate, persist, and emit a CostEvent (if enabled) plus the updated
+// SessionSummary.
+func (w *Watcher) streamLine(line []byte, sessionFallback string) {
+	ev, _, ok := parseClaudeCodeLine(line, w.table, sessionFallback)
+	if !ok {
+		return
+	}
+	if !w.apply(ev) {
+		return // duplicate
+	}
+	if w.store != nil {
+		_ = w.store.AppendEvent(ev)
+	}
+	if w.emit {
+		w.emitJSON(ev)
+	}
+	w.emitSummary(ev.SessionID)
+}
+
+// apply folds an event into the session aggregate. Returns false if the event
+// was already seen (deduped by request id).
+func (w *Watcher) apply(ev CostEvent) bool {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	if ev.RequestID != "" {
+		if w.seen[ev.RequestID] {
+			return false
+		}
+		w.seen[ev.RequestID] = true
+	}
+
+	st := w.sessions[ev.SessionID]
+	if st == nil {
+		st = &sessionState{
+			summary: SessionSummary{
+				V:         SchemaVersion,
+				Kind:      "session_summary",
+				SessionID: ev.SessionID,
+				Tool:      ev.Tool,
+				StartedAt: ev.Timestamp,
+			},
+			byModel: make(map[string]*ModelTotal),
+		}
+		w.sessions[ev.SessionID] = st
+	}
+
+	t := &st.summary.Totals
+	t.Input += ev.Tokens.Input
+	t.Output += ev.Tokens.Output
+	t.CacheRead += ev.Tokens.CacheRead
+	t.CacheWrite += ev.Tokens.CacheWrite
+	t.CostTotal += ev.Cost.Total
+	t.Currency = Currency
+
+	mt := st.byModel[ev.Model]
+	if mt == nil {
+		mt = &ModelTotal{Model: ev.Model}
+		st.byModel[ev.Model] = mt
+	}
+	mt.Tokens.Input += ev.Tokens.Input
+	mt.Tokens.Output += ev.Tokens.Output
+	mt.Tokens.CacheRead += ev.Tokens.CacheRead
+	mt.Tokens.CacheWrite += ev.Tokens.CacheWrite
+	mt.CostTotal += ev.Cost.Total
+
+	if st.summary.StartedAt == "" {
+		st.summary.StartedAt = ev.Timestamp
+	}
+	st.summary.UpdatedAt = ev.Timestamp
+	st.summary.Source = worstSource(st.summary.Source, ev.Source)
+	return true
+}
+
+// emitSummary writes the current SessionSummary for a session.
+func (w *Watcher) emitSummary(sessionID string) {
+	w.mu.Lock()
+	st := w.sessions[sessionID]
+	if st == nil {
+		w.mu.Unlock()
+		return
+	}
+	summary := st.summary
+	summary.ByModel = make([]ModelTotal, 0, len(st.byModel))
+	for _, mt := range st.byModel {
+		summary.ByModel = append(summary.ByModel, *mt)
+	}
+	w.mu.Unlock()
+
+	sort.Slice(summary.ByModel, func(i, j int) bool {
+		return summary.ByModel[i].CostTotal > summary.ByModel[j].CostTotal
+	})
+	w.emitJSON(summary)
+}
+
+// emitJSON writes one record as a JSON line, serializing writes so concurrent
+// tail goroutines don't interleave output.
+func (w *Watcher) emitJSON(v any) {
+	data, err := json.Marshal(v)
+	if err != nil {
+		return
+	}
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	_, _ = w.out.Write(append(data, '\n'))
+}
+
+// worstSource returns the least-accurate of two source labels for a session.
+func worstSource(a, b string) string {
+	if sourceRank(b) > sourceRank(a) {
+		return b
+	}
+	if a == "" {
+		return b
+	}
+	return a
+}
+
+func sourceRank(s string) int {
+	switch s {
+	case SourceEstimate:
+		return 2
+	case SourceReconciled:
+		return 1
+	case SourceExact:
+		return 0
+	default:
+		return -1
+	}
+}
+
+// nowUnixNano is a tiny indirection so the rescan loop's time read is the only
+// wall-clock dependency and is easy to reason about in tests.
+func nowUnixNano() int64 { return time.Now().UnixNano() }

--- a/internal/cost/watcher.go
+++ b/internal/cost/watcher.go
@@ -53,10 +53,12 @@ func NewWatcher(table *PriceTable, store *Store, out io.Writer, emitEvents bool)
 	}
 }
 
-// Run seeds the newest transcript per directory (to populate session totals
-// without flooding the stream), tails it for new turns, and periodically
-// rescans for new/resumed sessions. Returns when ctx is cancelled.
-func (w *Watcher) Run(ctx context.Context, dirs []string) error {
+// Run watches two kinds of sources: Claude Code transcript directories (parsed
+// per line) and Cursor cost-feed files (pre-priced CostEvent lines written by
+// `cost hook`). It seeds each (to populate session totals without flooding the
+// stream), tails for new entries, and periodically rescans Claude Code dirs for
+// new/resumed sessions. Returns when ctx is cancelled.
+func (w *Watcher) Run(ctx context.Context, dirs []string, cursorFeeds []string) error {
 	var wg sync.WaitGroup
 	tailed := make(map[string]bool)
 	var tmu sync.Mutex
@@ -80,14 +82,49 @@ func (w *Watcher) Run(ctx context.Context, dirs []string) error {
 		}()
 	}
 
-	// Initial pass: seed + tail the newest transcript in each directory.
+	// Cursor feeds carry already-priced CostEvent JSON lines, so they tail with
+	// a different handler (unmarshal, not parse-transcript).
+	startCursorTail := func(path string) {
+		tmu.Lock()
+		if tailed[path] {
+			tmu.Unlock()
+			return
+		}
+		tailed[path] = true
+		tmu.Unlock()
+
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for raw := range outbound.Tail(ctx, path, 0) {
+				w.streamCostEventLine(raw)
+			}
+		}()
+	}
+
+	// Seed all sources first (accumulate only — no per-turn emits), so the
+	// initial snapshot below reflects complete session totals.
+	var ccNewest []string
 	for _, dir := range dirs {
 		files := jsonlFiles(dir)
 		if len(files) == 0 {
 			continue
 		}
 		w.seedFile(files[0])
-		startTail(files[0])
+		ccNewest = append(ccNewest, files[0])
+	}
+	for _, feed := range cursorFeeds {
+		w.seedCursorFeed(feed)
+	}
+
+	// Emit one snapshot summary per known session, then start tailing for
+	// live per-turn updates.
+	w.emitAllSessions()
+	for _, p := range ccNewest {
+		startTail(p)
+	}
+	for _, feed := range cursorFeeds {
+		startCursorTail(feed)
 	}
 
 	// Rescan loop: pick up newly-created or recently-modified transcripts.
@@ -137,6 +174,15 @@ func (w *Watcher) SeedNewest(dirs []string) {
 	}
 }
 
+// SeedCursorFeeds seeds each Cursor cost feed and emits its session summaries.
+// Used by the one-shot `cost session` command so a Cursor-only workspace still
+// shows a total.
+func (w *Watcher) SeedCursorFeeds(feeds []string) {
+	for _, feed := range feeds {
+		w.seedCursorFeed(feed)
+	}
+}
+
 // seedFile fully parses one transcript, accumulating its turns into the session
 // aggregate without emitting per-turn events, then emits one SessionSummary.
 func (w *Watcher) seedFile(path string) {
@@ -150,22 +196,58 @@ func (w *Watcher) seedFile(path string) {
 	scanner := bufio.NewScanner(f)
 	scanner.Buffer(make([]byte, 0, 64*1024), 100*1024*1024)
 
-	var lastSession string
 	for scanner.Scan() {
 		ev, _, ok := parseClaudeCodeLine(scanner.Bytes(), w.table, sessionFallback)
 		if !ok {
 			continue
 		}
-		if w.apply(ev) {
-			lastSession = ev.SessionID
-			if w.store != nil {
-				_ = w.store.AppendEvent(ev)
-			}
+		if w.apply(ev) && w.store != nil {
+			_ = w.store.AppendEvent(ev)
 		}
 	}
-	if lastSession != "" {
-		w.emitSummary(lastSession)
+}
+
+// seedCursorFeed fully reads a Cursor cost feed (already-priced CostEvent
+// lines), accumulating into session aggregates without per-turn emits, then
+// emits one SessionSummary per session it touched.
+func (w *Watcher) seedCursorFeed(path string) {
+	f, err := os.Open(path)
+	if err != nil {
+		return
 	}
+	defer f.Close()
+
+	scanner := bufio.NewScanner(f)
+	scanner.Buffer(make([]byte, 0, 64*1024), 8*1024*1024)
+	for scanner.Scan() {
+		var ev CostEvent
+		if err := json.Unmarshal(scanner.Bytes(), &ev); err != nil || ev.Kind != "cost_event" {
+			continue
+		}
+		if w.apply(ev) && w.store != nil {
+			_ = w.store.AppendEvent(ev)
+		}
+	}
+}
+
+// streamCostEventLine handles one newly-appended Cursor feed line: unmarshal a
+// pre-priced CostEvent, dedup, aggregate, persist, and emit it plus the updated
+// SessionSummary.
+func (w *Watcher) streamCostEventLine(line []byte) {
+	var ev CostEvent
+	if err := json.Unmarshal(line, &ev); err != nil || ev.Kind != "cost_event" {
+		return
+	}
+	if !w.apply(ev) {
+		return
+	}
+	if w.store != nil {
+		_ = w.store.AppendEvent(ev)
+	}
+	if w.emit {
+		w.emitJSON(ev)
+	}
+	w.emitSummary(ev.SessionID)
 }
 
 // streamLine handles one newly-appended transcript line: parse, dedup,
@@ -226,7 +308,7 @@ func (w *Watcher) apply(ev CostEvent) bool {
 
 	mt := st.byModel[ev.Model]
 	if mt == nil {
-		mt = &ModelTotal{Model: ev.Model}
+		mt = &ModelTotal{Model: ev.Model, ModelPriced: ev.ModelPriced}
 		st.byModel[ev.Model] = mt
 	}
 	mt.Tokens.Input += ev.Tokens.Input
@@ -241,6 +323,36 @@ func (w *Watcher) apply(ev CostEvent) bool {
 	st.summary.UpdatedAt = ev.Timestamp
 	st.summary.Source = worstSource(st.summary.Source, ev.Source)
 	return true
+}
+
+// emitAllSessions emits a snapshot summary for every known session.
+func (w *Watcher) emitAllSessions() {
+	w.mu.Lock()
+	ids := make([]string, 0, len(w.sessions))
+	for id := range w.sessions {
+		ids = append(ids, id)
+	}
+	w.mu.Unlock()
+	for _, id := range ids {
+		w.emitSummary(id)
+	}
+}
+
+// EmitLatestSession emits only the most-recently-updated session's summary.
+// Used by the one-shot `cost session` command, where a Cursor workspace feed
+// may hold many past conversations but the user wants just the current one.
+func (w *Watcher) EmitLatestSession() {
+	w.mu.Lock()
+	var latest, latestTs string
+	for id, st := range w.sessions {
+		if latest == "" || st.summary.UpdatedAt > latestTs {
+			latest, latestTs = id, st.summary.UpdatedAt
+		}
+	}
+	w.mu.Unlock()
+	if latest != "" {
+		w.emitSummary(latest)
+	}
 }
 
 // emitSummary writes the current SessionSummary for a session.


### PR DESCRIPTION
## What

Adds a new `promptconduit cost` capability that computes AI coding-session spend **in real time, entirely on-device**. This is the CLI half of the "tolken" realtime cost-meter idea, built as a local-only feature inside PromptConduit (per product decision) — the editor extension (separate, not yet a repo) consumes its `cost watch --json` stream.

## Commands

- `promptconduit cost watch [--cwd PATH] [--all] [--json]` — long-running; tails transcripts and emits newline-delimited `cost_event` / `session_summary` JSON (the extension's feed). Mirrors to a local store.
- `promptconduit cost session` — current session's cost summary.
- `promptconduit cost history [--days N]` — aggregate from the local store.

## How it works

`internal/cost/` reads Claude Code transcripts (`~/.claude/projects/*/*.jsonl`), prices each assistant turn from `message.usage` against a `go:embed`-ed LiteLLM-shape rate table, dedups by `requestId`, and aggregates per-session totals. The 5-minute vs 1-hour cache-creation split is priced at its true rate — pricing 1h tokens at the 1.25× rate undercounts cache-heavy sessions by ~18% (verified against a live session: \$11.89 vs ~\$9.77).

Cursor's native agent (estimate + reconcile) is a later milestone — Cursor exposes no token data to hooks or on disk (verified), so it needs estimation, unlike Claude Code.

## Privacy

100% local. `TestPrivacy_NoPlatformSendInCostPackage` fails the build if `internal/cost` ever references the platform send path (`SendEnvelope` / `client.NewClient` / `DefaultAPIURL`). The cost feature needs no API key and makes no network calls.

## Verification

- `go build` / `go vet` / `gofmt` clean; `go test ./internal/cost/` passes (pricing math against a real usage block, alias resolution, parsing, project-path encoding, privacy guard).
- Exercised live against a real Claude Code session: `cost session`, `cost watch` (streamed as the session ran), `cost history` (deduped correctly).

🤖 Generated with [Claude Code](https://claude.com/claude-code)