### PR TITLE
feat: local full-fidelity event log in ~/.promptconduit/

### DIFF
--- a/cmd/config.go
+++ b/cmd/config.go
@@ -44,6 +44,11 @@ var configShowCmd = &cobra.Command{
 			autoUpdate = "disabled"
 		}
 		cmd.Printf("Auto-update: %s\n", autoUpdate)
+		eventLog := "enabled"
+		if cfg.DisableEventLog {
+			eventLog = "disabled"
+		}
+		cmd.Printf("Event log:   %s\n", eventLog)
 		cmd.Println()
 		cmd.Printf("Config:      %s\n", client.ConfigPath())
 
@@ -69,6 +74,7 @@ var (
 	setAPIURL            string
 	setDebug             bool
 	setDisableAutoUpdate bool
+	setDisableEventLog   bool
 )
 
 var configSetCmd = &cobra.Command{
@@ -90,7 +96,10 @@ Examples:
   promptconduit config set --disable-auto-update=true
 
   # Re-enable automatic background upgrades
-  promptconduit config set --disable-auto-update=false`,
+  promptconduit config set --disable-auto-update=false
+
+  # Opt out of the local event log (~/.promptconduit/events.ndjson)
+  promptconduit config set --disable-event-log=true`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		fc, err := client.LoadFileConfig()
 		if err != nil {
@@ -119,9 +128,13 @@ Examples:
 			fc.DisableAutoUpdate = setDisableAutoUpdate
 			changed = true
 		}
+		if cmd.Flags().Changed("disable-event-log") {
+			fc.DisableEventLog = setDisableEventLog
+			changed = true
+		}
 
 		if !changed {
-			return fmt.Errorf("no values provided. Use --api-key, --api-url, --debug, or --disable-auto-update")
+			return fmt.Errorf("no values provided. Use --api-key, --api-url, --debug, --disable-auto-update, or --disable-event-log")
 		}
 
 		if err := client.SaveFileConfig(fc); err != nil {
@@ -144,6 +157,13 @@ Examples:
 				state = "disabled"
 			}
 			cmd.Printf("  Auto-update: %s\n", state)
+		}
+		if cmd.Flags().Changed("disable-event-log") {
+			state := "enabled"
+			if fc.DisableEventLog {
+				state = "disabled"
+			}
+			cmd.Printf("  Event log:   %s\n", state)
 		}
 
 		return nil
@@ -365,6 +385,7 @@ func init() {
 	configSetCmd.Flags().StringVar(&setAPIURL, "api-url", "", "API URL (default: https://api.promptconduit.dev)")
 	configSetCmd.Flags().BoolVar(&setDebug, "debug", false, "Enable debug mode")
 	configSetCmd.Flags().BoolVar(&setDisableAutoUpdate, "disable-auto-update", false, "Disable the background self-upgrade check")
+	configSetCmd.Flags().BoolVar(&setDisableEventLog, "disable-event-log", false, "Disable the local event log written to ~/.promptconduit/")
 
 	// Environment subcommands
 	configEnvCmd.AddCommand(configEnvListCmd)

--- a/cmd/events.go
+++ b/cmd/events.go
@@ -1,0 +1,235 @@
+package cmd
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/promptconduit/cli/internal/eventlog"
+	"github.com/spf13/cobra"
+)
+
+var (
+	eventsTailN  int
+	eventsFollow bool
+	eventsErrors bool
+	eventsRaw    bool
+	eventsPath   bool
+)
+
+var eventsCmd = &cobra.Command{
+	Use:           "events",
+	Short:         "Inspect the local event log of payloads sent to the platform",
+	SilenceUsage:  true,
+	SilenceErrors: true,
+	Long: `Show the full JSON payloads the CLI has sent to the platform, recorded
+locally before/at send time — the actual envelope plus the HTTP outcome
+(status, latency) for each event.
+
+This reads ~/.promptconduit/events.ndjson (full-fidelity, one record per send;
+secrets scrubbed; the file rotates to events.ndjson.1 at 50MB). Use it to
+answer "what did my hook actually send?" and "did it reach the platform?".
+
+By default each record is shown as a one-line summary:
+
+  16:55:02  sent    UserPromptSubmit  claude-code  3.2KB  → 200 (87ms)
+
+Use --raw to print the full envelope payload beneath each summary, or
+--errors to tail the human-readable failure/drop log (errors.log) instead.
+
+Examples:
+  promptconduit events                # last 20 records, summary lines
+  promptconduit events --raw          # include the full payload per record
+  promptconduit events -n 5           # last 5 records
+  promptconduit events --follow       # stream new records live
+  promptconduit events --errors       # tail errors.log (failures + drops)
+  promptconduit events --path         # print the event-log file path`,
+	RunE: runEvents,
+}
+
+func init() {
+	eventsCmd.Flags().IntVarP(&eventsTailN, "lines", "n", 20, "Number of records to show from the end of the log")
+	eventsCmd.Flags().BoolVarP(&eventsFollow, "follow", "f", false, "Stream new records as they are written (like `tail -f`)")
+	eventsCmd.Flags().BoolVar(&eventsErrors, "errors", false, "Show the human-readable error log (errors.log) instead of the event log")
+	eventsCmd.Flags().BoolVar(&eventsRaw, "raw", false, "Print the full JSON payload beneath each summary line")
+	eventsCmd.Flags().BoolVar(&eventsPath, "path", false, "Print only the log file path and exit")
+}
+
+func runEvents(cmd *cobra.Command, args []string) error {
+	path := eventlog.EventsPath()
+	if eventsErrors {
+		path = eventlog.ErrorsPath()
+	}
+
+	if eventsPath {
+		cmd.Println(path)
+		return nil
+	}
+
+	if eventsFollow {
+		return followFile(cmd, path, renderEventLine)
+	}
+
+	// errors.log is already human-readable; print it verbatim.
+	if eventsErrors {
+		out, err := eventlog.TailErrors(eventsTailN)
+		if err != nil {
+			return fmt.Errorf("read error log: %w", err)
+		}
+		if out == "" {
+			cmd.Printf("No errors recorded yet.\n  Path: %s\n", path)
+			return nil
+		}
+		cmd.Print(out)
+		if !strings.HasSuffix(out, "\n") {
+			cmd.Println()
+		}
+		return nil
+	}
+
+	out, err := eventlog.TailEvents(eventsTailN)
+	if err != nil {
+		return fmt.Errorf("read event log: %w", err)
+	}
+	if out == "" {
+		cmd.Printf("No events recorded yet.\n  Path: %s\n", path)
+		cmd.Println("  (events are logged when the CLI sends to the platform; check `promptconduit status`)")
+		return nil
+	}
+	for _, line := range strings.Split(strings.TrimRight(out, "\n"), "\n") {
+		cmd.Print(renderEventLine(line))
+	}
+	return nil
+}
+
+// renderEventLine turns one NDJSON event record into a readable summary line
+// (plus the full payload when --raw is set). Lines that don't parse are echoed
+// verbatim so nothing is silently hidden.
+func renderEventLine(line string) string {
+	line = strings.TrimSpace(line)
+	if line == "" {
+		return ""
+	}
+	var rec struct {
+		TS        string          `json:"ts"`
+		Tool      string          `json:"tool"`
+		HookEvent string          `json:"hook_event"`
+		Outcome   string          `json:"outcome"`
+		Status    int             `json:"status"`
+		LatencyMs int64           `json:"latency_ms"`
+		Error     string          `json:"error"`
+		Payload   json.RawMessage `json:"payload"`
+	}
+	if err := json.Unmarshal([]byte(line), &rec); err != nil {
+		return line + "\n"
+	}
+
+	ts := rec.TS
+	if t, err := time.Parse(time.RFC3339, rec.TS); err == nil {
+		ts = t.Local().Format("15:04:05")
+	}
+
+	size := humanBytes(len(rec.Payload))
+	statusPart := fmt.Sprintf("→ %d (%dms)", rec.Status, rec.LatencyMs)
+	if rec.Status == 0 {
+		statusPart = fmt.Sprintf("→ no response (%dms)", rec.LatencyMs)
+	}
+
+	var b strings.Builder
+	fmt.Fprintf(&b, "%s  %-7s %-18s %-12s %7s  %s\n",
+		ts, rec.Outcome, dashIfEmpty(rec.HookEvent), dashIfEmpty(rec.Tool), size, statusPart)
+	if rec.Error != "" {
+		fmt.Fprintf(&b, "          error: %s\n", rec.Error)
+	}
+	if eventsRaw && len(rec.Payload) > 0 {
+		var pretty bytes.Buffer
+		if err := json.Indent(&pretty, rec.Payload, "          ", "  "); err == nil {
+			fmt.Fprintf(&b, "          %s\n", pretty.String())
+		} else {
+			fmt.Fprintf(&b, "          %s\n", string(rec.Payload))
+		}
+	}
+	return b.String()
+}
+
+func dashIfEmpty(s string) string {
+	if s == "" {
+		return "-"
+	}
+	return s
+}
+
+func humanBytes(n int) string {
+	switch {
+	case n >= 1<<20:
+		return fmt.Sprintf("%.1fMB", float64(n)/(1<<20))
+	case n >= 1<<10:
+		return fmt.Sprintf("%.1fKB", float64(n)/(1<<10))
+	default:
+		return fmt.Sprintf("%dB", n)
+	}
+}
+
+// followFile tails path, rendering each newly appended line with render. It
+// backfills the last eventsTailN lines first, then polls for growth. Kept
+// dependency-free (no external `tail`) so it behaves identically everywhere,
+// including reset-to-zero on rotation.
+func followFile(cmd *cobra.Command, path string, render func(string) string) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return fmt.Errorf("create event-log dir: %w", err)
+	}
+
+	// Backfill recent context.
+	if out, err := eventlog.TailEvents(eventsTailN); err == nil && !eventsErrors {
+		for _, line := range strings.Split(strings.TrimRight(out, "\n"), "\n") {
+			cmd.Print(render(line))
+		}
+	}
+
+	var offset int64
+	if info, err := os.Stat(path); err == nil {
+		offset = info.Size()
+	}
+	for {
+		time.Sleep(500 * time.Millisecond)
+		info, err := os.Stat(path)
+		if err != nil {
+			continue
+		}
+		// Rotation (or truncate) shrank the file — start over from the top.
+		if info.Size() < offset {
+			offset = 0
+		}
+		if info.Size() == offset {
+			continue
+		}
+		f, err := os.Open(path)
+		if err != nil {
+			continue
+		}
+		if _, err := f.Seek(offset, io.SeekStart); err == nil {
+			r := bufio.NewReader(f)
+			for {
+				lineBytes, err := r.ReadBytes('\n')
+				if len(lineBytes) > 0 {
+					offset += int64(len(lineBytes))
+					if eventsErrors {
+						cmd.Print(string(lineBytes))
+					} else {
+						cmd.Print(render(string(lineBytes)))
+					}
+				}
+				if err != nil {
+					break
+				}
+			}
+		}
+		_ = f.Close()
+	}
+}

