### PR TITLE
chore(cost): stable grouping keys for tab-aware cost (#72)

### DIFF
--- a/internal/cost/cost_test.go
+++ b/internal/cost/cost_test.go
@@ -263,6 +263,51 @@ func TestCostEventGroupingKeys(t *testing.T) {
 	}
 }
 
+// TestWatchStreamCarriesGroupingKeys is the end-to-end guard for issue #72's
+// acceptance criterion: the extension does not read CostEvent structs, it reads
+// `cost watch --json` lines off the watcher's stream. So drive a Cursor event
+// through the same emit path `cost watch` uses (streamCostEventLine -> emitJSON)
+// and assert the emitted cost_event line carries conversation_id, session_id,
+// and request_id with the exact JSON field names.
+func TestWatchStreamCarriesGroupingKeys(t *testing.T) {
+	tbl := mustTable(t)
+	var buf bytes.Buffer
+	w := NewWatcher(tbl, nil, &buf, true) // emit per-turn cost events, as `cost watch` does
+
+	raw := []byte(`{"hook_event_name":"stop","model":"claude-opus-4-8","conversation_id":"conv_42","generation_id":"gen_99","session_id":"sess_7","input_tokens":100,"output_tokens":50,"cache_read_tokens":0,"cache_write_tokens":0,"workspace_roots":["/p"]}`)
+	ev, _, ok := ParseCursorHookPayload(raw, tbl)
+	if !ok {
+		t.Fatal("cursor payload should parse")
+	}
+	data, _ := json.Marshal(ev)
+	w.streamCostEventLine(data) // exactly what the Cursor feed tail does
+
+	// Find the emitted cost_event line and assert its grouping keys, parsing it
+	// the way the extension would (raw JSON, exact field names).
+	var found bool
+	for _, line := range bytes.Split(buf.Bytes(), []byte{'\n'}) {
+		if len(line) == 0 {
+			continue
+		}
+		var probe struct {
+			Kind           string `json:"kind"`
+			ConversationID string `json:"conversation_id"`
+			SessionID      string `json:"session_id"`
+			RequestID      string `json:"request_id"`
+		}
+		if json.Unmarshal(line, &probe) != nil || probe.Kind != "cost_event" {
+			continue
+		}
+		found = true
+		if probe.ConversationID != "conv_42" || probe.SessionID != "sess_7" || probe.RequestID != "gen_99" {
+			t.Fatalf("emitted cost_event line missing grouping keys: %s", line)
+		}
+	}
+	if !found {
+		t.Fatalf("no cost_event line emitted on the watch stream; got:\n%s", buf.Bytes())
+	}
+}
+
 // assertGroupingJSON marshals an event and checks the grouping keys round-trip
 // with the exact JSON field names the extension reads.
 func assertGroupingJSON(t *testing.T, ev CostEvent, wantConv, wantSess, wantReq string) {

--- a/internal/cost/cost_test.go
+++ b/internal/cost/cost_test.go
@@ -197,6 +197,93 @@ func TestParseCursorHookPayload(t *testing.T) {
 	}
 }
 
