### PR TITLE
fix(install): write Homebrew opt-prefix path into hooks, not the versioned Cellar path

### DIFF
--- a/cmd/install.go
+++ b/cmd/install.go
@@ -63,7 +63,7 @@ func runInstall(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return fmt.Errorf("failed to get executable path: %w", err)
 	}
-	exePath, err = filepath.EvalSymlinks(exePath)
+	exePath, err = stableExecutablePath(exePath)
 	if err != nil {
 		return fmt.Errorf("failed to resolve executable path: %w", err)
 	}
@@ -77,6 +77,58 @@ func runInstall(cmd *cobra.Command, args []string) error {
 		}
 	}
 	return nil
+}
+
+// stableExecutablePath returns an absolute path to the running binary that is
+// safe to bake into AI-tool hook configs.
+//
+// It resolves symlinks to canonicalize the path, but for Homebrew installs it
+// rewrites the result back to Homebrew's version-independent symlink (e.g.
+// /opt/homebrew/opt/promptconduit/bin/promptconduit). Homebrew stores each
+// version under .../Cellar/<formula>/<version>/ and deletes the old directory
+// on `brew upgrade`, so a fully-resolved Cellar path written into a hook stops
+// working the moment the user upgrades. The opt-prefix (and linked bin)
+// symlinks always point at the current keg, so the hook survives upgrades.
+func stableExecutablePath(exePath string) (string, error) {
+	resolved, err := filepath.EvalSymlinks(exePath)
+	if err != nil {
+		return "", err
+	}
+	if stable, ok := homebrewStablePath(resolved); ok {
+		return stable, nil
+	}
+	return resolved, nil
+}
+
+// homebrewStablePath maps a fully-resolved Homebrew Cellar binary path to a
+// version-independent symlink that resolves back to it. It returns ok=false for
+// non-Homebrew paths, or when no such symlink is present (in which case callers
+// keep the resolved path — the previous behavior).
+func homebrewStablePath(resolved string) (string, bool) {
+	const marker = "/Cellar/"
+	idx := strings.Index(resolved, marker)
+	if idx < 0 {
+		return "", false
+	}
+	prefix := resolved[:idx]           // e.g. /opt/homebrew
+	rest := resolved[idx+len(marker):] // <formula>/<version>/bin/<binary>
+	formula, _, ok := strings.Cut(rest, "/")
+	if !ok || formula == "" {
+		return "", false
+	}
+	binName := filepath.Base(resolved)
+	// Prefer the opt-prefix symlink (Homebrew's canonical stable reference),
+	// then the linked bin symlink. Only accept a candidate that resolves back
+	// to the same binary, so a hook never points at a different formula.
+	for _, candidate := range []string{
+		filepath.Join(prefix, "opt", formula, "bin", binName),
+		filepath.Join(prefix, "bin", binName),
+	} {
+		if target, err := filepath.EvalSymlinks(candidate); err == nil && target == resolved {
+			return candidate, true
+		}
+	}
+	return "", false
 }
 
 // installTool dispatches to the per-tool installer.