--- a/cmd/hook.go
+++ b/cmd/hook.go
@@ -14,6 +14,7 @@ import (
 	"github.com/promptconduit/cli/internal/client"
 	"github.com/promptconduit/cli/internal/cost"
 	"github.com/promptconduit/cli/internal/envelope"
+	"github.com/promptconduit/cli/internal/eventlog"
 	"github.com/promptconduit/cli/internal/git"
 	"github.com/promptconduit/cli/internal/logger"
 	"github.com/promptconduit/cli/internal/sync"
@@ -55,10 +56,11 @@ func runHook(cmd *cobra.Command, args []string) error {
 func processHookEvent() error {
 	defer outputContinueResponse()
 
-	// Load config first so we can set the debug flag for the logger before
-	// emitting any trace lines.
+	// Load config first so we can set the debug flag for the logger and the
+	// enabled flag for the local event log before emitting any lines.
 	cfg := client.LoadConfig()
 	logger.SetDebug(cfg.Debug)
+	eventlog.SetEnabled(cfg.EventLogEnabled())
 
 	logger.Debug("Hook started")
 
@@ -67,12 +69,14 @@ func processHookEvent() error {
 	if err != nil {
 		debugLog("Failed to read stdin: %v", err)
 		logger.Error("Failed to read stdin: %v", err)
+		eventlog.RecordDrop("read_error", err.Error())
 		return nil
 	}
 
 	if len(rawInput) == 0 {
 		debugLog("Empty input, skipping")
 		logger.Debug("Empty input, skipping")
+		eventlog.RecordDrop("empty_stdin", "")
 		return nil
 	}
 
@@ -87,6 +91,7 @@ func processHookEvent() error {
 	if err := json.Unmarshal(rawInput, &nativeEvent); err != nil {
 		debugLog("Failed to parse JSON: %v", err)
 		logger.Error("Failed to parse JSON: %v (raw=%q)", err, string(rawInput[:previewLen]))
+		eventlog.RecordDrop("parse_error", err.Error())
 		return nil
 	}
 
@@ -101,6 +106,7 @@ func processHookEvent() error {
 	if !cfg.IsConfigured() {
 		debugLog("API key not configured, skipping")
 		logger.Error("API key not configured — event dropped. Run `promptconduit config set --api-key=...`")
+		eventlog.RecordDrop("not_configured", "run `promptconduit config set --api-key=...`")
 		return nil
 	}
 
@@ -327,12 +333,16 @@ func getSessionID(event map[string]interface{}) string {
 func sendEnvelopeFromStdin() error {
 	cfg := client.LoadConfig()
 	logger.SetDebug(cfg.Debug)
+	// This runs as a fresh subprocess, so the enabled flag must be set here
+	// too — it isn't inherited from the parent hook process.
+	eventlog.SetEnabled(cfg.EventLogEnabled())
 
 	logger.Debug("Async subprocess started")
 
 	inputData, err := io.ReadAll(os.Stdin)
 	if err != nil {
 		logger.Error("Async subprocess failed to read stdin: %v", err)
+		eventlog.RecordDrop("read_error", "async subprocess: "+err.Error())
 		return fmt.Errorf("failed to read stdin: %w", err)
 	}
 
@@ -340,6 +350,7 @@ func sendEnvelopeFromStdin() error {
 
 	if !cfg.IsConfigured() {
 		logger.Error("Async subprocess: API key not configured — envelope dropped")
+		eventlog.RecordDrop("not_configured", "async subprocess")
 		return fmt.Errorf("API key not configured")
 	}
 
@@ -469,7 +480,11 @@ func retryFailedSyncs(exe string) {
 	}
 }
 
-// writeLocalEvent writes hook events to local file for macOS app status tracking
+// writeLocalEvent appends a lightweight status trace to
+// ~/.promptconduit/hook-events so the macOS menu-bar app can tell when a
+// session starts/stops. This is NOT the API payload — only {event, cwd,
+// session_id, timestamp}. The full outgoing payload is recorded separately by
+// the eventlog package (~/.promptconduit/events.ndjson) at send time.
 func writeLocalEvent(hookEvent, cwd, sessionID string) {
 	// Only write status-relevant events
 	switch hookEvent {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -58,6 +58,7 @@ func init() {
 	rootCmd.AddCommand(watchCmd)
 	rootCmd.AddCommand(collectCmd)
 	rootCmd.AddCommand(logsCmd)
+	rootCmd.AddCommand(eventsCmd)
 	rootCmd.AddCommand(costCmd)
 }
 

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -6,8 +6,10 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/promptconduit/cli/internal/client"
+	"github.com/promptconduit/cli/internal/eventlog"
 	"github.com/spf13/cobra"
 )
 
@@ -34,6 +36,9 @@ func runStatus(cmd *cobra.Command, args []string) error {
 	fmt.Printf("Debug:   %v\n", cfg.Debug)
 	fmt.Println()
 
+	// Local event log health (sent/failed/dropped counters)
+	printEventLogStatus(cfg)
+
 	// Check tool installations
 	fmt.Println("Tool Installations:")
 	checkClaudeCodeInstallation()
@@ -41,6 +46,39 @@ func runStatus(cmd *cobra.Command, args []string) error {
 	checkGeminiInstallation()
 
 	return nil
+}
+
+// printEventLogStatus shows the rolling sent/failed/dropped counters from the
+// local event log so the user can tell at a glance whether events are flowing.
+func printEventLogStatus(cfg *client.Config) {
+	if !cfg.EventLogEnabled() {
+		fmt.Println("Event Log: disabled")
+		fmt.Println("  Re-enable with: promptconduit config set --disable-event-log=false")
+		fmt.Println()
+		return
+	}
+
+	st := eventlog.LoadStatus()
+	fmt.Println("Event Log: enabled")
+	fmt.Printf("  %d sent · %d failed · %d dropped\n", st.Sent, st.Failed, st.Dropped)
+	if st.LastSuccessAt != "" {
+		fmt.Printf("  Last success: %s\n", localTime(st.LastSuccessAt))
+	}
+	if st.LastError != "" {
+		fmt.Printf("  Last error:   %s — %s\n", localTime(st.LastErrorAt), st.LastError)
+	}
+	fmt.Printf("  Payloads:     %s\n", eventlog.EventsPath())
+	fmt.Println("  Inspect with: promptconduit events")
+	fmt.Println()
+}
+
+// localTime renders an RFC3339 timestamp in the local zone, falling back to the
+// raw value if it can't be parsed.
+func localTime(ts string) string {
+	if t, err := time.Parse(time.RFC3339, ts); err == nil {
+		return t.Local().Format("2006-01-02 15:04:05")
+	}
+	return ts
 }
 
 func checkClaudeCodeInstallation() {

--- a/internal/client/api.go
+++ b/internal/client/api.go
@@ -16,9 +16,30 @@ import (
 	"time"
 
 	"github.com/promptconduit/cli/internal/envelope"
+	"github.com/promptconduit/cli/internal/eventlog"
 	"github.com/promptconduit/cli/internal/logger"
 	"github.com/promptconduit/cli/internal/outbound"
 )
+
+// eventsEndpoint is the path every raw-event send targets. Centralized so the
+// event-log records and the request URLs can't drift apart.
+const eventsEndpoint = "/v1/events/raw"
+
+// recordEventSend writes a full-fidelity record of an outbound event send to
+// the local event log (~/.promptconduit/events.ndjson) and updates the rolling
+// status counters. Best-effort and gated by config; it never blocks or fails
+// the send. Called from every event-send chokepoint with the exact envelope
+// JSON we put on the wire plus the HTTP result.
+func recordEventSend(envJSON []byte, status int, latency time.Duration, attempt int, sendErr error) {
+	eventlog.RecordSend(eventlog.SendRecord{
+		Endpoint:  eventsEndpoint,
+		Payload:   envJSON,
+		Status:    status,
+		LatencyMs: latency.Milliseconds(),
+		Attempt:   attempt,
+		Err:       sendErr,
+	})
+}
 
 // APIResponse represents a response from the API
 type APIResponse struct {
@@ -123,8 +144,12 @@ func (c *Client) SendEnvelopeWithAttachments(env *envelope.RawEventEnvelope, att
 	req.Header.Set("Authorization", "Bearer "+c.config.APIKey)
 	req.Header.Set("User-Agent", fmt.Sprintf("PromptConduit-CLI/%s", c.version))
 
+	start := time.Now()
 	resp, err := c.httpClient.Do(req)
 	if err != nil {
+		// envJSON holds the logical envelope (the multipart body also carries
+		// binary attachments, but the event log records the envelope we sent).
+		recordEventSend(envJSON, 0, time.Since(start), 1, err)
 		return &APIResponse{
 			Success: false,
 			Error:   fmt.Sprintf("request failed: %v", err),
@@ -146,9 +171,12 @@ func (c *Client) SendEnvelopeWithAttachments(env *envelope.RawEventEnvelope, att
 		}
 	}
 
+	var sendErr error
 	if !result.Success {
 		result.Error = fmt.Sprintf("HTTP %d: %s", resp.StatusCode, string(respBody))
+		sendErr = fmt.Errorf("API error: %d - %s", resp.StatusCode, string(respBody))
 	}
+	recordEventSend(envJSON, resp.StatusCode, time.Since(start), 1, sendErr)
 
 	return result
 }
@@ -280,29 +308,39 @@ func openLogForStderr() *os.File {
 	return f
 }
 
-// sendEnvelopeBlocking sends the envelope synchronously (fallback)
+// sendEnvelopeBlocking sends the envelope synchronously. This is the single
+// chokepoint every event send funnels through — the async subprocess
+// (SendEnvelopeDirect) and the in-process fallback in sendAsync{Unix,Windows}
+// both land here — so it's where we record the full outgoing payload and the
+// HTTP outcome to the local event log.
 func (c *Client) sendEnvelopeBlocking(envJSON []byte) error {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Duration(c.config.TimeoutSeconds)*time.Second)
 	defer cancel()
 
-	req, err := http.NewRequestWithContext(ctx, "POST", c.config.APIURL+"/v1/events/raw", bytes.NewReader(envJSON))
+	req, err := http.NewRequestWithContext(ctx, "POST", c.config.APIURL+eventsEndpoint, bytes.NewReader(envJSON))
 	if err != nil {
+		recordEventSend(envJSON, 0, 0, 1, err)
 		return err
 	}
 
 	c.setHeaders(req)
 
+	start := time.Now()
 	resp, err := c.httpClient.Do(req)
 	if err != nil {
+		recordEventSend(envJSON, 0, time.Since(start), 1, err)
 		return err
 	}
 	defer resp.Body.Close()
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		body, _ := io.ReadAll(resp.Body)
-		return fmt.Errorf("API error: %d - %s", resp.StatusCode, string(body))
+		apiErr := fmt.Errorf("API error: %d - %s", resp.StatusCode, string(body))
+		recordEventSend(envJSON, resp.StatusCode, time.Since(start), 1, apiErr)
+		return apiErr
 	}
 
+	recordEventSend(envJSON, resp.StatusCode, time.Since(start), 1, nil)
 	return nil
 }
 

--- a/internal/client/config.go
+++ b/internal/client/config.go
@@ -16,6 +16,7 @@ const (
 	EnvTimeout         = "PROMPTCONDUIT_TIMEOUT"
 	EnvTool            = "PROMPTCONDUIT_TOOL"
 	EnvAutoUpdate      = "PROMPTCONDUIT_AUTO_UPDATE" // "0"/"false" disables background self-upgrade
+	EnvEventLog        = "PROMPTCONDUIT_EVENT_LOG"   // "0"/"false" disables the local ~/.promptconduit event log
 	EnvXDGConfigHome   = "XDG_CONFIG_HOME"
 	ConfigDirName      = "promptconduit" // ~/.config/promptconduit/
 	ConfigFileName     = "config.json"
@@ -30,6 +31,10 @@ type Config struct {
 	// DisableAutoUpdate opts out of the background "check + self-upgrade"
 	// behaviour. Zero value (false) leaves auto-update enabled.
 	DisableAutoUpdate bool `json:"disable_auto_update,omitempty"`
+	// DisableEventLog opts out of the local full-fidelity event log written
+	// to ~/.promptconduit/ (events.ndjson, errors.log, status.json). Zero
+	// value (false) leaves the event log enabled — it's on by default.
+	DisableEventLog bool `json:"disable_event_log,omitempty"`
 }
 
 // FileConfig represents the config file structure with environment support
@@ -46,6 +51,14 @@ type FileConfig struct {
 	Debug             bool   `json:"debug,omitempty"`
 	Timeout           int    `json:"timeout_seconds,omitempty"`
 	DisableAutoUpdate bool   `json:"disable_auto_update,omitempty"`
+	DisableEventLog   bool   `json:"disable_event_log,omitempty"`
+}
+
+// EventLogEnabled reports whether the local ~/.promptconduit event log should
+// be written. On by default; disabled only when explicitly opted out via
+// config (disable_event_log) or PROMPTCONDUIT_EVENT_LOG=0.
+func (c *Config) EventLogEnabled() bool {
+	return !c.DisableEventLog
 }
 
 // IsConfigured returns true if the API key is set
@@ -141,13 +154,14 @@ func (fc *FileConfig) GetCurrentConfig() *Config {
 	}
 
 	// Fall back to legacy flat config
-	if fc.APIKey != "" || fc.APIURL != "" || fc.DisableAutoUpdate {
+	if fc.APIKey != "" || fc.APIURL != "" || fc.DisableAutoUpdate || fc.DisableEventLog {
 		return &Config{
 			APIKey:            fc.APIKey,
 			APIURL:            fc.APIURL,
 			Debug:             fc.Debug,
 			TimeoutSeconds:    fc.Timeout,
 			DisableAutoUpdate: fc.DisableAutoUpdate,
+			DisableEventLog:   fc.DisableEventLog,
 		}
 	}
 
@@ -182,6 +196,9 @@ func LoadConfig() *Config {
 			if fileCfg.DisableAutoUpdate {
 				cfg.DisableAutoUpdate = true
 			}
+			if fileCfg.DisableEventLog {
+				cfg.DisableEventLog = true
+			}
 		}
 	}
 
@@ -189,6 +206,12 @@ func LoadConfig() *Config {
 	// leaves whatever the file config decided.
 	if v := os.Getenv(EnvAutoUpdate); v == "0" || v == "false" || v == "no" {
 		cfg.DisableAutoUpdate = true
+	}
+
+	// PROMPTCONDUIT_EVENT_LOG=0/false/no disables the local event log;
+	// anything else (or unset) leaves whatever the file config decided.
+	if v := os.Getenv(EnvEventLog); v == "0" || v == "false" || v == "no" {
+		cfg.DisableEventLog = true
 	}
 
 	// Apply defaults

--- a/internal/eventlog/errors.go
+++ b/internal/eventlog/errors.go
@@ -1,0 +1,57 @@
+package eventlog
+
+import (
+	"fmt"
+	"os"
+	"strings"
+)
+
+// Errorf appends a human-readable error line to errors.log. Use it for any
+// failure path that should be visible when debugging "events aren't reaching
+// the platform" — failed sends, dropped events, etc.
+//
+// Line format mirrors internal/logger for familiarity:
+//
+//	<RFC3339> ERROR pid=<pid> <message>
+//
+// Best-effort and gated on Enabled(); never blocks the caller.
+func Errorf(format string, args ...interface{}) {
+	if !Enabled() {
+		return
+	}
+	writeErrorLine("ERROR", fmt.Sprintf(format, args...))
+}
+
+// RecordDrop logs an event the CLI handled but did NOT send, with the reason
+// (e.g. "not_configured", "parse_error", "empty_stdin") and a short context
+// string. It both writes a line to errors.log and bumps the "dropped" counter,
+// so silent drops become visible in `promptconduit status` and the log.
+func RecordDrop(reason, context string) {
+	if !Enabled() {
+		return
+	}
+	detail := reason
+	if context != "" {
+		detail = reason + ": " + context
+	}
+	writeErrorLine("DROP", "event dropped ("+detail+")")
+	Bump(OutcomeDropped, detail)
+}
+
+func writeErrorLine(level, msg string) {
+	// Collapse newlines so each record stays a single grep-able line.
+	msg = strings.ReplaceAll(msg, "\n", " ")
+	line := fmt.Sprintf("%s %s pid=%d %s",
+		nowUTC().Format(timeLayout),
+		level,
+		os.Getpid(),
+		msg,
+	)
+	appendLine(ErrorsPath(), []byte(line), ErrorsRotateAt)
+}
+
+// TailErrors returns up to maxLines lines from the end of errors.log, or an
+// empty string when the file doesn't exist yet.
+func TailErrors(maxLines int) (string, error) {
+	return tailFile(ErrorsPath(), maxLines)
+}

--- a/internal/eventlog/eventlog.go
+++ b/internal/eventlog/eventlog.go
@@ -1,0 +1,158 @@
+// Package eventlog provides a discoverable, human-facing observability layer
+// for the CLI under the user's ~/.promptconduit/ directory — the same folder
+// that already holds the lightweight hook-events / app-events status traces.
+//
+// It writes three files:
+//
+//	events.ndjson  — one record per outbound event send, embedding the FULL
+//	                 envelope payload we POST to /v1/events/raw (untruncated),
+//	                 plus the HTTP outcome (status, latency, attempt).
+//	errors.log     — human-readable lines for every failure or silent drop,
+//	                 so "events aren't reaching the platform" is debuggable.
+//	status.json    — rolling counters (sent / failed / dropped) and the last
+//	                 success/error, surfaced by `promptconduit status`.
+//
+// Design notes:
+//   - This intentionally does NOT reuse internal/logger (combined error/debug
+//     log under ~/.config/…) or internal/outbound (an http.RoundTripper that
+//     truncates bodies at 64KB, also under ~/.config/…). Those serve different
+//     purposes; this layer is event-keyed, full-fidelity, and lives where the
+//     user actually browses.
+//   - Every write is best-effort: failures are swallowed so the event log can
+//     never block or fail the AI tool's hook. Observability must never break
+//     the thing it observes.
+//   - Writing is gated behind SetEnabled (default off until the process opts
+//     in via config), mirroring how internal/logger gates Debug output.
+package eventlog
+
+import (
+	"os"
+	"path/filepath"
+	"sync"
+	"time"
+)
+
+// EventsRotateAt is the size threshold at which events.ndjson is rotated to
+// events.ndjson.1. Records themselves are never truncated (full fidelity);
+// total disk is bounded by rotation instead. One backup is kept.
+const EventsRotateAt int64 = 50 * 1024 * 1024 // 50 MB
+
+// ErrorsRotateAt is the (smaller) rotation threshold for the human-readable
+// errors.log — sized like internal/logger so a tail/cat finishes instantly.
+const ErrorsRotateAt int64 = 1 << 20 // 1 MiB
+
+var (
+	// dirOverride replaces the home-dir lookup. Tests set this so they don't
+	// write into the real ~/.promptconduit. Guarded by dirMu.
+	dirOverride string
+	dirMu       sync.RWMutex
+
+	// writeMu serializes file open/append/rotate so concurrent writers (the
+	// hook process and its async send subprocess) don't interleave lines.
+	writeMu sync.Mutex
+
+	// enabled gates all writes. Off until SetEnabled(true); keeps a process
+	// that never loaded config (e.g. unit tests) from writing to the home dir.
+	enabledMu sync.RWMutex
+	enabled   bool
+)
+
+// SetDirForTest overrides the event-log directory. Test-only. Pass "" to clear.
+func SetDirForTest(dir string) {
+	dirMu.Lock()
+	defer dirMu.Unlock()
+	dirOverride = dir
+}
+
+// SetEnabled toggles all event-log writes. Call once during startup based on
+// the loaded config (cfg.EventLog). Until called, every write is a no-op.
+func SetEnabled(on bool) {
+	enabledMu.Lock()
+	enabled = on
+	enabledMu.Unlock()
+}
+
+// Enabled reports whether event-log writes are currently active.
+func Enabled() bool {
+	enabledMu.RLock()
+	defer enabledMu.RUnlock()
+	return enabled
+}
+
+// Dir returns the directory where event-log files are written:
+// ~/.promptconduit/ (matching the existing hook-events/app-events traces).
+//
+// Note this is deliberately the plain home dir, NOT client.ConfigDir(), which
+// points at ~/.config/promptconduit/. The two live in different places by
+// design — see the package doc.
+func Dir() string {
+	dirMu.RLock()
+	d := dirOverride
+	dirMu.RUnlock()
+	if d != "" {
+		return d
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return filepath.Join(os.TempDir(), "promptconduit")
+	}
+	return filepath.Join(home, ".promptconduit")
+}
+
+// EventsPath is the absolute path of the full-payload event log.
+func EventsPath() string { return filepath.Join(Dir(), "events.ndjson") }
+
+// ErrorsPath is the absolute path of the human-readable error log.
+func ErrorsPath() string { return filepath.Join(Dir(), "errors.log") }
+
+// StatusPath is the absolute path of the rolling counters file.
+func StatusPath() string { return filepath.Join(Dir(), "status.json") }
+
+// appendLine appends a single line (caller includes no trailing newline) to
+// path, rotating first if it has grown past rotateAt. Best-effort: any error
+// drops the line rather than disturbing the caller's hot path.
+func appendLine(path string, line []byte, rotateAt int64) {
+	writeMu.Lock()
+	defer writeMu.Unlock()
+
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return
+	}
+
+	rotateIfNeeded(path, rotateAt)
+
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644)
+	if err != nil {
+		return
+	}
+	defer f.Close()
+
+	_, _ = f.Write(line)
+	_, _ = f.Write([]byte{'\n'})
+}
+
+// rotateIfNeeded renames path -> path+".1" once it reaches rotateAt bytes. Any
+// prior backup is overwritten; only one is kept. Called with writeMu held.
+func rotateIfNeeded(path string, rotateAt int64) {
+	if rotateAt <= 0 {
+		return
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		return
+	}
+	if info.Size() < rotateAt {
+		return
+	}
+	backup := path + ".1"
+	_ = os.Remove(backup)
+	_ = os.Rename(path, backup)
+}
+
+// timeLayout is the timestamp format used across all event-log files.
+const timeLayout = time.RFC3339
+
+// nowUTC is the single clock used for all timestamps; kept as a var so tests
+// could stub it if needed.
+var nowUTC = func() time.Time { return time.Now().UTC() }

--- a/internal/eventlog/eventlog_test.go
+++ b/internal/eventlog/eventlog_test.go
@@ -1,0 +1,186 @@
+package eventlog
+
+import (
+	"encoding/json"
+	"errors"
+	"os"
+	"strings"
+	"testing"
+)
+
+// withTempDir points the event log at a throwaway dir and enables writes for
+// the duration of a test, restoring the prior state afterwards.
+func withTempDir(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	SetDirForTest(dir)
+	SetEnabled(true)
+	t.Cleanup(func() {
+		SetDirForTest("")
+		SetEnabled(false)
+	})
+	return dir
+}
+
+func TestRecordSendWritesFullPayloadAndBumpsSent(t *testing.T) {
+	withTempDir(t)
+
+	payload := []byte(`{"tool":"claude-code","hook_event":"Stop","native_payload":{"session_id":"abc"},"enrichment":{"correlation":{"trace_id":"t123"}}}`)
+	RecordSend(SendRecord{
+		Endpoint:  "/v1/events/raw",
+		Payload:   payload,
+		Status:    200,
+		LatencyMs: 42,
+		Attempt:   1,
+	})
+
+	data, err := os.ReadFile(EventsPath())
+	if err != nil {
+		t.Fatalf("read events.ndjson: %v", err)
+	}
+	line := strings.TrimSpace(string(data))
+
+	var rec eventRecord
+	if err := json.Unmarshal([]byte(line), &rec); err != nil {
+		t.Fatalf("event line is not valid JSON: %v\n%s", err, line)
+	}
+	if rec.Outcome != OutcomeSent {
+		t.Errorf("outcome = %q, want sent", rec.Outcome)
+	}
+	if rec.HookEvent != "Stop" || rec.Tool != "claude-code" {
+		t.Errorf("indexed fields wrong: tool=%q hook=%q", rec.Tool, rec.HookEvent)
+	}
+	if rec.SessionID != "abc" || rec.TraceID != "t123" {
+		t.Errorf("session/trace wrong: session=%q trace=%q", rec.SessionID, rec.TraceID)
+	}
+	if rec.Status != 200 || rec.LatencyMs != 42 {
+		t.Errorf("status/latency wrong: %d / %d", rec.Status, rec.LatencyMs)
+	}
+	// The full payload must be embedded as nested JSON, not a string.
+	var embedded map[string]any
+	if err := json.Unmarshal(rec.Payload, &embedded); err != nil {
+		t.Fatalf("payload is not embedded as JSON object: %v", err)
+	}
+
+	st := LoadStatus()
+	if st.Sent != 1 || st.Failed != 0 || st.Dropped != 0 {
+		t.Errorf("counters = %+v, want sent=1", st)
+	}
+	if st.LastSuccessAt == "" {
+		t.Error("last_success_at not set on success")
+	}
+}
+
+func TestRecordSendFailureWritesErrorAndBumpsFailed(t *testing.T) {
+	withTempDir(t)
+
+	RecordSend(SendRecord{
+		Endpoint: "/v1/events/raw",
+		Payload:  []byte(`{"tool":"cursor","hook_event":"Stop","native_payload":{}}`),
+		Status:   401,
+		Attempt:  1,
+		Err:      errors.New("API error: 401 - unauthorized"),
+	})
+
+	st := LoadStatus()
+	if st.Failed != 1 || st.Sent != 0 {
+		t.Errorf("counters = %+v, want failed=1", st)
+	}
+	if !strings.Contains(st.LastError, "401") {
+		t.Errorf("last_error = %q, want it to mention 401", st.LastError)
+	}
+
+	errLog, err := os.ReadFile(ErrorsPath())
+	if err != nil {
+		t.Fatalf("read errors.log: %v", err)
+	}
+	if !strings.Contains(string(errLog), "send failed") || !strings.Contains(string(errLog), "401") {
+		t.Errorf("errors.log missing failure line:\n%s", errLog)
+	}
+}
+
+func TestRecordDropLogsAndCounts(t *testing.T) {
+	withTempDir(t)
+
+	RecordDrop("not_configured", "no api key")
+
+	st := LoadStatus()
+	if st.Dropped != 1 {
+		t.Errorf("dropped = %d, want 1", st.Dropped)
+	}
+	errLog, _ := os.ReadFile(ErrorsPath())
+	if !strings.Contains(string(errLog), "not_configured") {
+		t.Errorf("errors.log missing drop reason:\n%s", errLog)
+	}
+}
+
+func TestRedactBodyMasksSecrets(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		bad  string
+	}{
+		{"openai key", `{"prompt":"my key is sk-ABCDEF0123456789abcd"}`, "sk-ABCDEF0123456789abcd"},
+		{"bearer", `Authorization: Bearer abcdefghijklmnop1234`, "abcdefghijklmnop1234"},
+		{"json token pair", `{"api_key":"supersecretvalue12345"}`, "supersecretvalue12345"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			out := string(RedactBody([]byte(tc.in)))
+			if strings.Contains(out, tc.bad) {
+				t.Errorf("secret not redacted: %s -> %s", tc.in, out)
+			}
+			if !strings.Contains(out, RedactionMask) {
+				t.Errorf("mask not present in output: %s", out)
+			}
+		})
+	}
+}
+
+func TestRedactBodyEmbeddedPayloadStaysValidJSON(t *testing.T) {
+	withTempDir(t)
+	payload := []byte(`{"tool":"claude-code","hook_event":"UserPromptSubmit","native_payload":{"prompt":"token sk-ABCDEF0123456789abcd here"}}`)
+	RecordSend(SendRecord{Endpoint: "/v1/events/raw", Payload: payload, Status: 200, Attempt: 1})
+
+	data, _ := os.ReadFile(EventsPath())
+	var rec eventRecord
+	if err := json.Unmarshal([]byte(strings.TrimSpace(string(data))), &rec); err != nil {
+		t.Fatalf("redacted line not valid JSON: %v", err)
+	}
+	if strings.Contains(string(rec.Payload), "sk-ABCDEF0123456789abcd") {
+		t.Error("secret leaked into embedded payload")
+	}
+}
+
+func TestEventsRotation(t *testing.T) {
+	dir := withTempDir(t)
+
+	// Write a line that exceeds a tiny rotation threshold by appending
+	// directly through the shared helper.
+	big := strings.Repeat("x", 200)
+	appendLine(EventsPath(), []byte(big), 100) // rotateAt=100 forces rotation
+	appendLine(EventsPath(), []byte(big), 100)
+
+	if _, err := os.Stat(EventsPath() + ".1"); err != nil {
+		t.Errorf("expected rotated backup %s.1 to exist: %v", EventsPath(), err)
+	}
+	_ = dir
+}
+
+func TestDisabledIsNoOp(t *testing.T) {
+	dir := t.TempDir()
+	SetDirForTest(dir)
+	SetEnabled(false)
+	t.Cleanup(func() { SetDirForTest("") })
+
+	RecordSend(SendRecord{Endpoint: "/v1/events/raw", Payload: []byte(`{}`), Status: 200, Attempt: 1})
+	RecordDrop("parse_error", "x")
+	Errorf("should not write")
+
+	if _, err := os.Stat(EventsPath()); !os.IsNotExist(err) {
+		t.Error("events.ndjson written while disabled")
+	}
+	if _, err := os.Stat(ErrorsPath()); !os.IsNotExist(err) {
+		t.Error("errors.log written while disabled")
+	}
+}

--- a/internal/eventlog/events.go
+++ b/internal/eventlog/events.go
@@ -1,0 +1,201 @@
+package eventlog
+
+import (
+	"encoding/json"
+	"net/http"
+	"os"
+)
+
+// SendRecord is what the client hands to RecordSend after attempting (or
+// completing) a POST to the events endpoint.
+type SendRecord struct {
+	Endpoint  string // e.g. "/v1/events/raw"
+	Payload   []byte // the exact envelope JSON we sent (full, untruncated)
+	Status    int    // HTTP status code; 0 if the request never completed
+	LatencyMs int64  // round-trip latency in milliseconds
+	Attempt   int    // 1-based attempt number
+	Err       error  // non-nil on transport error or non-2xx
+}
+
+// eventRecord is the on-disk shape (one NDJSON line in events.ndjson). The
+// envelope payload is embedded verbatim (after a secret-scrub) via RawMessage
+// so the file shows exactly what we put on the wire.
+type eventRecord struct {
+	TS        string          `json:"ts"`
+	Tool      string          `json:"tool,omitempty"`
+	HookEvent string          `json:"hook_event,omitempty"`
+	SessionID string          `json:"session_id,omitempty"`
+	TraceID   string          `json:"trace_id,omitempty"`
+	Endpoint  string          `json:"endpoint,omitempty"`
+	Outcome   Outcome         `json:"outcome"`
+	Status    int             `json:"status"`
+	LatencyMs int64           `json:"latency_ms"`
+	Attempt   int             `json:"attempt"`
+	Error     string          `json:"error,omitempty"`
+	Payload   json.RawMessage `json:"payload"`
+}
+
+// RecordSend writes one full-fidelity record to events.ndjson and updates the
+// rolling status counters. It is the single entry point the client calls for
+// every event send (success or failure). Best-effort and gated on Enabled().
+func RecordSend(rec SendRecord) {
+	if !Enabled() {
+		return
+	}
+
+	outcome := OutcomeSent
+	if rec.Err != nil || rec.Status < 200 || rec.Status >= 300 {
+		outcome = OutcomeFailed
+	}
+
+	meta := peekEnvelope(rec.Payload)
+
+	redacted := RedactBody(rec.Payload)
+	// Guarantee the payload field is always valid JSON. If the bytes aren't
+	// valid (shouldn't happen — it's our own envelope), store them as a JSON
+	// string so the NDJSON line stays parseable.
+	payload := json.RawMessage(redacted)
+	if !json.Valid(redacted) {
+		if quoted, err := json.Marshal(string(redacted)); err == nil {
+			payload = quoted
+		} else {
+			payload = json.RawMessage(`null`)
+		}
+	}
+
+	out := eventRecord{
+		TS:        nowUTC().Format(timeLayout),
+		Tool:      meta.Tool,
+		HookEvent: meta.HookEvent,
+		SessionID: meta.SessionID,
+		TraceID:   meta.TraceID,
+		Endpoint:  rec.Endpoint,
+		Outcome:   outcome,
+		Status:    rec.Status,
+		LatencyMs: rec.LatencyMs,
+		Attempt:   rec.Attempt,
+		Payload:   payload,
+	}
+	if rec.Err != nil {
+		out.Error = rec.Err.Error()
+	}
+
+	line, err := json.Marshal(out)
+	if err != nil {
+		return
+	}
+	appendLine(EventsPath(), line, EventsRotateAt)
+
+	if outcome == OutcomeFailed {
+		detail := out.Error
+		if detail == "" {
+			detail = httpDetail(rec.Status)
+		}
+		Errorf("send failed event=%s status=%d latency=%dms: %s",
+			emptyDash(meta.HookEvent), rec.Status, rec.LatencyMs, detail)
+		Bump(OutcomeFailed, detail)
+	} else {
+		Bump(OutcomeSent, "")
+	}
+}
+
+// envelopeMeta holds the few indexed fields we lift out of the envelope so the
+// event-log line is filterable without parsing the whole payload.
+type envelopeMeta struct {
+	Tool      string
+	HookEvent string
+	SessionID string
+	TraceID   string
+}
+
+// peekEnvelope unmarshals only the fields we index. The session ID lives in the
+// tool's native_payload under varying keys, so we check the common ones. All
+// best-effort: a parse failure just yields empty fields.
+func peekEnvelope(payload []byte) envelopeMeta {
+	var e struct {
+		Tool          string `json:"tool"`
+		HookEvent     string `json:"hook_event"`
+		NativePayload struct {
+			SessionID  string `json:"session_id"`
+			SessionID2 string `json:"sessionId"`
+		} `json:"native_payload"`
+		Enrichment struct {
+			Correlation struct {
+				TraceID string `json:"trace_id"`
+			} `json:"correlation"`
+		} `json:"enrichment"`
+	}
+	if err := json.Unmarshal(payload, &e); err != nil {
+		return envelopeMeta{}
+	}
+	sid := e.NativePayload.SessionID
+	if sid == "" {
+		sid = e.NativePayload.SessionID2
+	}
+	return envelopeMeta{
+		Tool:      e.Tool,
+		HookEvent: e.HookEvent,
+		SessionID: sid,
+		TraceID:   e.Enrichment.Correlation.TraceID,
+	}
+}
+
+func emptyDash(s string) string {
+	if s == "" {
+		return "-"
+	}
+	return s
+}
+
+func httpDetail(status int) string {
+	if status == 0 {
+		return "no response"
+	}
+	if txt := http.StatusText(status); txt != "" {
+		return txt
+	}
+	return "unexpected status"
+}
+
+// TailEvents returns up to maxLines lines from the end of events.ndjson, or an
+// empty string when the file doesn't exist yet.
+func TailEvents(maxLines int) (string, error) {
+	return tailFile(EventsPath(), maxLines)
+}
+
+// tailFile reads up to maxLines lines from the end of path. Returns ("", nil)
+// when the file is absent. Reads the whole file; intended for our rotated
+// (bounded) logs, not arbitrary large files.
+func tailFile(path string, maxLines int) (string, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return "", nil
+		}
+		return "", err
+	}
+	if maxLines <= 0 {
+		return string(data), nil
+	}
+	return lastLines(data, maxLines), nil
+}
+
+func lastLines(data []byte, n int) string {
+	if len(data) == 0 || n <= 0 {
+		return ""
+	}
+	count := 0
+	i := len(data) - 1
+	if data[i] == '\n' {
+		i--
+	}
+	for ; i >= 0; i-- {
+		if data[i] == '\n' {
+			count++
+			if count == n {
+				return string(data[i+1:])
+			}
+		}
+	}
+	return string(data)
+}

--- a/internal/eventlog/redact.go
+++ b/internal/eventlog/redact.go
@@ -1,0 +1,46 @@
+package eventlog
+
+import "regexp"
+
+// RedactionMask replaces any matched secret-looking substring.
+const RedactionMask = "***REDACTED***"
+
+// We write the FULL envelope payload to events.ndjson (full fidelity), so the
+// only safety pass is a conservative scrub of substrings that look like
+// credentials. The envelope body itself never carries the PromptConduit API
+// key — that travels in the Authorization header, which is not part of what we
+// log here. These patterns mainly guard against a secret a user pasted into a
+// prompt (which lands inside native_payload).
+//
+// Patterns are intentionally narrow to avoid corrupting legitimate payload
+// content. Each rule's replacement keeps any captured context groups and masks
+// only the secret value, never surrounding JSON.
+type redactRule struct {
+	re      *regexp.Regexp
+	replace string
+}
+
+var redactRules = []redactRule{
+	// Bearer <token> in any embedded auth string — keep the "Bearer " prefix.
+	{regexp.MustCompile(`(?i)(bearer\s+)[A-Za-z0-9._\-]{12,}`), `${1}` + RedactionMask},
+	// OpenAI-style and PromptConduit-style keys: sk-..., pc_..., pck_...
+	{regexp.MustCompile(`\bsk-[A-Za-z0-9]{16,}\b`), RedactionMask},
+	{regexp.MustCompile(`\bpc[ks]?_[A-Za-z0-9]{16,}\b`), RedactionMask},
+	// AWS access key IDs.
+	{regexp.MustCompile(`\bAKIA[0-9A-Z]{16}\b`), RedactionMask},
+	// GitHub personal access / fine-grained tokens.
+	{regexp.MustCompile(`\bgh[opsu]_[A-Za-z0-9]{20,}\b`), RedactionMask},
+	// Generic "<secret-ish key>": "<value>" JSON pairs (api_key, token,
+	// password, secret, access_token, ...). Keep the key, mask the value.
+	{regexp.MustCompile(`(?i)("(?:[a-z_]*(?:api[_-]?key|secret|token|password)[a-z_]*)"\s*:\s*")[^"]+(")`), `${1}` + RedactionMask + `${2}`},
+}
+
+// RedactBody returns a copy of b with well-known secret patterns masked. The
+// input is left unmodified. Full fidelity otherwise: nothing is truncated.
+func RedactBody(b []byte) []byte {
+	out := b
+	for _, rule := range redactRules {
+		out = rule.re.ReplaceAll(out, []byte(rule.replace))
+	}
+	return out
+}

--- a/internal/eventlog/status.go
+++ b/internal/eventlog/status.go
@@ -1,0 +1,121 @@
+package eventlog
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"sync"
+)
+
+// Outcome is the terminal disposition of an event the CLI handled.
+type Outcome string
+
+const (
+	OutcomeSent    Outcome = "sent"    // accepted by the platform (2xx)
+	OutcomeFailed  Outcome = "failed"  // attempted but the send errored / non-2xx
+	OutcomeDropped Outcome = "dropped" // never sent (not configured, parse error, …)
+)
+
+// Status is the rolling health summary persisted to status.json. It answers
+// "are my events actually reaching the platform?" at a glance and powers the
+// counters section of `promptconduit status`.
+type Status struct {
+	Sent          int64  `json:"sent"`
+	Failed        int64  `json:"failed"`
+	Dropped       int64  `json:"dropped"`
+	LastSuccessAt string `json:"last_success_at,omitempty"`
+	LastErrorAt   string `json:"last_error_at,omitempty"`
+	LastError     string `json:"last_error,omitempty"`
+	UpdatedAt     string `json:"updated_at,omitempty"`
+}
+
+// statusMu serializes the read-modify-write of status.json within a process.
+// Across processes (the hook parent and its async send subprocess), the
+// temp-file + rename write keeps each update atomic; the worst case is a lost
+// increment, never a corrupt file — acceptable for best-effort counters.
+var statusMu sync.Mutex
+
+// Bump increments the counter for outcome and, on failure, records the error
+// detail. Best-effort: any error is swallowed so it never disturbs the caller.
+func Bump(outcome Outcome, detail string) {
+	if !Enabled() {
+		return
+	}
+	statusMu.Lock()
+	defer statusMu.Unlock()
+
+	st := loadStatusLocked()
+	now := nowUTC().Format(timeLayout)
+	st.UpdatedAt = now
+
+	switch outcome {
+	case OutcomeSent:
+		st.Sent++
+		st.LastSuccessAt = now
+	case OutcomeFailed:
+		st.Failed++
+		st.LastErrorAt = now
+		if detail != "" {
+			st.LastError = detail
+		}
+	case OutcomeDropped:
+		st.Dropped++
+		st.LastErrorAt = now
+		if detail != "" {
+			st.LastError = detail
+		}
+	}
+
+	writeStatusLocked(st)
+}
+
+// LoadStatus returns the current counters, or a zero-value Status when the
+// file is absent or unreadable. Safe to call regardless of Enabled().
+func LoadStatus() Status {
+	statusMu.Lock()
+	defer statusMu.Unlock()
+	return loadStatusLocked()
+}
+
+func loadStatusLocked() Status {
+	var st Status
+	data, err := os.ReadFile(StatusPath())
+	if err != nil {
+		return st
+	}
+	_ = json.Unmarshal(data, &st)
+	return st
+}
+
+// writeStatusLocked writes status.json via a temp file + rename so a reader
+// never observes a half-written file. Called with statusMu held.
+func writeStatusLocked(st Status) {
+	path := StatusPath()
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return
+	}
+	data, err := json.MarshalIndent(st, "", "  ")
+	if err != nil {
+		return
+	}
+	tmp, err := os.CreateTemp(dir, "status-*.tmp")
+	if err != nil {
+		// Fall back to a direct write rather than dropping the update.
+		_ = os.WriteFile(path, data, 0o644)
+		return
+	}
+	tmpName := tmp.Name()
+	if _, err := tmp.Write(data); err != nil {
+		_ = tmp.Close()
+		_ = os.Remove(tmpName)
+		return
+	}
+	if err := tmp.Close(); err != nil {
+		_ = os.Remove(tmpName)
+		return
+	}
+	if err := os.Rename(tmpName, path); err != nil {
+		_ = os.Remove(tmpName)
+	}
+}


### PR DESCRIPTION
## Why

The `~/.promptconduit/` folder only held thin status traces (`hook-events`, `app-events` — just `{event, cwd, session_id, timestamp}`) so the macOS app can track sessions. It's easy to assume these are the payloads we send, but they aren't. The actual envelope POSTed to `/v1/events/raw` was only mirrored to `~/.config/promptconduit/outbound.ndjson` — truncated at 64KB, keyed on HTTP round-trips, with no dedicated error log and in a hidden dir users don't browse.

## What

A new `internal/eventlog` package writes a discoverable observability layer to `~/.promptconduit/`, beside the existing traces:

| File | Contents |
|------|----------|
| `events.ndjson` | One record per send: the **full untruncated envelope payload** + `outcome` (sent/failed/dropped), HTTP `status`, `latency_ms`, indexed `tool`/`hook_event`/`session_id`/`trace_id`. Secrets scrubbed; rotates to `.1` at 50MB. |
| `errors.log` | Human-readable line per failure and per silent drop (`parse_error`, `not_configured`, `empty_stdin`, `read_error`). |
| `status.json` | Rolling `sent`/`failed`/`dropped` counters + last success/error, surfaced in `promptconduit status`. |

Recording happens at the single send chokepoint (`sendEnvelopeBlocking` + the attachments path) that every send funnels through. Drops are logged at the existing drop sites in `cmd/hook.go`.

On by default with an off-switch: `config set --disable-event-log=true` or `PROMPTCONDUIT_EVENT_LOG=0`.

## Inspect

\`\`\`
promptconduit events            # summary lines
promptconduit events --raw      # full pretty-printed payload per record
promptconduit events --errors   # failures + drops
promptconduit events --follow   # live stream
promptconduit status            # new Event Log counters section
\`\`\`

## Tests / verification

- 7 new `eventlog` unit tests (record round-trip, redaction, rotation, drops, counters, disabled no-op)
- `go build`, `go vet`, `gofmt` clean; no net-new lint issues
- End-to-end smoke test against a throwaway HOME: success/failure/drop records, redaction of a planted `sk-…` key and `Bearer` token, and the off-switch all confirmed

🤖 Generated with [Claude Code](https://claude.com/claude-code)