+// TestCostEventGroupingKeys is a regression guard for issue #72: the editor
+// extension groups cost by "agent tab" using (session_id, conversation_id) and
+// dedups turns by request_id, so every emitted CostEvent must carry the keys
+// its source provides — and they must survive JSON serialization, since the
+// extension reads `cost watch --json` lines, not Go structs.
+func TestCostEventGroupingKeys(t *testing.T) {
+	tbl := mustTable(t)
+
+	// Cursor sends distinct conversation_id, generation_id, and session_id.
+	// All three must land on the event as distinct keys (conversation_id must
+	// NOT be conflated into session_id).
+	cursorRaw := []byte(`{"hook_event_name":"stop","model":"claude-opus-4-8","conversation_id":"conv_42","generation_id":"gen_99","session_id":"sess_7","input_tokens":100,"output_tokens":50,"cache_read_tokens":0,"cache_write_tokens":0,"workspace_roots":["/p"]}`)
+	cur, _, ok := ParseCursorHookPayload(cursorRaw, tbl)
+	if !ok {
+		t.Fatal("cursor payload should parse")
+	}
+	if cur.SessionID != "sess_7" {
+		t.Fatalf("cursor session_id = %q, want sess_7", cur.SessionID)
+	}
+	if cur.ConversationID != "conv_42" {
+		t.Fatalf("cursor conversation_id = %q, want conv_42", cur.ConversationID)
+	}
+	if cur.RequestID != "gen_99" {
+		t.Fatalf("cursor request_id = %q, want gen_99 (generation_id)", cur.RequestID)
+	}
+	// conversation_id and session_id must be carried separately, not aliased.
+	if cur.ConversationID == cur.SessionID {
+		t.Fatal("cursor conversation_id and session_id must be distinct keys")
+	}
+
+	// The JSON the extension consumes must expose the grouping keys.
+	assertGroupingJSON(t, cur, "conv_42", "sess_7", "gen_99")
+
+	// When Cursor omits session_id, fall back to conversation_id so the
+	// session grouping key is never empty.
+	noSess := []byte(`{"hook_event_name":"stop","model":"claude-opus-4-8","conversation_id":"conv_only","generation_id":"gen_x","input_tokens":10,"output_tokens":5,"cache_read_tokens":0,"cache_write_tokens":0,"workspace_roots":["/p"]}`)
+	curNS, _, ok := ParseCursorHookPayload(noSess, tbl)
+	if !ok {
+		t.Fatal("cursor payload without session_id should still parse")
+	}
+	if curNS.SessionID != "conv_only" || curNS.ConversationID != "conv_only" {
+		t.Fatalf("missing session_id should fall back to conversation_id: %+v", curNS)
+	}
+
+	// Claude Code carries session_id and request_id; it has no separate
+	// conversation id, so conversation_id is empty and omitted from JSON.
+	ccRaw := []byte(`{"type":"assistant","requestId":"req_abc","sessionId":"sess_cc","timestamp":"2026-06-13T12:00:00Z","cwd":"/Users/x/tolken","message":{"model":"claude-opus-4-8","usage":{"input_tokens":72,"output_tokens":3674,"cache_read_input_tokens":0,"cache_creation_input_tokens":0}}}`)
+	cc, _, ok := parseClaudeCodeLine(ccRaw, tbl, "fallback")
+	if !ok {
+		t.Fatal("claude code line should parse")
+	}
+	if cc.SessionID != "sess_cc" || cc.RequestID != "req_abc" {
+		t.Fatalf("claude code grouping keys wrong: session=%q request=%q", cc.SessionID, cc.RequestID)
+	}
+	if cc.ConversationID != "" {
+		t.Fatalf("claude code has no conversation id; got %q", cc.ConversationID)
+	}
+	data, err := json.Marshal(cc)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if strings.Contains(string(data), "conversation_id") {
+		t.Fatalf("empty conversation_id must be omitted from JSON: %s", data)
+	}
+}
+
+// assertGroupingJSON marshals an event and checks the grouping keys round-trip
+// with the exact JSON field names the extension reads.
+func assertGroupingJSON(t *testing.T, ev CostEvent, wantConv, wantSess, wantReq string) {
+	t.Helper()
+	data, err := json.Marshal(ev)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var got struct {
+		ConversationID string `json:"conversation_id"`
+		SessionID      string `json:"session_id"`
+		RequestID      string `json:"request_id"`
+	}
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if got.ConversationID != wantConv || got.SessionID != wantSess || got.RequestID != wantReq {
+		t.Fatalf("grouping keys in JSON = %+v; want conv=%q sess=%q req=%q", got, wantConv, wantSess, wantReq)
+	}
+}
+
 // TestWatcherCursorAggregationDedup is the end-to-end check for the behavior
 // verified by hand against real payloads: a watcher ingesting Cursor cost
 // events dedups stop + afterAgentResponse (same generation_id, identical

