### PR TITLE
feat(cost): per-request tool-call summary in cost feed (#70)

### DIFF
--- a/cmd/cost.go
+++ b/cmd/cost.go
@@ -9,6 +9,7 @@ import (
 	"os/signal"
 	"path/filepath"
 	"sort"
+	"strings"
 	"syscall"
 	"time"
 
@@ -258,6 +259,37 @@ func renderSessionHuman(out io.Writer, s cost.SessionSummary) {
 		fmt.Fprintf(out, "    %-22s %-10s  in %d · out %d · cache-read %d · cache-write %d\n",
 			m.Model, costStr, m.Tokens.Input, m.Tokens.Output, m.Tokens.CacheRead, m.Tokens.CacheWrite)
 	}
+	if s.Tools.Total > 0 {
+		fmt.Fprintf(out, "  Tools: %d call(s)%s\n", s.Tools.Total, formatToolBreakdown(s.Tools.ByName))
+	}
+}
+
+// formatToolBreakdown renders a per-tool count like "  (Read ×3, Bash ×1)",
+// sorted by count desc then name. Names only — no inputs are ever shown.
+// Returns "" when there's no breakdown.
+func formatToolBreakdown(byName map[string]int) string {
+	if len(byName) == 0 {
+		return ""
+	}
+	type tc struct {
+		name  string
+		count int
+	}
+	tcs := make([]tc, 0, len(byName))
+	for n, c := range byName {
+		tcs = append(tcs, tc{n, c})
+	}
+	sort.Slice(tcs, func(i, j int) bool {
+		if tcs[i].count != tcs[j].count {
+			return tcs[i].count > tcs[j].count
+		}
+		return tcs[i].name < tcs[j].name
+	})
+	parts := make([]string, len(tcs))
+	for i, t := range tcs {
+		parts[i] = fmt.Sprintf("%s ×%d", t.name, t.count)
+	}
+	return "  (" + strings.Join(parts, ", ") + ")"
 }
 
 func runCostHistory(cmd *cobra.Command, args []string) error {

--- a/internal/cost/claudecode.go
+++ b/internal/cost/claudecode.go
@@ -166,7 +166,11 @@ type ccLine struct {
 	Cwd       string `json:"cwd"`
 	Message   struct {
 		Model string `json:"model"`
-		Usage struct {
+		// Content holds the assistant turn's blocks. We read only the `type`
+		// and (for tool_use) the `name` of each — never the `input`, which
+		// carries file paths / commands / prompt text. See ccContentBlock.
+		Content []ccContentBlock `json:"content"`
+		Usage   struct {
 			InputTokens              int64 `json:"input_tokens"`
 			OutputTokens             int64 `json:"output_tokens"`
 			CacheReadInputTokens     int64 `json:"cache_read_input_tokens"`
@@ -177,6 +181,15 @@ type ccLine struct {
 			} `json:"cache_creation"`
 		} `json:"usage"`
 	} `json:"message"`
+}
+
+// ccContentBlock is the privacy-narrowed view of one assistant content block.
+// It deliberately omits `input` (and `text`/`thinking`) so a tool call's
+// arguments can never leak into a cost event — only the tool's Name is read,
+// and only for tool_use blocks.
+type ccContentBlock struct {
+	Type string `json:"type"`
+	Name string `json:"name"`
 }
 
 // parseClaudeCodeLine turns one transcript line into a priced CostEvent. The
@@ -218,6 +231,16 @@ func parseClaudeCodeLine(line []byte, table *PriceTable, sessionFallback string)
 		sessionID = sessionFallback
 	}
 
+	// Collect the names of any tool_use blocks in this assistant turn. The
+	// transcript is the same source the cost event already parses, so no extra
+	// I/O or join is needed. Names only — inputs are never read.
+	var toolNames []string
+	for _, b := range l.Message.Content {
+		if b.Type == "tool_use" {
+			toolNames = append(toolNames, b.Name)
+		}
+	}
+
 	ev = CostEvent{
 		V:           SchemaVersion,
 		Kind:        "cost_event",
@@ -236,6 +259,7 @@ func parseClaudeCodeLine(line []byte, table *PriceTable, sessionFallback string)
 		},
 		Cost:    c,
 		CwdBase: filepath.Base(l.Cwd),
+		Tools:   summarizeToolNames(toolNames),
 	}
 	return ev, dedupKey, true
 }

--- a/internal/cost/cost_test.go
+++ b/internal/cost/cost_test.go
@@ -137,6 +137,96 @@ func TestParseClaudeCodeLine(t *testing.T) {
 	}
 }
 
