### PR TITLE
feat: Free local-only tier + capture-time events.jsonl

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -88,6 +88,28 @@ promptconduit sync --limit 10   # Sync only N most recent
 - **Server-side adapters**: The CLI sends raw events; all transformation happens in platform adapters
 - **Config file over env vars**: Prefer `~/.config/promptconduit/config.json` for multi-environment setups
 - **Async sending**: Events are sent asynchronously to avoid blocking the AI tool
+- **Capture is decoupled from sending**: `processHookEvent` always builds the
+  envelope and writes it to the local capture log (`eventlog.RecordCapture` →
+  `~/.promptconduit/events.jsonl`) *before* deciding whether to send. The single
+  send gate is `cfg.ShouldSend()` (`internal/client/config.go`) = API key set
+  AND not local-only. This is what makes the Free tier work.
+
+## Free / local-only tier
+
+The **Free tier** is enforced entirely client-side: when `cfg.ShouldSend()` is
+false — i.e. no API key, or `local_only` is set (config `local_only`, flag
+`--local-only`, or `PROMPTCONDUIT_LOCAL_ONLY=1`) — events are captured to
+`~/.promptconduit/events.jsonl` and **never POSTed**. No platform change is
+required. A missing API key is a normal Free state, not an error (the old
+`not_configured` drop/error path was removed).
+
+Two distinct local logs under `~/.promptconduit/`:
+- `events.jsonl` — raw event envelopes, one per line, written at capture time
+  (before send) for *every* event. The stable substrate external tools read.
+- `events.ndjson` — send-outcome diagnostics (status/latency), written only when
+  an event is actually sent. Surfaced by `promptconduit status` / `events`.
+
+Both are gated by the same `PROMPTCONDUIT_EVENT_LOG` knob (on by default).
 
 ## Branch Naming
 