--- a/cmd/install_test.go
+++ b/cmd/install_test.go
@@ -1,6 +1,8 @@
 package cmd
 
 import (
+	"os"
+	"path/filepath"
 	"reflect"
 	"testing"
 
@@ -59,4 +61,91 @@ func TestResolveInstallTools_Args(t *testing.T) {
 	if _, err := resolveInstallTools(cmd, []string{"emacs"}); err == nil {
 		t.Fatal("expected error for unknown tool")
 	}
+}
+
+// brewLayout builds a throwaway Homebrew-style directory tree and returns the
+// real Cellar binary path plus the opt/bin symlink paths. makeOpt/makeBin
+// control which version-independent symlinks exist.
+func brewLayout(t *testing.T, makeOpt, makeBin bool) (realBin, optLink, binLink string) {
+	t.Helper()
+	// macOS temp dirs live under /var -> /private/var; canonicalize the base so
+	// EvalSymlinks results compare equal to the paths we construct.
+	base, err := filepath.EvalSymlinks(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	cellarBin := filepath.Join(base, "Cellar", "promptconduit", "0.4.0", "bin")
+	if err := os.MkdirAll(cellarBin, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	realBin = filepath.Join(cellarBin, "promptconduit")
+	if err := os.WriteFile(realBin, []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	optLink = filepath.Join(base, "opt", "promptconduit", "bin", "promptconduit")
+	binLink = filepath.Join(base, "bin", "promptconduit")
+	link := func(p string) {
+		if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.Symlink(realBin, p); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if makeOpt {
+		link(optLink)
+	}
+	if makeBin {
+		link(binLink)
+	}
+	return realBin, optLink, binLink
+}
+
+func TestHomebrewStablePath(t *testing.T) {
+	t.Run("prefers opt prefix over bin", func(t *testing.T) {
+		real, optLink, _ := brewLayout(t, true, true)
+		got, ok := homebrewStablePath(real)
+		if !ok || got != optLink {
+			t.Fatalf("got (%q, %v), want (%q, true)", got, ok, optLink)
+		}
+	})
+
+	t.Run("falls back to linked bin symlink", func(t *testing.T) {
+		real, _, binLink := brewLayout(t, false, true)
+		got, ok := homebrewStablePath(real)
+		if !ok || got != binLink {
+			t.Fatalf("got (%q, %v), want (%q, true)", got, ok, binLink)
+		}
+	})
+
+	t.Run("no stable symlink present keeps resolved path", func(t *testing.T) {
+		real, _, _ := brewLayout(t, false, false)
+		if got, ok := homebrewStablePath(real); ok {
+			t.Fatalf("expected ok=false, got %q", got)
+		}
+	})
+
+	t.Run("non-homebrew path untouched", func(t *testing.T) {
+		if got, ok := homebrewStablePath("/usr/local/bin/promptconduit"); ok {
+			t.Fatalf("expected ok=false, got %q", got)
+		}
+	})
+
+	t.Run("rejects symlink resolving to a different binary", func(t *testing.T) {
+		real, optLink, _ := brewLayout(t, false, false)
+		// An opt symlink that points at some other binary must not be trusted.
+		other := filepath.Join(filepath.Dir(real), "other")
+		if err := os.WriteFile(other, []byte("x"), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.MkdirAll(filepath.Dir(optLink), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.Symlink(other, optLink); err != nil {
+			t.Fatal(err)
+		}
+		if got, ok := homebrewStablePath(real); ok {
+			t.Fatalf("expected ok=false for stale symlink, got %q", got)
+		}
+	})
 }

--- a/cmd/install_test.go
+++ b/cmd/install_test.go
@@ -74,7 +74,8 @@ func brewLayout(t *testing.T, makeOpt, makeBin bool) (realBin, optLink, binLink 
 	if err != nil {
 		t.Fatal(err)
 	}
-	cellarBin := filepath.Join(base, "Cellar", "promptconduit", "0.4.0", "bin")
+	versionDir := filepath.Join(base, "Cellar", "promptconduit", "0.4.0")
+	cellarBin := filepath.Join(versionDir, "bin")
 	if err := os.MkdirAll(cellarBin, 0o755); err != nil {
 		t.Fatal(err)
 	}
@@ -84,19 +85,24 @@ func brewLayout(t *testing.T, makeOpt, makeBin bool) (realBin, optLink, binLink 
 	}
 	optLink = filepath.Join(base, "opt", "promptconduit", "bin", "promptconduit")
 	binLink = filepath.Join(base, "bin", "promptconduit")
-	link := func(p string) {
-		if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
-			t.Fatal(err)
-		}
-		if err := os.Symlink(realBin, p); err != nil {
-			t.Fatal(err)
-		}
-	}
 	if makeOpt {
-		link(optLink)
+		// Mirror real Homebrew: opt/<formula> is a directory symlink to the keg,
+		// so the binary is reached at opt/<formula>/bin/<binary> through it.
+		optDir := filepath.Join(base, "opt")
+		if err := os.MkdirAll(optDir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.Symlink(versionDir, filepath.Join(optDir, "promptconduit")); err != nil {
+			t.Fatal(err)
+		}
 	}
 	if makeBin {
-		link(binLink)
+		if err := os.MkdirAll(filepath.Dir(binLink), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.Symlink(realBin, binLink); err != nil {
+			t.Fatal(err)
+		}
 	}
 	return realBin, optLink, binLink
 }
@@ -146,6 +152,37 @@ func TestHomebrewStablePath(t *testing.T) {
 		}
 		if got, ok := homebrewStablePath(real); ok {
 			t.Fatalf("expected ok=false for stale symlink, got %q", got)
+		}
+	})
+}
+
+func TestStableExecutablePath(t *testing.T) {
+	t.Run("homebrew binary maps to stable symlink", func(t *testing.T) {
+		real, optLink, _ := brewLayout(t, true, true)
+		got, err := stableExecutablePath(real)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got != optLink {
+			t.Fatalf("got %q, want %q", got, optLink)
+		}
+	})
+
+	t.Run("non-homebrew binary returns the resolved path", func(t *testing.T) {
+		dir, err := filepath.EvalSymlinks(t.TempDir())
+		if err != nil {
+			t.Fatal(err)
+		}
+		bin := filepath.Join(dir, "promptconduit")
+		if err := os.WriteFile(bin, []byte("x"), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		got, err := stableExecutablePath(bin)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got != bin {
+			t.Fatalf("got %q, want %q", got, bin)
 		}
 	})
 }


### PR DESCRIPTION
Closes #66.

## Problem

`promptconduit install` resolved the running binary with `os.Executable()` + `filepath.EvalSymlinks`, which follows Homebrew's stable symlink all the way down to the **version-pinned keg** (`.../Cellar/promptconduit/<version>/bin/promptconduit`) and baked that into every hook command. `brew upgrade` deletes the old keg, so every hook then fails with `No such file or directory` and event capture silently stops. All tools installed via the unified `install` flow are affected (claude-code, cursor, gemini, codex, copilot) since they share the resolved path.

## Fix

Route the resolved path through a new `stableExecutablePath()`. For Homebrew installs it rewrites the Cellar path back to a version-independent symlink:

1. `<prefix>/opt/<formula>/bin/<binary>` — Homebrew's canonical stable reference
2. fall back to `<prefix>/bin/<binary>` (the linked symlink)
3. fall back to the resolved path — unchanged behavior for non-Homebrew installs

A candidate is only accepted if it resolves back to the **same** binary, so a hook can never be pointed at a different formula.

## Tests

- `TestHomebrewStablePath` (table of subcases): prefers opt over bin, falls back to bin, keeps resolved path when no stable symlink exists, leaves non-Homebrew paths untouched, and rejects a symlink that resolves elsewhere.
- `go build`, `go test ./...`, `go vet ./...` all pass.

## Verification

End-to-end: ran the built binary through a simulated Homebrew layout (`Cellar/promptconduit/9.9.9` + `opt`/`bin` symlinks) with an isolated `$HOME`. The hook command written to `settings.json` was the stable `.../opt/promptconduit/bin/promptconduit hook` — **no versioned Cellar path**. Also confirmed against the real machine: `/opt/homebrew/opt/promptconduit/bin/promptconduit` resolves to the current `0.4.0` keg.

🤖 Generated with [Claude Code](https://claude.com/claude-code)