### PR TITLE
v0.5.0 — cost meter in standard setup, multi-tool install, friendly UX

### DIFF
--- a/cmd/cost.go
+++ b/cmd/cost.go
@@ -9,7 +9,6 @@ import (
 	"os/signal"
 	"path/filepath"
 	"sort"
-	"strings"
 	"syscall"
 	"time"
 
@@ -28,23 +27,26 @@ var costCmd = &cobra.Command{
 	Use:   "cost",
 	Short: "Real-time AI token cost for your sessions (100% local)",
 	Long: `Compute what your AI coding sessions cost, in real time, entirely on
-your machine. The cost feature reads local transcripts, prices each turn against
-a bundled rate table, and never sends any of your data to the PromptConduit
-platform or anywhere else.
+your machine. The cost feature reads local transcripts/hook payloads, prices
+each turn against a bundled rate table, and never sends any of your data to the
+PromptConduit platform or anywhere else.
+
+Run with no subcommand to see the current session's cost.
 
 Subcommands:
+  (none)          Show the current session's cost summary
   watch           Stream cost events as your session runs (the editor extension's feed)
-  session         Print the current session's cost summary
+  session         Same as running 'cost' with no subcommand
   history         Aggregate cost over the last N days
-  install-hooks   Wire the local Cursor cost hook into ~/.cursor/hooks.json
-  uninstall-hooks Remove it
+  refresh-pricing Fetch the latest public model-price table (opt-in)
 
-Prices both Claude Code (exact token counts from the transcript) and Cursor
-(exact token counts from its agent hooks — run install-hooks first). Models
-not in the bundled rate table are reported with exact tokens but flagged
-unpriced rather than guessed.`,
+Cost tracking is part of the standard setup: 'promptconduit install cursor'
+wires the hooks that capture Cursor's exact token usage, and Claude Code cost
+comes from its local transcripts automatically. Models not in the rate table are
+reported with exact tokens but flagged unpriced rather than guessed.`,
 	SilenceUsage:  true,
 	SilenceErrors: true,
+	RunE:          runCostSession, // bare 'promptconduit cost' shows the current session
 }
 
 var costWatchCmd = &cobra.Command{
@@ -71,31 +73,6 @@ var costHistoryCmd = &cobra.Command{
 	RunE:          runCostHistory,
 }
 
-var costHookCmd = &cobra.Command{
-	Use:           "hook",
-	Short:         "Record a Cursor agent hook payload's cost (local-only; for ~/.cursor/hooks.json)",
-	Hidden:        true,
-	SilenceUsage:  true,
-	SilenceErrors: true,
-	RunE:          runCostHook,
-}
-
-var costInstallHooksCmd = &cobra.Command{
-	Use:           "install-hooks",
-	Short:         "Wire the local Cursor cost hook into ~/.cursor/hooks.json",
-	SilenceUsage:  true,
-	SilenceErrors: true,
-	RunE:          runCostInstallHooks,
-}
-
-var costUninstallHooksCmd = &cobra.Command{
-	Use:           "uninstall-hooks",
-	Short:         "Remove the Cursor cost hook from ~/.cursor/hooks.json",
-	SilenceUsage:  true,
-	SilenceErrors: true,
-	RunE:          runCostUninstallHooks,
-}
-
 // litellmPricingURL is the public, maintained model-price table the optional
 // refresh fetches. It contains no user data; the request is a plain GET.
 // NOTE: the file lives at the repo ROOT, not under litellm/ (the latter 404s).
@@ -119,11 +96,15 @@ file.`,
 
 func init() {
 	costWatchCmd.Flags().StringVar(&costCwd, "cwd", "", "workspace directory to scope to (default: current directory)")
-	costWatchCmd.Flags().BoolVar(&costAll, "all", false, "watch every Claude Code project, not just the current workspace")
-	costWatchCmd.Flags().BoolVar(&costJSON, "json", true, "emit newline-delimited JSON (the only format today)")
+	costWatchCmd.Flags().BoolVar(&costAll, "all", false, "watch every project, not just the current workspace")
+	costWatchCmd.Flags().BoolVar(&costJSON, "json", true, "emit newline-delimited JSON (the editor extension's feed)")
 
-	costSessionCmd.Flags().StringVar(&costCwd, "cwd", "", "workspace directory to scope to (default: current directory)")
-	costSessionCmd.Flags().BoolVar(&costJSON, "json", true, "emit JSON (the only format today)")
+	// Bare `cost` and `cost session` share behavior: human-readable by default,
+	// --json for scripts. They bind the same package vars (only one runs).
+	for _, c := range []*cobra.Command{costCmd, costSessionCmd} {
+		c.Flags().StringVar(&costCwd, "cwd", "", "workspace directory to scope to (default: current directory)")
+		c.Flags().BoolVar(&costJSON, "json", false, "emit JSON instead of a human-readable summary")
+	}
 
 	costHistoryCmd.Flags().IntVar(&costDays, "days", 7, "number of days to include")
 	costHistoryCmd.Flags().BoolVar(&costJSON, "json", false, "emit JSON instead of a table")
@@ -131,9 +112,6 @@ func init() {
 	costCmd.AddCommand(costWatchCmd)
 	costCmd.AddCommand(costSessionCmd)
 	costCmd.AddCommand(costHistoryCmd)
-	costCmd.AddCommand(costHookCmd)
-	costCmd.AddCommand(costInstallHooksCmd)
-	costCmd.AddCommand(costUninstallHooksCmd)
 	costCmd.AddCommand(costRefreshPricingCmd)
 }
 
@@ -237,159 +215,49 @@ func runCostSession(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return fmt.Errorf("load pricing table: %w", err)
 	}
-	dirs, err := cost.ResolveDirs(resolveCwd(), false)
+	cwd := resolveCwd()
+	dirs, err := cost.ResolveDirs(cwd, false)
 	if err != nil {
 		return fmt.Errorf("resolve transcript directories: %w", err)
 	}
-	w := cost.NewWatcher(table, nil, cmd.OutOrStdout(), false)
+
+	// We read the summary directly rather than stream it, so the watcher's emit
+	// sink is discarded.
+	w := cost.NewWatcher(table, nil, io.Discard, false)
 	w.SeedNewest(dirs)
-	w.SeedCursorFeeds(cost.CursorFeedPaths(resolveCwd(), false))
-	w.EmitLatestSession()
-	return nil
-}
+	w.SeedCursorFeeds(cost.CursorFeedPaths(cwd, false))
 
-func runCostHook(cmd *cobra.Command, args []string) error {
-	// Always tell the agent to continue, no matter what — a cost hook must
-	// never block or fail the editor.
-	defer fmt.Fprintln(cmd.OutOrStdout(), `{"continue": true}`)
-
-	raw, err := io.ReadAll(cmd.InOrStdin())
-	if err != nil || len(raw) == 0 {
-		return nil
-	}
-	table, err := cost.LoadBundledPriceTable()
-	if err != nil {
-		return nil
-	}
-	ev, cwd, ok := cost.ParseCursorHookPayload(raw, table)
+	summary, ok := w.LatestSummary()
+	out := cmd.OutOrStdout()
 	if !ok {
-		return nil // not a token-bearing Cursor event — nothing to record
-	}
-	ev.Timestamp = time.Now().UTC().Format(time.RFC3339)
-	_ = cost.AppendCursorEvent(ev, cwd) // best-effort, local-only
-	return nil
-}
-
-// cursorCostHooks are the Cursor agent events the cost hook listens on. Both
-// carry identical per-generation tokens; the watcher dedups by generation_id,
-// so installing both is safe and resilient.
-var cursorCostHookEvents = []string{"afterAgentResponse", "stop"}
-
-func runCostInstallHooks(cmd *cobra.Command, args []string) error {
-	exe, err := osExecutable()
-	if err != nil {
-		return err
-	}
-	home, err := os.UserHomeDir()
-	if err != nil {
-		return err
-	}
-	path := filepath.Join(home, ".cursor", "hooks.json")
-
-	settings := map[string]interface{}{}
-	if data, err := os.ReadFile(path); err == nil {
-		_ = json.Unmarshal(data, &settings)
-	}
-	hooks, _ := settings["hooks"].(map[string]interface{})
-	if hooks == nil {
-		hooks = map[string]interface{}{}
-	}
-
-	hookCmd := fmt.Sprintf("%s cost hook", exe)
-	for _, event := range cursorCostHookEvents {
-		entries, _ := hooks[event].([]interface{})
-		// Drop any prior cost-hook entry so re-install is idempotent.
-		kept := entries[:0:0]
-		for _, e := range entries {
-			if m, ok := e.(map[string]interface{}); ok {
-				if c, _ := m["command"].(string); containsCostHook(c) {
-					continue
-				}
-			}
-			kept = append(kept, e)
-		}
-		kept = append(kept, map[string]interface{}{"command": hookCmd})
-		hooks[event] = kept
-	}
-	settings["hooks"] = hooks
-	if settings["version"] == nil {
-		settings["version"] = 1
-	}
-
-	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
-		return err
-	}
-	data, err := json.MarshalIndent(settings, "", "  ")
-	if err != nil {
-		return err
-	}
-	if err := os.WriteFile(path, data, 0o644); err != nil {
-		return err
-	}
-	fmt.Fprintf(cmd.OutOrStdout(), "Installed Cursor cost hooks (%v) in %s\n", cursorCostHookEvents, path)
-	fmt.Fprintln(cmd.OutOrStdout(), "Run `promptconduit cost watch` (or the editor extension) to see live cost.")
-	return nil
-}
-
-func runCostUninstallHooks(cmd *cobra.Command, args []string) error {
-	home, err := os.UserHomeDir()
-	if err != nil {
-		return err
-	}
-	path := filepath.Join(home, ".cursor", "hooks.json")
-	data, err := os.ReadFile(path)
-	if err != nil {
-		fmt.Fprintln(cmd.OutOrStdout(), "No Cursor hooks file — nothing to remove.")
+		fmt.Fprintln(out, "No AI session cost recorded yet for this workspace.")
+		fmt.Fprintln(out, "Use Claude Code here, or run `promptconduit install cursor` and use Cursor, then try again.")
 		return nil
 	}
-	settings := map[string]interface{}{}
-	if err := json.Unmarshal(data, &settings); err != nil {
-		return err
-	}
-	if hooks, ok := settings["hooks"].(map[string]interface{}); ok {
-		for event, v := range hooks {
-			entries, _ := v.([]interface{})
-			kept := entries[:0:0]
-			for _, e := range entries {
-				if m, ok := e.(map[string]interface{}); ok {
-					if c, _ := m["command"].(string); containsCostHook(c) {
-						continue
-					}
-				}
-				kept = append(kept, e)
-			}
-			if len(kept) == 0 {
-				delete(hooks, event)
-			} else {
-				hooks[event] = kept
-			}
+	if costJSON {
+		data, err := json.Marshal(summary)
+		if err != nil {
+			return err
 		}
+		fmt.Fprintln(out, string(data))
+		return nil
 	}
-	out, err := json.MarshalIndent(settings, "", "  ")
-	if err != nil {
-		return err
-	}
-	if err := os.WriteFile(path, out, 0o644); err != nil {
-		return err
-	}
-	fmt.Fprintf(cmd.OutOrStdout(), "Removed Cursor cost hooks from %s\n", path)
+	renderSessionHuman(out, summary)
 	return nil
 }
 
-// containsCostHook reports whether a hook command string is our cost hook
-// (`<binary> cost hook`), so install/uninstall can find and replace just ours.
-func containsCostHook(command string) bool {
-	return strings.HasSuffix(command, "cost hook")
-}
-
-// osExecutable resolves the running binary's path (indirection kept tiny so the
-// install command reads cleanly).
-func osExecutable() (string, error) {
-	exe, err := os.Executable()
-	if err != nil {
-		return "", err
+// renderSessionHuman prints a friendly one-screen cost summary.
+func renderSessionHuman(out io.Writer, s cost.SessionSummary) {
+	fmt.Fprintf(out, "AI session cost — %s  (%s)\n", s.Tool, s.Source)
+	fmt.Fprintf(out, "  Total: $%.4f %s\n", s.Totals.CostTotal, s.Totals.Currency)
+	for _, m := range s.ByModel {
+		costStr := fmt.Sprintf("$%.4f", m.CostTotal)
+		if !m.ModelPriced {
+			costStr = "unpriced"
+		}
+		fmt.Fprintf(out, "    %-22s %-10s  in %d · out %d · cache-read %d · cache-write %d\n",
+			m.Model, costStr, m.Tokens.Input, m.Tokens.Output, m.Tokens.CacheRead, m.Tokens.CacheWrite)
 	}
-	return filepath.EvalSymlinks(exe)
 }
 
 func runCostHistory(cmd *cobra.Command, args []string) error {

--- a/cmd/cost.go
+++ b/cmd/cost.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"net/http"
 	"os"
 	"os/signal"
 	"path/filepath"
@@ -95,6 +96,27 @@ var costUninstallHooksCmd = &cobra.Command{
 	RunE:          runCostUninstallHooks,
 }
 
+// litellmPricingURL is the public, maintained model-price table the optional
+// refresh fetches. It contains no user data; the request is a plain GET.
+// NOTE: the file lives at the repo ROOT, not under litellm/ (the latter 404s).
+const litellmPricingURL = "https://raw.githubusercontent.com/BerriAI/litellm/main/model_prices_and_context_window.json"
+
+var costRefreshPricingCmd = &cobra.Command{
+	Use:   "refresh-pricing",
+	Short: "Fetch the latest public model-price table and cache it locally (opt-in)",
+	Long: `Fetch LiteLLM's public model_prices_and_context_window.json and cache it at
+~/.config/promptconduit/cost/pricing.json. The curated built-in rates always
+take precedence; the cache only adds coverage for models the built-in table
+doesn't include.
+
+This is the only command that touches the network, it is never run
+automatically, and it sends none of your data — it's a plain GET of a public
+file.`,
+	SilenceUsage:  true,
+	SilenceErrors: true,
+	RunE:          runCostRefreshPricing,
+}
+
 func init() {
 	costWatchCmd.Flags().StringVar(&costCwd, "cwd", "", "workspace directory to scope to (default: current directory)")
 	costWatchCmd.Flags().BoolVar(&costAll, "all", false, "watch every Claude Code project, not just the current workspace")
@@ -112,6 +134,47 @@ func init() {
 	costCmd.AddCommand(costHookCmd)
 	costCmd.AddCommand(costInstallHooksCmd)
 	costCmd.AddCommand(costUninstallHooksCmd)
+	costCmd.AddCommand(costRefreshPricingCmd)
+}
+
+func runCostRefreshPricing(cmd *cobra.Command, args []string) error {
+	out := cmd.OutOrStdout()
+	fmt.Fprintf(cmd.ErrOrStderr(), "Fetching public price table (no data sent): %s\n", litellmPricingURL)
+
+	client := &http.Client{Timeout: 20 * time.Second}
+	req, err := http.NewRequestWithContext(cmd.Context(), http.MethodGet, litellmPricingURL, nil)
+	if err != nil {
+		return err
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return fmt.Errorf("fetch pricing: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("fetch pricing: HTTP %d", resp.StatusCode)
+	}
+	data, err := io.ReadAll(io.LimitReader(resp.Body, 32*1024*1024))
+	if err != nil {
+		return fmt.Errorf("read pricing: %w", err)
+	}
+
+	// Validate it parses before caching, so a bad fetch can't poison the table.
+	n, err := cost.ValidatePricingData(data)
+	if err != nil {
+		return fmt.Errorf("fetched pricing did not parse: %w", err)
+	}
+
+	path := cost.CachedPricingPath()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return err
+	}
+	if err := os.WriteFile(path, data, 0o644); err != nil {
+		return err
+	}
+	fmt.Fprintf(out, "Cached %d model prices to %s\n", n, path)
+	fmt.Fprintln(out, "Built-in curated rates still take precedence; cached rates fill gaps.")
+	return nil
 }
 
 // resolveCwd returns the explicit --cwd or the process working directory.
@@ -126,7 +189,7 @@ func resolveCwd() string {
 }
 
 func runCostWatch(cmd *cobra.Command, args []string) error {
-	table, err := cost.LoadBundledPriceTable()
+	table, err := cost.LoadPriceTable()
 	if err != nil {
 		return fmt.Errorf("load pricing table: %w", err)
 	}
@@ -158,12 +221,19 @@ func runCostWatch(cmd *cobra.Command, args []string) error {
 	}
 	fmt.Fprintf(cmd.ErrOrStderr(), "cost: watching %s (Claude Code + Cursor) — local only, Ctrl-C to stop.\n", scope)
 
+	// Under --all, let the watcher rescan the Cursor feed dir for workspaces
+	// that come online after startup.
+	cursorRescanDir := ""
+	if costAll {
+		cursorRescanDir = cost.CursorFeedDir()
+	}
+
 	w := cost.NewWatcher(table, store, cmd.OutOrStdout(), true)
-	return w.Run(ctx, dirs, cursorFeeds)
+	return w.Run(ctx, dirs, cursorFeeds, cursorRescanDir)
 }
 
 func runCostSession(cmd *cobra.Command, args []string) error {
-	table, err := cost.LoadBundledPriceTable()
+	table, err := cost.LoadPriceTable()
 	if err != nil {
 		return fmt.Errorf("load pricing table: %w", err)
 	}

--- a/cmd/hook.go
+++ b/cmd/hook.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/promptconduit/cli/internal/client"
+	"github.com/promptconduit/cli/internal/cost"
 	"github.com/promptconduit/cli/internal/envelope"
 	"github.com/promptconduit/cli/internal/git"
 	"github.com/promptconduit/cli/internal/logger"
@@ -87,6 +88,14 @@ func processHookEvent() error {
 		debugLog("Failed to parse JSON: %v", err)
 		logger.Error("Failed to parse JSON: %v (raw=%q)", err, string(rawInput[:previewLen]))
 		return nil
+	}
+
+	// Realtime cost tracking is local and unconditional: extract token cost from
+	// Cursor agent-hook payloads here, BEFORE the platform-send gate below, so
+	// the cost meter works for any Cursor hook install — with or without an API
+	// key, and with no separate setup step. Best-effort; never blocks the hook.
+	if _, isCursor := nativeEvent["cursor_version"]; isCursor {
+		recordCursorCost(rawInput)
 	}
 
 	if !cfg.IsConfigured() {
@@ -343,6 +352,26 @@ func sendEnvelopeFromStdin() error {
 	}
 	logger.Debug("Async subprocess: envelope sent successfully")
 	return nil
+}
+
+// recordCursorCost extracts token cost from a Cursor agent-hook payload and
+// appends it to the local cost feed. This is what makes realtime cost tracking
+// part of the standard PromptConduit setup: the `stop`/`afterAgentResponse`
+// hooks that `install cursor` already wires carry exact tokens, so the cost
+// meter "just works" with no extra command. Local-only and best-effort — it
+// reads no API key, sends nothing, and ignores all errors so the hook never
+// blocks the editor.
+func recordCursorCost(rawInput []byte) {
+	table, err := cost.LoadBundledPriceTable()
+	if err != nil {
+		return
+	}
+	ev, cwd, ok := cost.ParseCursorHookPayload(rawInput, table)
+	if !ok {
+		return // not a token-bearing Cursor event
+	}
+	ev.Timestamp = time.Now().UTC().Format(time.RFC3339)
+	_ = cost.AppendCursorEvent(ev, cwd)
 }
 
 // outputContinueResponse writes the success response to stdout

--- a/cmd/install.go
+++ b/cmd/install.go
@@ -119,9 +119,14 @@ func installClaudeCode(exePath string) error {
 		return fmt.Errorf("failed to write settings: %w", err)
 	}
 
-	fmt.Println("Successfully installed PromptConduit hooks for Claude Code")
-	fmt.Printf("Settings file: %s\n", settingsPath)
-	fmt.Println("\nMake sure you have configured your API key:")
+	fmt.Println("✓ Installed PromptConduit hooks for Claude Code")
+	fmt.Printf("  %s\n", settingsPath)
+	fmt.Println()
+	fmt.Println("Realtime token-cost tracking works for Claude Code too (from local transcripts):")
+	fmt.Println("  Live spend:    promptconduit cost watch      (or install the editor extension)")
+	fmt.Println("  This session:  promptconduit cost")
+	fmt.Println()
+	fmt.Println("Optional — also sync events to the PromptConduit platform:")
 	fmt.Println("  promptconduit config set --api-key=\"your-api-key\"")
 
 	return nil
@@ -258,9 +263,14 @@ func installCursor(exePath string) error {
 		return fmt.Errorf("failed to write settings: %w", err)
 	}
 
-	fmt.Println("Successfully installed PromptConduit hooks for Cursor")
-	fmt.Printf("Settings file: %s\n", settingsPath)
-	fmt.Println("\nMake sure you have configured your API key:")
+	fmt.Println("✓ Installed PromptConduit hooks for Cursor")
+	fmt.Printf("  %s\n", settingsPath)
+	fmt.Println()
+	fmt.Println("Realtime token-cost tracking is now ON for Cursor — computed 100% locally.")
+	fmt.Println("  Live spend:    promptconduit cost watch      (or install the editor extension)")
+	fmt.Println("  This session:  promptconduit cost")
+	fmt.Println()
+	fmt.Println("Optional — also sync events to the PromptConduit platform:")
 	fmt.Println("  promptconduit config set --api-key=\"your-api-key\"")
 
 	return nil

--- a/cmd/install.go
+++ b/cmd/install.go
@@ -1,20 +1,30 @@
 package cmd
 
 import (
+	"bufio"
 	"encoding/json"
 	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strconv"
+	"strings"
 
 	"github.com/promptconduit/cli/internal/envelope"
+	"github.com/promptconduit/cli/internal/outbound"
 	"github.com/spf13/cobra"
 )
 
 var installCmd = &cobra.Command{
-	Use:   "install <tool>",
-	Short: "Install PromptConduit hooks for an AI tool",
-	Long: `Install PromptConduit hooks for the specified AI coding assistant.
+	Use:   "install [tool...]",
+	Short: "Set up PromptConduit for one or more AI tools",
+	Long: `Set up PromptConduit hooks for your AI coding assistants.
+
+Run with no arguments to pick interactively, or name one or more tools:
+  promptconduit install                      # interactive multi-select
+  promptconduit install cursor               # a single tool
+  promptconduit install cursor claude-code   # several at once
+  promptconduit install all                  # every supported tool
 
 Supported tools:
   - claude-code: Claude Code CLI            (~/.claude/settings.json)
@@ -23,35 +33,55 @@ Supported tools:
   - codex:       OpenAI Codex CLI           (~/.codex/hooks.json)
   - copilot:     GitHub Copilot CLI         (~/.copilot/hooks/promptconduit.json)
 
-The hooks will capture events from the tool and send them to the PromptConduit API.
-
-Prerequisites:
-  1. Set your API key: promptconduit config set --api-key="your-key"
-  2. Have the target tool installed`,
-	Args: cobra.ExactArgs(1),
+The hooks capture events locally and realtime cost tracking works immediately.
+Set an API key (promptconduit config set --api-key=...) only if you also want to
+sync events to the PromptConduit platform.`,
+	Args: cobra.ArbitraryArgs,
 	RunE: runInstall,
 }
 
-func runInstall(cmd *cobra.Command, args []string) error {
-	toolName := args[0]
+// installableTools is the ordered set offered in the interactive picker.
+var installableTools = []struct{ name, label string }{
+	{"claude-code", "Claude Code"},
+	{"cursor", "Cursor"},
+	{"gemini-cli", "Gemini CLI"},
+	{"codex", "OpenAI Codex"},
+	{"copilot", "GitHub Copilot"},
+}
 
-	if !envelope.IsValidTool(toolName) {
-		return fmt.Errorf("unknown tool: %s. Supported: %v", toolName, envelope.SupportedTools())
+func runInstall(cmd *cobra.Command, args []string) error {
+	tools, err := resolveInstallTools(cmd, args)
+	if err != nil {
+		return err
+	}
+	if len(tools) == 0 {
+		fmt.Fprintln(cmd.ErrOrStderr(), "No tools selected.")
+		return nil
 	}
 
-	// Get the executable path for hook commands
 	exePath, err := os.Executable()
 	if err != nil {
 		return fmt.Errorf("failed to get executable path: %w", err)
 	}
-
-	// Resolve symlinks to get actual binary path
 	exePath, err = filepath.EvalSymlinks(exePath)
 	if err != nil {
 		return fmt.Errorf("failed to resolve executable path: %w", err)
 	}
 
-	switch toolName {
+	for i, tool := range tools {
+		if i > 0 {
+			fmt.Fprintln(cmd.OutOrStdout())
+		}
+		if err := installTool(tool, exePath); err != nil {
+			return fmt.Errorf("install %s: %w", tool, err)
+		}
+	}
+	return nil
+}
+
+// installTool dispatches to the per-tool installer.
+func installTool(name, exePath string) error {
+	switch name {
 	case "claude-code":
 		return installClaudeCode(exePath)
 	case "cursor":
@@ -63,8 +93,104 @@ func runInstall(cmd *cobra.Command, args []string) error {
 	case "copilot":
 		return installCopilot(exePath)
 	default:
-		return fmt.Errorf("installation not implemented for: %s", toolName)
+		return fmt.Errorf("installation not implemented for: %s", name)
 	}
+}
+
+// resolveInstallTools turns CLI args — or an interactive prompt when none are
+// given — into a validated, de-duplicated list of tool names. "all" expands to
+// every supported tool.
+func resolveInstallTools(cmd *cobra.Command, args []string) ([]string, error) {
+	if len(args) == 0 {
+		if !outbound.IsTerminal(os.Stdin) {
+			return nil, fmt.Errorf("name one or more tools (e.g. `install cursor claude-code` or `install all`), or run in a terminal to choose interactively.\nSupported: %s", strings.Join(toolNames(), ", "))
+		}
+		return selectToolsInteractive(cmd)
+	}
+	seen := map[string]bool{}
+	var out []string
+	for _, tok := range args {
+		t := normalizeToolName(strings.ToLower(strings.TrimSpace(tok)))
+		if t == "all" {
+			return toolNames(), nil
+		}
+		if !envelope.IsValidTool(t) {
+			return nil, fmt.Errorf("unknown tool: %s. Supported: %s (or 'all')", tok, strings.Join(toolNames(), ", "))
+		}
+		if !seen[t] {
+			seen[t] = true
+			out = append(out, t)
+		}
+	}
+	return out, nil
+}
+
+// selectToolsInteractive prompts the user to pick tools by number or name.
+func selectToolsInteractive(cmd *cobra.Command) ([]string, error) {
+	out := cmd.OutOrStdout()
+	fmt.Fprintln(out, "Which AI tools should PromptConduit set up?")
+	for i, t := range installableTools {
+		fmt.Fprintf(out, "  %d) %s\n", i+1, t.label)
+	}
+	fmt.Fprint(out, "Enter numbers (e.g. 1,2), names, or 'all': ")
+
+	line, err := bufio.NewReader(cmd.InOrStdin()).ReadString('\n')
+	if err != nil && strings.TrimSpace(line) == "" {
+		return nil, nil
+	}
+	return parseToolSelection(line)
+}
+
+// parseToolSelection resolves a comma-separated picker response (numbers,
+// names, or "all").
+func parseToolSelection(input string) ([]string, error) {
+	input = strings.ToLower(strings.TrimSpace(input))
+	if input == "" {
+		return nil, nil
+	}
+	if input == "all" || input == "*" {
+		return toolNames(), nil
+	}
+	seen := map[string]bool{}
+	var out []string
+	for _, tok := range strings.Split(input, ",") {
+		tok = strings.TrimSpace(tok)
+		if tok == "" {
+			continue
+		}
+		var name string
+		if n, err := strconv.Atoi(tok); err == nil {
+			if n < 1 || n > len(installableTools) {
+				return nil, fmt.Errorf("invalid choice: %s (pick 1-%d)", tok, len(installableTools))
+			}
+			name = installableTools[n-1].name
+		} else {
+			name = normalizeToolName(tok)
+			if !envelope.IsValidTool(name) {
+				return nil, fmt.Errorf("unknown tool: %s", tok)
+			}
+		}
+		if !seen[name] {
+			seen[name] = true
+			out = append(out, name)
+		}
+	}
+	return out, nil
+}
+
+func normalizeToolName(s string) string {
+	if s == "gemini" {
+		return "gemini-cli"
+	}
+	return s
+}
+
+func toolNames() []string {
+	names := make([]string, len(installableTools))
+	for i, t := range installableTools {
+		names[i] = t.name
+	}
+	return names
 }
 
 func installClaudeCode(exePath string) error {
@@ -382,9 +508,10 @@ func installGemini(exePath string) error {
 		return fmt.Errorf("failed to write settings: %w", err)
 	}
 
-	fmt.Println("Successfully installed PromptConduit hooks for Gemini CLI")
-	fmt.Printf("Settings file: %s\n", settingsPath)
-	fmt.Println("\nMake sure you have configured your API key:")
+	fmt.Println("✓ Installed PromptConduit hooks for Gemini CLI")
+	fmt.Printf("  %s\n", settingsPath)
+	fmt.Println()
+	fmt.Println("Optional — sync events to the PromptConduit platform:")
 	fmt.Println("  promptconduit config set --api-key=\"your-api-key\"")
 
 	return nil
@@ -512,9 +639,10 @@ func installCodex(exePath string) error {
 		return fmt.Errorf("failed to write settings: %w", err)
 	}
 
-	fmt.Println("Successfully installed PromptConduit hooks for Codex CLI")
-	fmt.Printf("Settings file: %s\n", settingsPath)
-	fmt.Println("\nMake sure you have configured your API key:")
+	fmt.Println("✓ Installed PromptConduit hooks for OpenAI Codex CLI")
+	fmt.Printf("  %s\n", settingsPath)
+	fmt.Println()
+	fmt.Println("Optional — sync events to the PromptConduit platform:")
 	fmt.Println("  promptconduit config set --api-key=\"your-api-key\"")
 
 	return nil
@@ -612,9 +740,10 @@ func installCopilot(exePath string) error {
 		return fmt.Errorf("failed to write hooks file: %w", err)
 	}
 
-	fmt.Println("Successfully installed PromptConduit hooks for GitHub Copilot CLI")
-	fmt.Printf("Hooks file: %s\n", settingsPath)
-	fmt.Println("\nMake sure you have configured your API key:")
+	fmt.Println("✓ Installed PromptConduit hooks for GitHub Copilot CLI")
+	fmt.Printf("  %s\n", settingsPath)
+	fmt.Println()
+	fmt.Println("Optional — sync events to the PromptConduit platform:")
 	fmt.Println("  promptconduit config set --api-key=\"your-api-key\"")
 
 	return nil

--- a/cmd/install_test.go
+++ b/cmd/install_test.go
@@ -1,0 +1,62 @@
+package cmd
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+func TestParseToolSelection(t *testing.T) {
+	cases := []struct {
+		in   string
+		want []string
+		err  bool
+	}{
+		{"", nil, false},
+		{"all", []string{"claude-code", "cursor", "gemini-cli", "codex", "copilot"}, false},
+		{"*", []string{"claude-code", "cursor", "gemini-cli", "codex", "copilot"}, false},
+		{"1,2", []string{"claude-code", "cursor"}, false},
+		{"cursor, gemini", []string{"cursor", "gemini-cli"}, false}, // alias normalized
+		{"1,cursor,1", []string{"claude-code", "cursor"}, false},    // dedupe
+		{"9", nil, true},
+		{"bogus", nil, true},
+	}
+	for _, c := range cases {
+		got, err := parseToolSelection(c.in)
+		if c.err {
+			if err == nil {
+				t.Errorf("parseToolSelection(%q): expected error", c.in)
+			}
+			continue
+		}
+		if err != nil {
+			t.Errorf("parseToolSelection(%q): unexpected error %v", c.in, err)
+			continue
+		}
+		if !reflect.DeepEqual(got, c.want) {
+			t.Errorf("parseToolSelection(%q) = %v, want %v", c.in, got, c.want)
+		}
+	}
+}
+
+func TestResolveInstallTools_Args(t *testing.T) {
+	cmd := &cobra.Command{}
+	// Multiple explicit tools, with an alias and a duplicate.
+	got, err := resolveInstallTools(cmd, []string{"cursor", "gemini", "cursor"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(got, []string{"cursor", "gemini-cli"}) {
+		t.Fatalf("got %v", got)
+	}
+	// "all" expands.
+	got, err = resolveInstallTools(cmd, []string{"all"})
+	if err != nil || len(got) != len(installableTools) {
+		t.Fatalf("all: got %v err %v", got, err)
+	}
+	// Unknown tool errors.
+	if _, err := resolveInstallTools(cmd, []string{"emacs"}); err == nil {
+		t.Fatal("expected error for unknown tool")
+	}
+}

--- a/cmd/skills_local.go
+++ b/cmd/skills_local.go
@@ -858,4 +858,3 @@ func pluralS(n int) string {
 	}
 	return "s"
 }
-

--- a/internal/cost/cost_test.go
+++ b/internal/cost/cost_test.go
@@ -201,6 +201,46 @@ func TestParseCursorHookPayload(t *testing.T) {
 // verified by hand against real payloads: a watcher ingesting Cursor cost
 // events dedups stop + afterAgentResponse (same generation_id, identical
 // tokens) to one billable unit, sums across generations, and prices composer.
+// TestLoadPriceTableMerge verifies the refresh-cache layering: curated rates
+// win, the cache fills in models the curated table lacks, and free/non-chat
+// entries are skipped.
+func TestLoadPriceTableMerge(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir()) // isolate StoreDir() from the real config
+
+	cache := `{
+      "claude-opus-4-8": {"input_cost_per_token": 0.999, "output_cost_per_token": 0.999},
+      "gpt-5.5": {"input_cost_per_token": 0.000002, "output_cost_per_token": 0.000008},
+      "text-embedding-x": {"input_cost_per_token": 0, "output_cost_per_token": 0}
+    }`
+	path := CachedPricingPath()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(cache), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	tbl, err := LoadPriceTable()
+	if err != nil {
+		t.Fatalf("LoadPriceTable: %v", err)
+	}
+
+	// Curated entry must win over the cache's bogus override.
+	opus, ok := tbl.ResolvePrice("claude-opus-4-8")
+	if !ok || opus.Input != 0.000005 {
+		t.Fatalf("curated opus rate should win; got %v ok=%v", opus.Input, ok)
+	}
+	// A model only in the cache is added.
+	gpt, ok := tbl.ResolvePrice("gpt-5.5")
+	if !ok || gpt.Input != 0.000002 {
+		t.Fatalf("cache-only model should resolve; got %v ok=%v", gpt.Input, ok)
+	}
+	// Free/non-chat entries are skipped.
+	if _, ok := tbl.ResolvePrice("text-embedding-x"); ok {
+		t.Fatal("zero-cost model should be skipped from the merge")
+	}
+}
+
 func TestWatcherCursorAggregationDedup(t *testing.T) {
 	tbl := mustTable(t)
 	var buf bytes.Buffer

--- a/internal/cost/cost_test.go
+++ b/internal/cost/cost_test.go
@@ -295,6 +295,27 @@ func TestWatcherCursorAggregationDedup(t *testing.T) {
 	}
 }
 
+// TestLatestSummary verifies the one-shot `cost` path picks the most-recently
+// updated session and reports its total.
+func TestLatestSummary(t *testing.T) {
+	w := NewWatcher(nil, nil, nil, false) // table/out unused by apply + LatestSummary
+	w.apply(CostEvent{Kind: "cost_event", Tool: ToolCursor, SessionID: "old", RequestID: "g1", Timestamp: "2026-06-13T10:00:00Z", Model: "m", ModelPriced: true, Cost: Cost{Total: 1}})
+	w.apply(CostEvent{Kind: "cost_event", Tool: ToolCursor, SessionID: "new", RequestID: "g2", Timestamp: "2026-06-13T11:00:00Z", Model: "m", ModelPriced: true, Cost: Cost{Total: 2}})
+
+	s, ok := w.LatestSummary()
+	if !ok || s.SessionID != "new" {
+		t.Fatalf("want latest session 'new'; got ok=%v id=%q", ok, s.SessionID)
+	}
+	if s.Totals.CostTotal != 2 || len(s.ByModel) != 1 {
+		t.Fatalf("unexpected summary: total=%v models=%d", s.Totals.CostTotal, len(s.ByModel))
+	}
+
+	empty := NewWatcher(nil, nil, nil, false)
+	if _, ok := empty.LatestSummary(); ok {
+		t.Fatal("LatestSummary should report ok=false with no sessions")
+	}
+}
+
 func TestEncodeProjectPath(t *testing.T) {
 	got := encodeProjectPath("/Users/scotthavird/Documents/GitHub/scotthavird/tolken")
 	want := "-Users-scotthavird-Documents-GitHub-scotthavird-tolken"

--- a/internal/cost/pricing.go
+++ b/internal/cost/pricing.go
@@ -3,6 +3,8 @@ package cost
 import (
 	_ "embed"
 	"encoding/json"
+	"os"
+	"path/filepath"
 	"strings"
 )
 
@@ -49,11 +51,60 @@ var modelAliases = map[string]string{
 	"claude-3-5-haiku-latest":   "claude-3-5-haiku",
 }
 
-// LoadBundledPriceTable parses the embedded snapshot. It never fails on a
-// well-formed build — the JSON is compiled in — but returns an error so a
-// future on-disk override path can share the signature.
+// LoadBundledPriceTable parses the embedded snapshot only. Tests use this for
+// deterministic rates; commands use LoadPriceTable so a user's refreshed cache
+// (if any) is layered in.
 func LoadBundledPriceTable() (*PriceTable, error) {
 	return parsePriceTable(bundledPricingJSON)
+}
+
+// CachedPricingPath is where an opt-in `cost refresh-pricing` writes the
+// fetched upstream table (~/.config/promptconduit/cost/pricing.json). It is
+// read locally — no network — by LoadPriceTable.
+func CachedPricingPath() string {
+	return filepath.Join(StoreDir(), "pricing.json")
+}
+
+// LoadPriceTable returns the curated embedded rates with the user's refreshed
+// cache (if present) layered in as a fallback for models the curated table
+// doesn't cover. Curated entries always win — they carry knowledge the upstream
+// table lacks (Anthropic's 1-hour cache rate, Cursor Composer rates). This read
+// is purely local; the network fetch lives behind the explicit
+// `cost refresh-pricing` command.
+func LoadPriceTable() (*PriceTable, error) {
+	base, err := parsePriceTable(bundledPricingJSON)
+	if err != nil {
+		return nil, err
+	}
+	data, err := os.ReadFile(CachedPricingPath())
+	if err != nil {
+		return base, nil // no cache yet — embedded only
+	}
+	cached, err := parsePriceTable(data)
+	if err != nil {
+		return base, nil // corrupt cache — ignore, fall back to embedded
+	}
+	for key, mp := range cached.models {
+		if _, exists := base.models[key]; exists {
+			continue // curated entry wins
+		}
+		if mp.Input == 0 && mp.Output == 0 {
+			continue // skip free/non-chat entries (embeddings, etc.)
+		}
+		base.models[key] = mp
+	}
+	return base, nil
+}
+
+// ValidatePricingData parses raw pricing JSON and returns how many priced
+// models it contains. Used by `cost refresh-pricing` to validate a fetched
+// table before caching it.
+func ValidatePricingData(data []byte) (int, error) {
+	t, err := parsePriceTable(data)
+	if err != nil {
+		return 0, err
+	}
+	return len(t.models), nil
 }
 
 func parsePriceTable(data []byte) (*PriceTable, error) {

--- a/internal/cost/watcher.go
+++ b/internal/cost/watcher.go
@@ -359,21 +359,32 @@ func (w *Watcher) emitAllSessions() {
 	}
 }
 
-// EmitLatestSession emits only the most-recently-updated session's summary.
-// Used by the one-shot `cost session` command, where a Cursor workspace feed
-// may hold many past conversations but the user wants just the current one.
-func (w *Watcher) EmitLatestSession() {
+// LatestSummary returns the most-recently-updated session's summary (with its
+// by-model breakdown populated and sorted), for the one-shot `cost`/`cost
+// session` command. A Cursor workspace feed may hold many past conversations;
+// this returns just the current one. ok is false if no session was seen.
+func (w *Watcher) LatestSummary() (SessionSummary, bool) {
 	w.mu.Lock()
-	var latest, latestTs string
+	defer w.mu.Unlock()
+	var latestID, latestTs string
 	for id, st := range w.sessions {
-		if latest == "" || st.summary.UpdatedAt > latestTs {
-			latest, latestTs = id, st.summary.UpdatedAt
+		if latestID == "" || st.summary.UpdatedAt > latestTs {
+			latestID, latestTs = id, st.summary.UpdatedAt
 		}
 	}
-	w.mu.Unlock()
-	if latest != "" {
-		w.emitSummary(latest)
+	if latestID == "" {
+		return SessionSummary{}, false
 	}
+	st := w.sessions[latestID]
+	summary := st.summary
+	summary.ByModel = make([]ModelTotal, 0, len(st.byModel))
+	for _, mt := range st.byModel {
+		summary.ByModel = append(summary.ByModel, *mt)
+	}
+	sort.Slice(summary.ByModel, func(i, j int) bool {
+		return summary.ByModel[i].CostTotal > summary.ByModel[j].CostTotal
+	})
+	return summary, true
 }
 
 // emitSummary writes the current SessionSummary for a session.

--- a/internal/cost/watcher.go
+++ b/internal/cost/watcher.go
@@ -6,7 +6,9 @@ import (
 	"encoding/json"
 	"io"
 	"os"
+	"path/filepath"
 	"sort"
+	"strings"
 	"sync"
 	"time"
 
@@ -58,7 +60,7 @@ func NewWatcher(table *PriceTable, store *Store, out io.Writer, emitEvents bool)
 // `cost hook`). It seeds each (to populate session totals without flooding the
 // stream), tails for new entries, and periodically rescans Claude Code dirs for
 // new/resumed sessions. Returns when ctx is cancelled.
-func (w *Watcher) Run(ctx context.Context, dirs []string, cursorFeeds []string) error {
+func (w *Watcher) Run(ctx context.Context, dirs []string, cursorFeeds []string, cursorRescanDir string) error {
 	var wg sync.WaitGroup
 	tailed := make(map[string]bool)
 	var tmu sync.Mutex
@@ -147,6 +149,25 @@ func (w *Watcher) Run(ctx context.Context, dirs []string, cursorFeeds []string) 
 					}
 					if info, err := os.Stat(path); err == nil && info.ModTime().UnixNano() >= cutoff {
 						startTail(path)
+					}
+				}
+			}
+			// Under --all, pick up Cursor feeds for workspaces that started
+			// after the watcher did. New feed files are near-empty, so tailing
+			// from the end captures everything without re-seeding.
+			if cursorRescanDir != "" {
+				if entries, err := os.ReadDir(cursorRescanDir); err == nil {
+					for _, e := range entries {
+						if e.IsDir() || !strings.HasSuffix(e.Name(), ".ndjson") {
+							continue
+						}
+						p := filepath.Join(cursorRescanDir, e.Name())
+						tmu.Lock()
+						already := tailed[p]
+						tmu.Unlock()
+						if !already {
+							startCursorTail(p)
+						}
 					}
 				}
 			}


### PR DESCRIPTION
Follow-up to the cost meter (v0.4.0). Makes realtime cost a **first-class part of PromptConduit setup** rather than a bolt-on, plus pricing/UX polish.

## Developer experience
- **Cost is now part of the standard hook + install flow.** `promptconduit hook` extracts Cursor token cost locally (before the platform-send gate, so it works **with or without an API key**), and `promptconduit install cursor` already wires the `stop`/`afterAgentResponse` hooks that carry the tokens — so after the normal setup, cost "just works." Claude Code cost comes from local transcripts automatically.
- **`install cursor` / `install claude-code`** now surface cost tracking and how to view it.
- **Removed the bolt-on commands** `cost hook` / `cost install-hooks` / `cost uninstall-hooks` (redundant now).
- **Bare `promptconduit cost`** (and `cost session`) print a friendly human-readable summary; `--json` is opt-in. `cost watch` stays JSON (the editor extension's feed).

## Pricing
- **`promptconduit cost refresh-pricing`** — opt-in fetch of LiteLLM's public table (repo **root**; the `/litellm/` path 404s), cached locally and merged *under* the curated rates (curated wins, cache fills gaps, free entries skipped). Verified: fetched 2784 models.
- **`cost watch --all`** rescans the Cursor feed dir for workspaces that start mid-watch.

## Verified
- `go test ./internal/cost ./cmd`, `go vet`, `go build` green.
- `install cursor` (temp HOME) wires `stop`+`afterAgentResponse` → `<binary> hook`, prints the cost message.
- Piping real Cursor payloads to `promptconduit hook` (no API key) records 3 deduped generations to the local feed; bare `cost` renders `composer-2.5-fast … $3.1893`.

Closes the "make it part of setup" request. Remaining #63 items (Cursor cache-rate decision; passthrough model strings) still need live data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)