--- a/README.md
+++ b/README.md
@@ -305,6 +305,59 @@ Detected 3 skills:
 3 skills written. Use them with /ci-monitor, etc.
 ```
 
+## Free Tier — Local-Only Mode
+
+PromptConduit has a **Free tier that is 100% local**: every event is captured to
+a file on your machine and **nothing is ever sent to the cloud**. You register
+for free, but no telemetry leaves your computer.
+
+Local-only mode is the default whenever no API key is configured — installing
+hooks and capturing events works with no account at all. You can also opt in
+explicitly (useful if you have a key but want to stay local):
+
+```bash
+# Capture locally, never send — even if an API key is set
+promptconduit config set --local-only=true
+
+# Or enable it at install time
+promptconduit install claude-code --local-only
+
+# Or per-invocation via environment variable
+PROMPTCONDUIT_LOCAL_ONLY=1 ...
+```
+
+`promptconduit status` shows whether you're in **Free (local-only)** or
+**Cloud sync** mode. To enable cloud sync later, set an API key and turn
+local-only off (`promptconduit config set --local-only=false`).
+
+### The local event capture log (`events.jsonl`)
+
+Every captured event is written — **before any network send** — to:
+
+```
+~/.promptconduit/events.jsonl
+```
+
+This file is the durable, send-independent record of your events. It is written
+in **both** Free and Cloud modes (in Cloud mode the same envelope is then also
+sent to the platform). Each line is exactly one event envelope — the same JSON
+the CLI would POST to `/v1/events/raw`:
+
+```json
+{"envelope_version":"1.2","tool":"claude-code","hook_event":"UserPromptSubmit","captured_at":"2026-06-23T21:11:57Z","native_payload":{ ... },"enrichment":{ ... }}
+```
+
+This format is a stable contract for local tooling (e.g. an editor extension
+that reads `events.jsonl` to show a live cost estimator). Secrets matching
+well-known patterns (API keys, bearer tokens) are redacted before write; the
+file rotates to `events.jsonl.1` at 50MB. Disable all local logging — including
+this file — with `PROMPTCONDUIT_EVENT_LOG=0` or
+`promptconduit config set --disable-event-log=true`.
+
+> Note: `events.jsonl` (raw events, captured before send) is distinct from
+> `events.ndjson` (the send-outcome diagnostics log, written only when an event
+> is actually sent).
+
 ## Configuration
 
 The CLI supports multiple configuration methods with the following priority:
@@ -590,6 +643,12 @@ make snapshot
 - **Minimal**: Only captures events needed for analysis
 - **Secure**: HTTPS with API key authentication
 - **Non-blocking**: Never interferes with your workflow
+- **Free / local-only tier**: With no API key (or `--local-only`), events are
+  captured to `~/.promptconduit/events.jsonl` and **nothing is sent to the
+  cloud**. See [Free Tier — Local-Only Mode](#free-tier--local-only-mode).
+- **Local event capture log**: Every event is written to
+  `~/.promptconduit/events.jsonl` (mode `0644`) before any send, with secrets
+  redacted; rotates at 50MB. Disable with `PROMPTCONDUIT_EVENT_LOG=0`.
 - **Local outbound mirror**: Every HTTP request the CLI makes is also
   written to `~/.config/promptconduit/outbound.ndjson` (mode `0600`,
   owner-only) so you can tail it with `promptconduit watch`.

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -49,6 +49,16 @@ var configShowCmd = &cobra.Command{
 			eventLog = "disabled"
 		}
 		cmd.Printf("Event log:   %s\n", eventLog)
+		// Effective mode: Free / local-only (nothing sent) vs cloud sync. This
+		// reflects ShouldSend, so "no API key" also reads as local-only.
+		mode := "cloud sync"
+		if !cfg.ShouldSend() {
+			mode = "local-only (Free)"
+		}
+		cmd.Printf("Mode:        %s\n", mode)
+		if cfg.LocalOnly {
+			cmd.Printf("Local-only:  on\n")
+		}
 		cmd.Println()
 		cmd.Printf("Config:      %s\n", client.ConfigPath())
 
@@ -75,6 +85,7 @@ var (
 	setDebug             bool
 	setDisableAutoUpdate bool
 	setDisableEventLog   bool
+	setLocalOnly         bool
 )
 
 var configSetCmd = &cobra.Command{
@@ -99,7 +110,13 @@ Examples:
   promptconduit config set --disable-auto-update=false
 
   # Opt out of the local event log (~/.promptconduit/events.ndjson)
-  promptconduit config set --disable-event-log=true`,
+  promptconduit config set --disable-event-log=true
+
+  # Free / local-only mode: capture events locally, never send to the cloud
+  promptconduit config set --local-only=true
+
+  # Re-enable cloud sync (events sent when an API key is set)
+  promptconduit config set --local-only=false`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		fc, err := client.LoadFileConfig()
 		if err != nil {
@@ -132,9 +149,13 @@ Examples:
 			fc.DisableEventLog = setDisableEventLog
 			changed = true
 		}
+		if cmd.Flags().Changed("local-only") {
+			fc.LocalOnly = setLocalOnly
+			changed = true
+		}
 
 		if !changed {
-			return fmt.Errorf("no values provided. Use --api-key, --api-url, --debug, --disable-auto-update, or --disable-event-log")
+			return fmt.Errorf("no values provided. Use --api-key, --api-url, --debug, --disable-auto-update, --disable-event-log, or --local-only")
 		}
 
 		if err := client.SaveFileConfig(fc); err != nil {
@@ -164,6 +185,13 @@ Examples:
 				state = "disabled"
 			}
 			cmd.Printf("  Event log:   %s\n", state)
+		}
+		if cmd.Flags().Changed("local-only") {
+			if fc.LocalOnly {
+				cmd.Printf("  Mode:        local-only (Free) — events captured locally, nothing sent\n")
+			} else {
+				cmd.Printf("  Mode:        cloud sync — events sent when an API key is set\n")
+			}
 		}
 
 		return nil
@@ -386,6 +414,7 @@ func init() {
 	configSetCmd.Flags().BoolVar(&setDebug, "debug", false, "Enable debug mode")
 	configSetCmd.Flags().BoolVar(&setDisableAutoUpdate, "disable-auto-update", false, "Disable the background self-upgrade check")
 	configSetCmd.Flags().BoolVar(&setDisableEventLog, "disable-event-log", false, "Disable the local event log written to ~/.promptconduit/")
+	configSetCmd.Flags().BoolVar(&setLocalOnly, "local-only", false, "Free / local-only mode: capture events locally, never send to the cloud")
 
 	// Environment subcommands
 	configEnvCmd.AddCommand(configEnvListCmd)

--- a/cmd/hook.go
+++ b/cmd/hook.go
@@ -103,11 +103,14 @@ func processHookEvent() error {
 		recordCursorCost(rawInput)
 	}
 
-	if !cfg.IsConfigured() {
-		debugLog("API key not configured, skipping")
-		logger.Error("API key not configured — event dropped. Run `promptconduit config set --api-key=...`")
-		eventlog.RecordDrop("not_configured", "run `promptconduit config set --api-key=...`")
-		return nil
+	// Free / local-only mode: when no API key is set (or local_only is on) we
+	// still build and capture every event to the local event log below — we just
+	// never send it to the cloud. This is the legitimate Free experience, not an
+	// error, so no drop is recorded and no error is logged.
+	shouldSend := cfg.ShouldSend()
+	if !shouldSend {
+		debugLog("local-only mode — capturing locally, not sending")
+		logger.Debug("local-only mode — events captured to %s, nothing sent", eventlog.EventsJSONLPath())
 	}
 
 	// Detect tool (simple heuristics)
@@ -136,7 +139,9 @@ func processHookEvent() error {
 	// Stop: Fires after each Claude response - gives us incremental sync opportunities
 	// The sync logic deduplicates via hash checking, so frequent triggers are safe
 	// NOTE: Called directly (not in goroutine) since it spawns a subprocess and returns quickly
-	if hookEvent == "SessionEnd" || hookEvent == "Stop" {
+	// Auto-sync uploads transcripts to the platform, so it only runs in cloud
+	// mode — in Free / local-only mode there is nothing to upload.
+	if shouldSend && (hookEvent == "SessionEnd" || hookEvent == "Stop") {
 		if sessionID != "" {
 			triggerAutoSync(sessionID)
 		}
@@ -150,8 +155,6 @@ func processHookEvent() error {
 	}
 
 	enr := buildEnrichment(gitCtx, corr)
-
-	apiClient := client.NewClient(cfg, Version)
 
 	// For UserPromptSubmit events, check if the user's message includes attachments
 	// We extract from the transcript which should have the message by now
@@ -190,13 +193,20 @@ func processHookEvent() error {
 				// Create envelope with attachment metadata
 				env := envelope.NewWithAttachments(Version, tool, hookEvent, rawInput, enr, envAttachments)
 
-				// Send via multipart with binary attachments
-				if err := apiClient.SendEnvelopeWithAttachmentsAsync(env, attachmentData); err != nil {
-					logger.Error("Failed to send envelope with attachments (event=%s, tool=%s): %v", hookEvent, tool, err)
+				// Always record the captured event locally, before any send.
+				captureEnvelope(env)
+
+				if shouldSend {
+					// Send via multipart with binary attachments
+					if err := client.NewClient(cfg, Version).SendEnvelopeWithAttachmentsAsync(env, attachmentData); err != nil {
+						logger.Error("Failed to send envelope with attachments (event=%s, tool=%s): %v", hookEvent, tool, err)
+					} else {
+						logger.Debug("UserPromptSubmit with %d attachments sent successfully", len(attachments))
+					}
 				} else {
-					logger.Debug("UserPromptSubmit with %d attachments sent successfully", len(attachments))
+					logger.Debug("local-only: captured UserPromptSubmit with %d attachments, not sent", len(attachments))
 				}
-				// Return here - we've sent the event with attachments, don't send again below
+				// Return here - we've handled the event with attachments, don't process again below
 				return nil
 			}
 		}
@@ -207,14 +217,35 @@ func processHookEvent() error {
 
 	logger.Debug("Created envelope: tool=%s, event=%s", tool, hookEvent)
 
+	// Always record the captured event locally, before any send.
+	captureEnvelope(env)
+
+	if !shouldSend {
+		return nil
+	}
+
 	// Send async
-	if err := apiClient.SendEnvelopeAsync(env); err != nil {
+	if err := client.NewClient(cfg, Version).SendEnvelopeAsync(env); err != nil {
 		debugLog("Failed to send envelope async: %v", err)
 		logger.Error("Failed to spawn async sender (event=%s, tool=%s): %v", hookEvent, tool, err)
 	}
 
 	logger.Debug("Envelope queued for async send")
 	return nil
+}
+
+// captureEnvelope writes the exact envelope JSON we would POST to the local
+// capture log (~/.promptconduit/events.jsonl) before any network send. This is
+// the unconditional local record of the event — it runs for both cloud and
+// Free / local-only installs. Best-effort: serialization failure is logged at
+// debug and the line is dropped rather than disturbing the hook.
+func captureEnvelope(env *envelope.RawEventEnvelope) {
+	data, err := env.ToJSON()
+	if err != nil {
+		logger.Debug("capture: failed to serialize envelope: %v", err)
+		return
+	}
+	eventlog.RecordCapture(data)
 }
 
 // buildEnrichment assembles the enrichment block: CLI-computed context that

--- a/cmd/install.go
+++ b/cmd/install.go
@@ -10,6 +10,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/promptconduit/cli/internal/client"
 	"github.com/promptconduit/cli/internal/envelope"
 	"github.com/promptconduit/cli/internal/outbound"
 	"github.com/spf13/cobra"
@@ -34,10 +35,22 @@ Supported tools:
   - copilot:     GitHub Copilot CLI         (~/.copilot/hooks/promptconduit.json)
 
 The hooks capture events locally and realtime cost tracking works immediately.
-Set an API key (promptconduit config set --api-key=...) only if you also want to
-sync events to the PromptConduit platform.`,
+This is the Free tier: 100% local — every event is captured to
+~/.promptconduit/events.jsonl and nothing is sent anywhere. Set an API key
+(promptconduit config set --api-key=...) only if you also want to sync events to
+the PromptConduit platform. To stay local-only even after setting a key, pass
+--local-only.`,
 	Args: cobra.ArbitraryArgs,
 	RunE: runInstall,
+}
+
+// installLocalOnly opts the install into Free / local-only mode: events are
+// captured to the local event log but never sent to the cloud.
+var installLocalOnly bool
+
+func init() {
+	installCmd.Flags().BoolVar(&installLocalOnly, "local-only", false,
+		"Free / local-only mode: capture events locally, never send to the cloud")
 }
 
 // installableTools is the ordered set offered in the interactive picker.
@@ -59,6 +72,15 @@ func runInstall(cmd *cobra.Command, args []string) error {
 		return nil
 	}
 
+	if installLocalOnly {
+		if err := persistLocalOnly(true); err != nil {
+			fmt.Fprintf(cmd.ErrOrStderr(), "warning: could not save local-only setting: %v\n", err)
+		} else {
+			fmt.Fprintln(cmd.OutOrStdout(), "Free / local-only mode enabled — events are captured locally and never sent.")
+			fmt.Fprintln(cmd.OutOrStdout())
+		}
+	}
+
 	exePath, err := os.Executable()
 	if err != nil {
 		return fmt.Errorf("failed to get executable path: %w", err)
@@ -77,6 +99,21 @@ func runInstall(cmd *cobra.Command, args []string) error {
 		}
 	}
 	return nil
+}
+
+// persistLocalOnly writes the local_only flag into the config file so the Free
+// tier survives across hook invocations. Mirrors how `config set --local-only`
+// persists the same setting.
+func persistLocalOnly(v bool) error {
+	fc, err := client.LoadFileConfig()
+	if err != nil {
+		return err
+	}
+	if fc == nil {
+		fc = &client.FileConfig{}
+	}
+	fc.LocalOnly = v
+	return client.SaveFileConfig(fc)
 }
 
 // stableExecutablePath returns an absolute path to the running binary that is

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -23,13 +23,24 @@ var statusCmd = &cobra.Command{
 func runStatus(cmd *cobra.Command, args []string) error {
 	fmt.Printf("PromptConduit CLI v%s\n\n", Version)
 
-	// Check API key configuration
+	// Mode + API key. Free / local-only is a first-class mode, not an error:
+	// events are captured locally and nothing is sent. Cloud sync requires an
+	// API key and local_only off.
 	cfg := client.LoadConfig()
-	if cfg.IsConfigured() {
+	if cfg.ShouldSend() {
+		fmt.Println("Mode:    Cloud sync — events sent to the platform")
 		fmt.Printf("API Key: %s (configured)\n", client.MaskAPIKey(cfg.APIKey))
 	} else {
-		fmt.Println("API Key: Not configured")
-		fmt.Println("  Set with: promptconduit config set --api-key=\"your-api-key\"")
+		fmt.Println("Mode:    Free (local-only) — events captured locally, nothing sent")
+		if cfg.LocalOnly {
+			fmt.Println("  local_only is on. Enable cloud sync with: promptconduit config set --local-only=false")
+		}
+		if cfg.IsConfigured() {
+			fmt.Printf("API Key: %s (configured, unused in local-only mode)\n", client.MaskAPIKey(cfg.APIKey))
+		} else {
+			fmt.Println("API Key: Not set — add one to enable cloud sync:")
+			fmt.Println("  promptconduit config set --api-key=\"your-api-key\"")
+		}
 	}
 
 	fmt.Printf("API URL: %s\n", cfg.APIURL)
@@ -67,7 +78,14 @@ func printEventLogStatus(cfg *client.Config) {
 	if st.LastError != "" {
 		fmt.Printf("  Last error:   %s — %s\n", localTime(st.LastErrorAt), st.LastError)
 	}
-	fmt.Printf("  Payloads:     %s\n", eventlog.EventsPath())
+	// Captured events: the send-independent local stream (events.jsonl), written
+	// for every event even in Free / local-only mode.
+	fmt.Printf("  Captured:     %s", eventlog.EventsJSONLPath())
+	if n, ok := eventlog.CountCaptured(); ok {
+		fmt.Printf(" (%d events)", n)
+	}
+	fmt.Println()
+	fmt.Printf("  Sent log:     %s\n", eventlog.EventsPath())
 	fmt.Println("  Inspect with: promptconduit events")
 	fmt.Println()
 }

--- a/cmd/test.go
+++ b/cmd/test.go
@@ -20,8 +20,18 @@ Prerequisites:
 func runTest(cmd *cobra.Command, args []string) error {
 	cfg := client.LoadConfig()
 
+	// Free / local-only mode sends nothing, so there's no cloud connection to
+	// test. Report it plainly rather than failing on a missing key.
+	if cfg.LocalOnly {
+		fmt.Println("Local-only mode: events are captured locally and never sent, so there's nothing to test.")
+		fmt.Println("Enable cloud sync with: promptconduit config set --local-only=false (and set an API key).")
+		return nil
+	}
+
 	if !cfg.IsConfigured() {
-		return fmt.Errorf("API key not configured. Set PROMPTCONDUIT_API_KEY environment variable")
+		fmt.Println("Local-only mode: no API key is set, so events are captured locally and nothing is sent.")
+		fmt.Println("Enable cloud sync with: promptconduit config set --api-key=\"your-api-key\"")
+		return nil
 	}
 
 	fmt.Printf("Testing connection to %s...\n", cfg.APIURL)

--- a/internal/client/config.go
+++ b/internal/client/config.go
@@ -17,6 +17,7 @@ const (
 	EnvTool            = "PROMPTCONDUIT_TOOL"
 	EnvAutoUpdate      = "PROMPTCONDUIT_AUTO_UPDATE" // "0"/"false" disables background self-upgrade
 	EnvEventLog        = "PROMPTCONDUIT_EVENT_LOG"   // "0"/"false" disables the local ~/.promptconduit event log
+	EnvLocalOnly       = "PROMPTCONDUIT_LOCAL_ONLY"  // "1"/"true" forces Free / local-only mode (never send to the cloud)
 	EnvXDGConfigHome   = "XDG_CONFIG_HOME"
 	ConfigDirName      = "promptconduit" // ~/.config/promptconduit/
 	ConfigFileName     = "config.json"
@@ -35,6 +36,10 @@ type Config struct {
 	// to ~/.promptconduit/ (events.ndjson, errors.log, status.json). Zero
 	// value (false) leaves the event log enabled — it's on by default.
 	DisableEventLog bool `json:"disable_event_log,omitempty"`
+	// LocalOnly is the Free tier: events are captured to the local event log
+	// but NEVER sent to the cloud, regardless of whether an API key is set.
+	// Zero value (false) leaves cloud sync enabled (when an API key exists).
+	LocalOnly bool `json:"local_only,omitempty"`
 }
 
 // FileConfig represents the config file structure with environment support
@@ -52,6 +57,7 @@ type FileConfig struct {
 	Timeout           int    `json:"timeout_seconds,omitempty"`
 	DisableAutoUpdate bool   `json:"disable_auto_update,omitempty"`
 	DisableEventLog   bool   `json:"disable_event_log,omitempty"`
+	LocalOnly         bool   `json:"local_only,omitempty"`
 }
 
 // EventLogEnabled reports whether the local ~/.promptconduit event log should
@@ -64,6 +70,14 @@ func (c *Config) EventLogEnabled() bool {
 // IsConfigured returns true if the API key is set
 func (c *Config) IsConfigured() bool {
 	return c.APIKey != ""
+}
+
+// ShouldSend reports whether captured events should be sent to the cloud. It is
+// the single send gate: events go to the platform only when an API key is set
+// AND local-only mode is off. A missing API key OR LocalOnly both mean Free /
+// local-only — events are still captured locally, just never transmitted.
+func (c *Config) ShouldSend() bool {
+	return c.IsConfigured() && !c.LocalOnly
 }
 
 // ConfigPath returns the path to the config file (XDG standard)
@@ -154,7 +168,7 @@ func (fc *FileConfig) GetCurrentConfig() *Config {
 	}
 
 	// Fall back to legacy flat config
-	if fc.APIKey != "" || fc.APIURL != "" || fc.DisableAutoUpdate || fc.DisableEventLog {
+	if fc.APIKey != "" || fc.APIURL != "" || fc.DisableAutoUpdate || fc.DisableEventLog || fc.LocalOnly {
 		return &Config{
 			APIKey:            fc.APIKey,
 			APIURL:            fc.APIURL,
@@ -162,6 +176,7 @@ func (fc *FileConfig) GetCurrentConfig() *Config {
 			TimeoutSeconds:    fc.Timeout,
 			DisableAutoUpdate: fc.DisableAutoUpdate,
 			DisableEventLog:   fc.DisableEventLog,
+			LocalOnly:         fc.LocalOnly,
 		}
 	}
 
@@ -199,6 +214,9 @@ func LoadConfig() *Config {
 			if fileCfg.DisableEventLog {
 				cfg.DisableEventLog = true
 			}
+			if fileCfg.LocalOnly {
+				cfg.LocalOnly = true
+			}
 		}
 	}
 
@@ -212,6 +230,12 @@ func LoadConfig() *Config {
 	// anything else (or unset) leaves whatever the file config decided.
 	if v := os.Getenv(EnvEventLog); v == "0" || v == "false" || v == "no" {
 		cfg.DisableEventLog = true
+	}
+
+	// PROMPTCONDUIT_LOCAL_ONLY=1/true/yes forces Free / local-only mode;
+	// anything else (or unset) leaves whatever the file config decided.
+	if v := os.Getenv(EnvLocalOnly); v == "1" || v == "true" || v == "yes" {
+		cfg.LocalOnly = true
 	}
 
 	// Apply defaults

--- a/internal/client/config_test.go
+++ b/internal/client/config_test.go
@@ -32,6 +32,82 @@ func TestConfigPath(t *testing.T) {
 	}
 }
 
+func TestShouldSend(t *testing.T) {
+	cases := []struct {
+		name      string
+		apiKey    string
+		localOnly bool
+		want      bool
+	}{
+		{"key set, cloud mode", "sk_x", false, true},
+		{"key set, local-only", "sk_x", true, false},
+		{"no key (implicit local-only)", "", false, false},
+		{"no key, local-only", "", true, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			c := &Config{APIKey: tc.apiKey, LocalOnly: tc.localOnly}
+			if got := c.ShouldSend(); got != tc.want {
+				t.Errorf("ShouldSend() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+// withIsolatedConfig points config resolution at a throwaway XDG dir and clears
+// any PROMPTCONDUIT_* env vars that would otherwise leak from the host, so
+// LoadConfig is deterministic. Restores prior env on cleanup.
+func withIsolatedConfig(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	keys := []string{EnvXDGConfigHome, EnvAPIKey, EnvAPIURL, EnvLocalOnly, EnvEventLog, EnvAutoUpdate, EnvDebug, EnvTimeout}
+	saved := make(map[string]string, len(keys))
+	for _, k := range keys {
+		saved[k] = os.Getenv(k)
+		os.Unsetenv(k)
+	}
+	os.Setenv(EnvXDGConfigHome, dir)
+	t.Cleanup(func() {
+		for k, v := range saved {
+			if v == "" {
+				os.Unsetenv(k)
+			} else {
+				os.Setenv(k, v)
+			}
+		}
+	})
+	return dir
+}
+
+func TestLoadConfigLocalOnlyFromEnv(t *testing.T) {
+	withIsolatedConfig(t)
+	os.Setenv(EnvLocalOnly, "1")
+
+	if cfg := LoadConfig(); !cfg.LocalOnly {
+		t.Error("LocalOnly should be true when PROMPTCONDUIT_LOCAL_ONLY=1")
+	}
+}
+
+func TestLoadConfigLocalOnlyFromFile(t *testing.T) {
+	withIsolatedConfig(t)
+
+	if err := SaveFileConfig(&FileConfig{LocalOnly: true}); err != nil {
+		t.Fatalf("save config: %v", err)
+	}
+	if cfg := LoadConfig(); !cfg.LocalOnly {
+		t.Error("LocalOnly should be true when local_only:true is set in the config file")
+	}
+}
+
+func TestLoadConfigDefaultsToCloudMode(t *testing.T) {
+	withIsolatedConfig(t)
+
+	cfg := LoadConfig()
+	if cfg.LocalOnly {
+		t.Error("LocalOnly should default to false with no env/file override")
+	}
+}
+
 func TestAllConfigPaths(t *testing.T) {
 	// Save original env vars
 	origXDG := os.Getenv(EnvXDGConfigHome)

--- a/internal/eventlog/capture.go
+++ b/internal/eventlog/capture.go
@@ -1,0 +1,59 @@
+package eventlog
+
+import (
+	"encoding/json"
+	"os"
+)
+
+// RecordCapture appends one raw event envelope to events.jsonl, exactly as it
+// would be POSTed to /v1/events/raw, captured at hook time BEFORE any network
+// send is attempted.
+//
+// This is deliberately distinct from RecordSend (events.ndjson): RecordSend is
+// keyed on a send outcome and only fires when we actually try to send, whereas
+// RecordCapture is the unconditional local record of the event. It runs for
+// every captured event — including Free / local-only installs that never send —
+// so the file is a complete, send-independent stream that local tooling (e.g. a
+// cost estimator) can read.
+//
+// Each line is the bare envelope JSON (no outcome wrapper), secret-scrubbed by
+// RedactBody. Best-effort and gated on Enabled(): a write failure drops the
+// line rather than disturbing the hook's hot path.
+func RecordCapture(payload []byte) {
+	if !Enabled() {
+		return
+	}
+
+	line := RedactBody(payload)
+	// The payload is our own envelope, so this should always hold; guard anyway
+	// so a malformed line can never corrupt the JSONL stream readers depend on.
+	if !json.Valid(line) {
+		return
+	}
+
+	appendLine(EventsJSONLPath(), line, EventsRotateAt)
+}
+
+// CountCaptured returns the number of events currently in events.jsonl and
+// false if the file doesn't exist yet. Best-effort; reads the whole file, whose
+// size is bounded by rotation (EventsRotateAt).
+func CountCaptured() (int, bool) {
+	data, err := os.ReadFile(EventsJSONLPath())
+	if err != nil {
+		return 0, false
+	}
+	if len(data) == 0 {
+		return 0, true
+	}
+	n := 0
+	for _, b := range data {
+		if b == '\n' {
+			n++
+		}
+	}
+	// Count a trailing line that has no terminating newline.
+	if data[len(data)-1] != '\n' {
+		n++
+	}
+	return n, true
+}

--- a/internal/eventlog/capture_test.go
+++ b/internal/eventlog/capture_test.go
@@ -1,0 +1,92 @@
+package eventlog
+
+import (
+	"encoding/json"
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestRecordCaptureWritesBareEnvelope(t *testing.T) {
+	withTempDir(t)
+
+	payload := []byte(`{"envelope_version":"1.2","tool":"claude-code","hook_event":"UserPromptSubmit","native_payload":{"session_id":"abc"}}`)
+	RecordCapture(payload)
+
+	data, err := os.ReadFile(EventsJSONLPath())
+	if err != nil {
+		t.Fatalf("read events.jsonl: %v", err)
+	}
+	line := strings.TrimSpace(string(data))
+
+	// The line must be the bare envelope object, not the send-outcome wrapper
+	// that events.ndjson uses — external readers parse a clean envelope stream.
+	var env map[string]any
+	if err := json.Unmarshal([]byte(line), &env); err != nil {
+		t.Fatalf("captured line is not valid JSON: %v\n%s", err, line)
+	}
+	if env["tool"] != "claude-code" || env["hook_event"] != "UserPromptSubmit" {
+		t.Errorf("unexpected envelope fields: %v", env)
+	}
+	if _, ok := env["outcome"]; ok {
+		t.Error("capture line should not carry a send-outcome wrapper (outcome)")
+	}
+	if _, ok := env["payload"]; ok {
+		t.Error("capture line should be the bare envelope, not a {payload:...} wrapper")
+	}
+
+	if n, ok := CountCaptured(); !ok || n != 1 {
+		t.Errorf("CountCaptured() = %d,%v want 1,true", n, ok)
+	}
+}
+
+func TestRecordCaptureRedactsSecrets(t *testing.T) {
+	withTempDir(t)
+
+	RecordCapture([]byte(`{"tool":"cursor","native_payload":{"prompt":"my key sk-ABCDEF0123456789abcd"}}`))
+
+	data, err := os.ReadFile(EventsJSONLPath())
+	if err != nil {
+		t.Fatalf("read events.jsonl: %v", err)
+	}
+	if strings.Contains(string(data), "sk-ABCDEF0123456789abcd") {
+		t.Errorf("secret leaked into events.jsonl:\n%s", data)
+	}
+}
+
+func TestRecordCaptureDisabledIsNoOp(t *testing.T) {
+	dir := t.TempDir()
+	SetDirForTest(dir)
+	SetEnabled(false)
+	t.Cleanup(func() { SetDirForTest("") })
+
+	RecordCapture([]byte(`{"tool":"claude-code"}`))
+
+	if _, err := os.Stat(EventsJSONLPath()); !os.IsNotExist(err) {
+		t.Error("events.jsonl written while disabled")
+	}
+	if n, ok := CountCaptured(); ok || n != 0 {
+		t.Errorf("CountCaptured() = %d,%v want 0,false", n, ok)
+	}
+}
+
+func TestRecordCaptureSkipsInvalidJSON(t *testing.T) {
+	withTempDir(t)
+
+	RecordCapture([]byte(`this is not json`))
+
+	if _, err := os.Stat(EventsJSONLPath()); !os.IsNotExist(err) {
+		t.Error("invalid JSON should never be appended to events.jsonl")
+	}
+}
+
+func TestCountCapturedCountsEachLine(t *testing.T) {
+	withTempDir(t)
+
+	for i := 0; i < 3; i++ {
+		RecordCapture([]byte(`{"tool":"claude-code","hook_event":"Stop"}`))
+	}
+	if n, ok := CountCaptured(); !ok || n != 3 {
+		t.Errorf("CountCaptured() = %d,%v want 3,true", n, ok)
+	}
+}

--- a/internal/eventlog/eventlog.go
+++ b/internal/eventlog/eventlog.go
@@ -102,6 +102,13 @@ func Dir() string {
 // EventsPath is the absolute path of the full-payload event log.
 func EventsPath() string { return filepath.Join(Dir(), "events.ndjson") }
 
+// EventsJSONLPath is the absolute path of the capture log: one raw envelope per
+// line, written at capture time BEFORE any network send. Unlike events.ndjson
+// (which is keyed on send outcome), this file is the durable local substrate of
+// the events themselves — it is written even when nothing is sent (Free /
+// local-only mode), and is the file external local tooling reads.
+func EventsJSONLPath() string { return filepath.Join(Dir(), "events.jsonl") }
+
 // ErrorsPath is the absolute path of the human-readable error log.
 func ErrorsPath() string { return filepath.Join(Dir(), "errors.log") }
 


### PR DESCRIPTION
## Summary

Adds a **Free tier that is 100% local** and a **capture-time `events.jsonl`** log. The core change is decoupling local event capture from cloud sending:

- The CLI now **always builds the event envelope and writes it locally before deciding whether to send.**
- Sending happens only when an API key is set **and** local-only mode is off.

A Free user is simply "registered + CLI running local-only" — nothing is transmitted. This is enforced **entirely client-side; no server changes**.

## Changes

**Capture log (data substrate)**
- `internal/eventlog/capture.go` (new): `RecordCapture` writes the bare envelope, one per line, to `~/.promptconduit/events.jsonl` at capture time, for every event in both Free and Cloud modes. Secrets redacted; rotates at 50MB.
- `eventlog.EventsJSONLPath()` + `CountCaptured()`.
- Distinct from `events.ndjson`, which stays as the send-outcome diagnostics log. Stable format for future local tooling (e.g. an editor cost estimator).

**Free / local-only mode**
- `internal/client/config.go`: `LocalOnly` field (`local_only` / `--local-only` / `PROMPTCONDUIT_LOCAL_ONLY`) + single send gate `cfg.ShouldSend()` = API key set AND not local-only.
- `cmd/hook.go`: build + `RecordCapture` always, send only when `ShouldSend()`. Removed the `not_configured` drop/error spam (missing key is now a normal Free state). Auto-sync gated off in local-only mode.
- `cmd/config.go`, `cmd/status.go`, `cmd/test.go`, `cmd/install.go`: surface **Free (local-only)** vs **Cloud sync** mode; `--local-only` install flag.

**Docs**: `README.md` (new "Free Tier — Local-Only Mode" section + `events.jsonl` format contract, Privacy bullets), `CLAUDE.md`.

## Testing

- New tests: `RecordCapture` (write / redact / disabled / count) and `ShouldSend` truth table + env/file parsing.
- `go build`, `go vet`, `go test ./...` all pass. (`make lint` exits non-zero on pre-existing issues only — same 62 on `main`; this PR adds none.)
- Verified end-to-end in an isolated HOME/XDG:
  - **Free path**: events written to `events.jsonl` (envelope + correlation IDs, secret redacted); no `outbound.ndjson` / `events.ndjson` / `errors.log`.
  - **Cloud path**: `events.jsonl` captured *and* a send attempted (lands in `events.ndjson`).

## Notes

Paid billing is untouched — this PR only adds the Free path and the local capture log. Free enforcement is client-side by design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)