+// TestSummarizeToolNames covers the names-only roll-up helper: counts, the
+// per-name map, empty-name skipping, and the empty input case.
+func TestSummarizeToolNames(t *testing.T) {
+	s := summarizeToolNames([]string{"Read", "Bash", "Read", ""})
+	if s.Total != 3 {
+		t.Fatalf("total = %d, want 3 (empty name skipped)", s.Total)
+	}
+	if s.ByName["Read"] != 2 || s.ByName["Bash"] != 1 {
+		t.Fatalf("by_name = %v, want Read:2 Bash:1", s.ByName)
+	}
+	if _, ok := s.ByName[""]; ok {
+		t.Fatal("empty tool name must never be recorded")
+	}
+
+	empty := summarizeToolNames(nil)
+	if empty.Total != 0 || empty.ByName != nil {
+		t.Fatalf("no tools should yield zero summary, got %+v", empty)
+	}
+}
+
+// TestParseClaudeCodeLine_ToolSummary verifies the per-request tool-call
+// summary is derived from the assistant turn's tool_use blocks (names only),
+// from the same transcript line the cost event already parses.
+func TestParseClaudeCodeLine_ToolSummary(t *testing.T) {
+	tbl := mustTable(t)
+
+	// Two tool_use blocks (Read twice) plus a text block, all in one turn.
+	line := []byte(`{"type":"assistant","requestId":"req_tools","sessionId":"s","timestamp":"2026-06-24T00:00:00Z","cwd":"/p","message":{"model":"claude-opus-4-8","content":[{"type":"text","text":"on it"},{"type":"tool_use","id":"t1","name":"Read","input":{"file_path":"/etc/passwd"}},{"type":"tool_use","id":"t2","name":"Read","input":{"file_path":"/secret"}}],"usage":{"input_tokens":10,"output_tokens":20}}}`)
+	ev, _, ok := parseClaudeCodeLine(line, tbl, "fallback")
+	if !ok {
+		t.Fatal("assistant line with usage should parse")
+	}
+	if ev.Tools.Total != 2 {
+		t.Fatalf("tools total = %d, want 2", ev.Tools.Total)
+	}
+	if ev.Tools.ByName["Read"] != 2 {
+		t.Fatalf("Read count = %d, want 2", ev.Tools.ByName["Read"])
+	}
+
+	// Privacy invariant: serialized event must not leak any tool input. The
+	// token-count fields legitimately use the key "input", so we assert on the
+	// tool-input KEY ("file_path") and its VALUES (the actual paths) instead.
+	data, err := json.Marshal(ev)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	for _, leak := range []string{"file_path", "/etc/passwd", "/secret"} {
+		if bytes.Contains(data, []byte(leak)) {
+			t.Fatalf("serialized cost event leaked tool content %q: %s", leak, data)
+		}
+	}
+
+	// A turn with no tool_use blocks yields an empty (omitted) summary.
+	noTools := []byte(`{"type":"assistant","requestId":"req_none","message":{"model":"claude-opus-4-8","content":[{"type":"text","text":"hi"}],"usage":{"input_tokens":1,"output_tokens":1}}}`)
+	evN, _, ok := parseClaudeCodeLine(noTools, tbl, "fallback")
+	if !ok {
+		t.Fatal("text-only assistant line should still parse for cost")
+	}
+	if evN.Tools.Total != 0 || evN.Tools.ByName != nil {
+		t.Fatalf("no-tool turn should have empty summary, got %+v", evN.Tools)
+	}
+}
+
+// TestSessionSummaryToolAggregation verifies per-request tool summaries roll
+// up into the session-level SessionSummary.Tools the watcher emits.
+func TestSessionSummaryToolAggregation(t *testing.T) {
+	w := NewWatcher(nil, nil, nil, false)
+	w.apply(CostEvent{
+		Kind: "cost_event", Tool: ToolClaudeCode, SessionID: "s", RequestID: "r1",
+		Timestamp: "2026-06-24T00:00:00Z", Model: "m",
+		Tools: summarizeToolNames([]string{"Read", "Bash"}),
+	})
+	w.apply(CostEvent{
+		Kind: "cost_event", Tool: ToolClaudeCode, SessionID: "s", RequestID: "r2",
+		Timestamp: "2026-06-24T00:00:01Z", Model: "m",
+		Tools: summarizeToolNames([]string{"Read"}),
+	})
+
+	s, ok := w.LatestSummary()
+	if !ok {
+		t.Fatal("expected a session summary")
+	}
+	if s.Tools.Total != 3 {
+		t.Fatalf("session tool total = %d, want 3", s.Tools.Total)
+	}
+	if s.Tools.ByName["Read"] != 2 || s.Tools.ByName["Bash"] != 1 {
+		t.Fatalf("aggregated by_name = %v, want Read:2 Bash:1", s.Tools.ByName)
+	}
+}
+
 // TestParseCursorHookPayload uses the real Cursor hook shape captured from the
 // M0 probe: top-level token fields, model, conversation/generation ids.
 func TestParseCursorHookPayload(t *testing.T) {

--- a/internal/cost/cursor.go
+++ b/internal/cost/cursor.go
@@ -76,6 +76,14 @@ func ParseCursorHookPayload(raw []byte, table *PriceTable) (ev CostEvent, cwd st
 	mp, priced := table.ResolvePrice(p.Model)
 	c, cacheWriteTokens := CostForUsage(usage, mp)
 
+	// Tool-call summary (schema v2): left empty for Cursor. The cost event is
+	// derived solely from the `stop` / `afterAgentResponse` payload, which
+	// carries token counts but no tool names. Cursor's per-tool hooks
+	// (`preToolUse`, `afterFileEdit`, `beforeShellExecution`, …) fire in
+	// separate processes earlier in the turn, and Cursor does not guarantee a
+	// stable `generation_id` on them to join back to this final event. Rather
+	// than emit a wrong or partial count, we leave Tools zero-valued
+	// (Total: 0, ByName omitted) — correctness over completeness (see issue #70).
 	ev = CostEvent{
 		V:           SchemaVersion,
 		Kind:        "cost_event",

--- a/internal/cost/event.go
+++ b/internal/cost/event.go
@@ -10,7 +10,11 @@ package cost
 const (
 	// SchemaVersion is stamped on every emitted record so the extension can
 	// reject shapes it doesn't understand rather than mis-render them.
-	SchemaVersion = 1
+	//
+	// v2 adds CostEvent.Tools (a content-free per-request tool-call summary).
+	// The editor extension's SCHEMA_VERSION (src/types.ts, tracked in #4) MUST
+	// be bumped to 2 to match before it reads the new field.
+	SchemaVersion = 2
 
 	// Currency is the only currency v1 prices in; the pricing table is in USD.
 	Currency = "USD"
@@ -48,22 +52,71 @@ type Cost struct {
 	Currency   string  `json:"currency"`
 }
 
+// ToolSummary is a content-free per-request tool-call summary: how many tool
+// calls the assistant made in this turn and a per-tool-name count. It carries
+// TOOL NAMES ONLY — never tool inputs, file paths, commands, prompt text, or
+// any other content. This is a privacy-first feature in a public/MIT repo, so
+// the no-content invariant is load-bearing (see TestPrivacy_* in cost_test.go).
+type ToolSummary struct {
+	// Total is the number of tool calls in the request (sum of ByName).
+	Total int `json:"total"`
+	// ByName maps each tool name to how many times it was called this turn,
+	// e.g. {"Read": 2, "Bash": 1}. Empty/omitted when no tools were called or
+	// when names aren't derivable for the source (see Cursor note in cursor.go).
+	ByName map[string]int `json:"by_name,omitempty"`
+}
+
 // CostEvent is emitted once per priced assistant turn — the "request cost" the
 // status bar shows. It carries only counts, costs, and identifiers; the
 // transcript text that produced the counts is never included.
 type CostEvent struct {
-	V           int    `json:"v"`
-	Kind        string `json:"kind"` // always "cost_event"
-	Tool        string `json:"tool"`
-	SessionID   string `json:"session_id"`
-	RequestID   string `json:"request_id"` // dedup key (Claude Code requestId)
-	Timestamp   string `json:"ts"`
-	Model       string `json:"model"`
-	ModelPriced bool   `json:"model_priced"` // false => unknown model, cost is 0
-	Source      string `json:"source"`
-	Tokens      Tokens `json:"tokens"`
-	Cost        Cost   `json:"cost"`
-	CwdBase     string `json:"cwd_base"` // basename only — never the full path or prompt
+	V           int         `json:"v"`
+	Kind        string      `json:"kind"` // always "cost_event"
+	Tool        string      `json:"tool"`
+	SessionID   string      `json:"session_id"`
+	RequestID   string      `json:"request_id"` // dedup key (Claude Code requestId)
+	Timestamp   string      `json:"ts"`
+	Model       string      `json:"model"`
+	ModelPriced bool        `json:"model_priced"` // false => unknown model, cost is 0
+	Source      string      `json:"source"`
+	Tokens      Tokens      `json:"tokens"`
+	Cost        Cost        `json:"cost"`
+	CwdBase     string      `json:"cwd_base"` // basename only — never the full path or prompt
+	Tools       ToolSummary `json:"tools"`    // names-only tool-call summary (schema v2+)
+}
+
+// summarizeToolNames builds a ToolSummary from a flat list of tool-call names
+// (e.g. the `name` of each tool_use block in a Claude Code assistant turn).
+// Empty names are ignored. The result holds counts only — by construction it
+// can never carry tool inputs or any other content.
+func summarizeToolNames(names []string) ToolSummary {
+	var s ToolSummary
+	for _, n := range names {
+		if n == "" {
+			continue
+		}
+		if s.ByName == nil {
+			s.ByName = make(map[string]int)
+		}
+		s.ByName[n]++
+		s.Total++
+	}
+	return s
+}
+
+// add folds src into the receiver, summing Total and per-name counts. Used to
+// roll per-request tool summaries up into a session aggregate.
+func (s *ToolSummary) add(src ToolSummary) {
+	if src.Total == 0 && len(src.ByName) == 0 {
+		return
+	}
+	s.Total += src.Total
+	for name, n := range src.ByName {
+		if s.ByName == nil {
+			s.ByName = make(map[string]int)
+		}
+		s.ByName[name] += n
+	}
 }
 
 // ModelTotal is one model's contribution to a session. ModelPriced is false
@@ -90,6 +143,10 @@ type SessionSummary struct {
 	UpdatedAt string       `json:"updated_at"`
 	Totals    SessionTotal `json:"totals"`
 	ByModel   []ModelTotal `json:"by_model"`
+	// Tools is the session's running tool-call total, summed across its cost
+	// events (names only; schema v2+). Empty for Cursor sessions, whose cost
+	// events don't carry tool names — see cursor.go.
+	Tools ToolSummary `json:"tools"`
 }
 
 // SessionTotal is the flattened token+cost total for a session.

--- a/internal/cost/watcher.go
+++ b/internal/cost/watcher.go
@@ -327,6 +327,8 @@ func (w *Watcher) apply(ev CostEvent) bool {
 	t.CostTotal += ev.Cost.Total
 	t.Currency = Currency
 
+	st.summary.Tools.add(ev.Tools)
+
 	mt := st.byModel[ev.Model]
 	if mt == nil {
 		mt = &ModelTotal{Model: ev.Model, ModelPriced: ev.ModelPriced}


### PR DESCRIPTION
Closes #70 — https://github.com/promptconduit/cli/issues/70

## Summary

Adds a content-free per-request tool-call summary to the local cost feed so the editor extension can show "tools called" per prompt.

- New `ToolSummary` type (`Total` + `ByName map[string]int`) on `CostEvent.Tools`. **Names only** — never tool inputs, file paths, commands, or prompt text. This is a privacy-first feature in a public/MIT repo, and a unit test asserts no tool content leaks into the serialized event.
- **Claude Code:** populated from the `tool_use` blocks in the same assistant transcript line the cost event already parses (`parseClaudeCodeLine`). This is the tightest possible join — the tool names live in the exact line being priced, so there's no cross-file correlation by `session_id`/`request_id` that could mismatch requests, and no extra I/O. Only each block's `name` is read, never its `input`.
- **Cursor:** intentionally left empty (see Limitations).
- **Session roll-up:** `SessionSummary.Tools` aggregates per-request summaries across the session, surfaced by `cost session` (JSON and human-readable, e.g. `Tools: 5 call(s)  (Read ×3, Bash ×2)`).
- `cost watch --json` emits the per-request tool summary automatically (it serializes the full `CostEvent`).

## Schema version bump

`SchemaVersion` 1 → 2 (`internal/cost/event.go`). v2 adds `CostEvent.Tools`. The change is additive and backward-compatible — existing fields are unchanged, so old consumers still parse.

⚠️ **This schema bump must be matched by extension issue 1.3** — the editor extension's `SCHEMA_VERSION` in `src/types.ts` must be bumped to **2** before it reads the new `tools` field. That work lives in the extension repo and is **not** modified by this PR (this repo is the CLI only).

## Tests

- `make test` / `go test ./...` — **green** (all packages pass).
- `make build` — **passes**.
- Added focused unit tests: `TestSummarizeToolNames`, `TestParseClaudeCodeLine_ToolSummary` (incl. a no-content-leak privacy assertion), and `TestSessionSummaryToolAggregation`.

## Limitations / follow-ups

- **Cursor tool summary is empty.** The Cursor cost event is derived solely from the `stop` / `afterAgentResponse` hook payload, which carries token counts but no tool names. Cursor's per-tool hooks (`preToolUse`, `afterFileEdit`, `beforeShellExecution`, …) fire in separate processes earlier in the turn and don't guarantee a stable `generation_id` to join back to the final cost event. Per the issue's guidance ("correctness over completeness"), `Tools` is left zero-valued for Cursor rather than emitting a wrong/partial count.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