--- a/internal/cost/cursor.go
+++ b/internal/cost/cursor.go
@@ -59,9 +59,14 @@ func ParseCursorHookPayload(raw []byte, table *PriceTable) (ev CostEvent, cwd st
 	if dedupKey == "" {
 		dedupKey = p.ConversationID
 	}
-	sessionID := p.ConversationID
+	// Grouping keys the extension needs (see CostEvent): conversation_id is the
+	// per-tab key, session_id the per-session key. Cursor sends both. Prefer the
+	// genuine session_id; fall back to conversation_id so the watcher always has
+	// a stable, non-empty session to group by even on payloads that omit
+	// session_id.
+	sessionID := p.SessionID
 	if sessionID == "" {
-		sessionID = p.SessionID
+		sessionID = p.ConversationID
 	}
 	if len(p.WorkspaceRoots) > 0 {
 		cwd = p.WorkspaceRoots[0]
@@ -77,14 +82,15 @@ func ParseCursorHookPayload(raw []byte, table *PriceTable) (ev CostEvent, cwd st
 	c, cacheWriteTokens := CostForUsage(usage, mp)
 
 	ev = CostEvent{
-		V:           SchemaVersion,
-		Kind:        "cost_event",
-		Tool:        ToolCursor,
-		SessionID:   sessionID,
-		RequestID:   dedupKey,
-		Model:       p.Model,
-		ModelPriced: priced,
-		Source:      SourceExact,
+		V:              SchemaVersion,
+		Kind:           "cost_event",
+		Tool:           ToolCursor,
+		SessionID:      sessionID,
+		ConversationID: p.ConversationID,
+		RequestID:      dedupKey,
+		Model:          p.Model,
+		ModelPriced:    priced,
+		Source:         SourceExact,
 		Tokens: Tokens{
 			Input:      p.InputTokens,
 			Output:     p.OutputTokens,

--- a/internal/cost/event.go
+++ b/internal/cost/event.go
@@ -51,12 +51,27 @@ type Cost struct {
 // CostEvent is emitted once per priced assistant turn — the "request cost" the
 // status bar shows. It carries only counts, costs, and identifiers; the
 // transcript text that produced the counts is never included.
+//
+// Grouping keys: the editor extension groups cost by "agent tab" using a
+// (SessionID, ConversationID) pair and dedups individual turns by RequestID.
+// All three are populated from the source's native identifiers where they
+// exist (see SessionID/ConversationID/RequestID below); they are the stable
+// keys the extension relies on, so do not repurpose or conflate them.
 type CostEvent struct {
-	V           int    `json:"v"`
-	Kind        string `json:"kind"` // always "cost_event"
-	Tool        string `json:"tool"`
-	SessionID   string `json:"session_id"`
-	RequestID   string `json:"request_id"` // dedup key (Claude Code requestId)
+	V    int    `json:"v"`
+	Kind string `json:"kind"` // always "cost_event"
+	Tool string `json:"tool"`
+	// SessionID is the per-session grouping key: Claude Code's `sessionId`
+	// (transcript filename fallback) or Cursor's `session_id`.
+	SessionID string `json:"session_id"`
+	// ConversationID is Cursor's `conversation_id` — the per-tab grouping key
+	// the extension uses alongside SessionID. Claude Code has no separate
+	// conversation id, so it is empty there (hence omitempty).
+	ConversationID string `json:"conversation_id,omitempty"`
+	// RequestID is the per-turn dedup key: Cursor's `generation_id` or Claude
+	// Code's `requestId` (UUID fallback). Two hook events for one generation
+	// share it, so deduping by RequestID collapses them to one billable turn.
+	RequestID   string `json:"request_id"`
 	Timestamp   string `json:"ts"`
 	Model       string `json:"model"`
 	ModelPriced bool   `json:"model_priced"` // false => unknown model, cost is 0


### PR DESCRIPTION
Closes #72

The editor extension groups cost by "agent tab" using `(session_id, conversation_id)` and dedups individual turns by `request_id`. This verifies those keys are present and stable on every emitted `CostEvent`, and fixes a gap for Cursor.

## Keys: already present vs added

**Claude Code** (`internal/cost/claudecode.go`) — no change needed:
- `session_id` ← transcript `sessionId` (filename-derived fallback). Already present.
- `request_id` ← `requestId` (`uuid` fallback). Already present.
- `conversation_id` — Claude Code has no separate conversation id, so this stays empty (and is omitted from JSON via `omitempty`). Correct.

**Cursor** (`internal/cost/cursor.go`) — fixed:
- `request_id` ← `generation_id` (`conversation_id` fallback). Already present.
- `conversation_id` — **added.** The hook payload carries a distinct `conversation_id`, but the parser was conflating it into `SessionID` and only using the genuine `session_id` as a fallback, so the per-tab key never reached the event. Now carried on its own `CostEvent.ConversationID` field.
- `session_id` — now prefers the genuine `session_id`, falling back to `conversation_id` only when `session_id` is absent (keeps the watcher's session grouping non-empty).

## Schema version

No bump. The new `conversation_id` is an additive, optional (`omitempty`) field — backward-compatible with v1 consumers. This deliberately avoids colliding with the independent v2 bump on #70 (tool-call summary); that PR owns the v2 version.

## Test added

`TestCostEventGroupingKeys` in `internal/cost/cost_test.go` — regression guard asserting that:
- Cursor events carry distinct `session_id`, `conversation_id`, and `request_id` (conversation_id is not aliased to session_id), and that missing `session_id` falls back to `conversation_id`.
- Claude Code events carry `session_id` + `request_id` and omit `conversation_id` from JSON.
- All grouping keys survive JSON serialization with the exact field names the extension reads (`cost watch --json`).

Doc comments added to the `CostEvent` struct fields documenting the grouping-key contract.

## Test / build results

- `make test` — green (all packages).
- `make build` — green.
- New `errcheck`/`staticcheck` lint findings: none from this change (the 3 `errcheck` `defer f.Close()` findings in `internal/cost` pre-exist on `main`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)