### PR TITLE
feat(cost): emit cost-reduction signals (derived metrics) (#71)

### DIFF
--- a/cmd/cost.go
+++ b/cmd/cost.go
@@ -262,6 +262,18 @@ func renderSessionHuman(out io.Writer, s cost.SessionSummary) {
 	if s.Tools.Total > 0 {
 		fmt.Fprintf(out, "  Tools: %d call(s)%s\n", s.Tools.Total, formatToolBreakdown(s.Tools.ByName))
 	}
+	renderSignalsHuman(out, s.Signals)
+}
+
+// renderSignalsHuman prints the derived cost-reduction signals as percentages.
+// Numbers only — no prompt content. Skipped entirely for an unpriced session,
+// where the cost-share signal would be a meaningless 0.
+func renderSignalsHuman(out io.Writer, sig cost.Signals) {
+	fmt.Fprintf(out, "  Signals: cache-hit %.0f%% · input-share %.0f%% · tier %s\n",
+		sig.CacheHitRate*100, sig.InputTokenShare*100, sig.Tier)
+	if sig.ModelPriced {
+		fmt.Fprintf(out, "           cache-miss cost share %.0f%%\n", sig.CacheMissCostShare*100)
+	}
 }
 
 // formatToolBreakdown renders a per-tool count like "  (Read ×3, Bash ×1)",

--- a/internal/cost/claudecode.go
+++ b/internal/cost/claudecode.go
@@ -241,6 +241,14 @@ func parseClaudeCodeLine(line []byte, table *PriceTable, sessionFallback string)
 		}
 	}
 
+	tokens := Tokens{
+		Input:      u.InputTokens,
+		Output:     u.OutputTokens,
+		CacheRead:  u.CacheReadInputTokens,
+		CacheWrite: cacheWriteTokens,
+	}
+	tools := summarizeToolNames(toolNames)
+
 	ev = CostEvent{
 		V:           SchemaVersion,
 		Kind:        "cost_event",
@@ -251,15 +259,11 @@ func parseClaudeCodeLine(line []byte, table *PriceTable, sessionFallback string)
 		Model:       l.Message.Model,
 		ModelPriced: priced,
 		Source:      SourceExact,
-		Tokens: Tokens{
-			Input:      u.InputTokens,
-			Output:     u.OutputTokens,
-			CacheRead:  u.CacheReadInputTokens,
-			CacheWrite: cacheWriteTokens,
-		},
-		Cost:    c,
-		CwdBase: filepath.Base(l.Cwd),
-		Tools:   summarizeToolNames(toolNames),
+		Tokens:      tokens,
+		Cost:        c,
+		CwdBase:     filepath.Base(l.Cwd),
+		Tools:       tools,
+		Signals:     computeSignals(tokens, c, l.Message.Model, priced, tools.Total),
 	}
 	return ev, dedupKey, true
 }

--- a/internal/cost/cost_test.go
+++ b/internal/cost/cost_test.go
@@ -3,6 +3,7 @@ package cost
 import (
 	"bytes"
 	"encoding/json"
+	"io"
 	"math"
 	"os"
 	"path/filepath"
@@ -547,6 +548,154 @@ func TestEncodeProjectPath(t *testing.T) {
 	// Dots in repo names also become dashes (e.g. havoptic.com).
 	if got := encodeProjectPath("/a/havoptic.com"); got != "-a-havoptic-com" {
 		t.Fatalf("dot encoding = %q, want -a-havoptic-com", got)
+	}
+}
+
+// approx is a small float tolerance helper for the signal-ratio assertions.
+func approx(got, want float64) bool { return math.Abs(got-want) < 1e-9 }
+
+// TestSignalFormulas pins the three derived ratios against hand-computed values
+// and exercises the divide-by-zero guards. The cache-hit formula is the one
+// called out in #71: cache_read / (cache_read + cache_creation + input).
+func TestSignalFormulas(t *testing.T) {
+	// input 100, cache_read 700, cache_creation 200 -> denom 1000.
+	if got := cacheHitRate(100, 700, 200); !approx(got, 0.7) {
+		t.Fatalf("cacheHitRate = %v, want 0.7", got)
+	}
+	if got := inputTokenShare(100, 700, 200); !approx(got, 0.1) {
+		t.Fatalf("inputTokenShare = %v, want 0.1", got)
+	}
+	// No input-side tokens at all -> 0, not NaN/panic.
+	if got := cacheHitRate(0, 0, 0); got != 0 {
+		t.Fatalf("cacheHitRate(0,0,0) = %v, want 0", got)
+	}
+	if got := inputTokenShare(0, 0, 0); got != 0 {
+		t.Fatalf("inputTokenShare(0,0,0) = %v, want 0", got)
+	}
+
+	// cache-miss cost share = (input + cache_write) / total.
+	c := Cost{Input: 2, Output: 1, CacheRead: 1, CacheWrite: 3, Total: 7}
+	if got := cacheMissCostShare(c); !approx(got, 5.0/7.0) {
+		t.Fatalf("cacheMissCostShare = %v, want %v", got, 5.0/7.0)
+	}
+	if got := cacheMissCostShare(Cost{Total: 0}); got != 0 {
+		t.Fatalf("cacheMissCostShare with zero total = %v, want 0", got)
+	}
+}
+
+// TestModelTier covers the coarse, names-only tier buckets, including the
+// unpriced override (an unpriced model is always TierUnknown).
+func TestModelTier(t *testing.T) {
+	cases := []struct {
+		model  string
+		priced bool
+		want   string
+	}{
+		{"claude-opus-4-8", true, TierPremium},
+		{"gpt-5.5", true, TierPremium},
+		{"claude-sonnet-4-5", true, TierStandard},
+		{"composer-2.5-fast", true, TierStandard},
+		{"claude-3-5-haiku", true, TierEconomy},
+		{"gemini-2.0-flash", true, TierEconomy},
+		{"gpt-4o-mini", true, TierEconomy},      // economy markers win over premium gpt-4
+		{"claude-opus-4-8", false, TierUnknown}, // unpriced overrides everything
+		{"", true, TierUnknown},
+	}
+	for _, tc := range cases {
+		if got := modelTier(tc.model, tc.priced); got != tc.want {
+			t.Errorf("modelTier(%q, priced=%v) = %q, want %q", tc.model, tc.priced, got, tc.want)
+		}
+	}
+}
+
+// TestParseClaudeCodeLine_Signals checks the per-request signals are wired onto
+// the CostEvent from the same transcript line, with the exact ratios for a real
+// usage block (input 72, cache_read 132405, cache_creation 19640).
+func TestParseClaudeCodeLine_Signals(t *testing.T) {
+	tbl := mustTable(t)
+	line := []byte(`{"type":"assistant","requestId":"req_sig","sessionId":"s","timestamp":"2026-06-24T00:00:00Z","cwd":"/p","message":{"model":"claude-opus-4-8","content":[{"type":"tool_use","id":"t1","name":"Bash"}],"usage":{"input_tokens":72,"output_tokens":3674,"cache_read_input_tokens":132405,"cache_creation_input_tokens":19640,"cache_creation":{"ephemeral_1h_input_tokens":19640,"ephemeral_5m_input_tokens":0}}}}`)
+	ev, _, ok := parseClaudeCodeLine(line, tbl, "fallback")
+	if !ok {
+		t.Fatal("assistant line should parse")
+	}
+	denom := float64(72 + 132405 + 19640)
+	wantHit := 132405.0 / denom
+	wantInShare := 72.0 / denom
+	if !approx(ev.Signals.CacheHitRate, wantHit) {
+		t.Fatalf("cache_hit_rate = %v, want %v", ev.Signals.CacheHitRate, wantHit)
+	}
+	if !approx(ev.Signals.InputTokenShare, wantInShare) {
+		t.Fatalf("input_token_share = %v, want %v", ev.Signals.InputTokenShare, wantInShare)
+	}
+	if ev.Signals.Tier != TierPremium || !ev.Signals.ModelPriced {
+		t.Fatalf("tier/priced wrong: %q priced=%v", ev.Signals.Tier, ev.Signals.ModelPriced)
+	}
+	if ev.Signals.ToolCalls != 1 {
+		t.Fatalf("tool_calls signal = %d, want 1 (mirrors Tools.Total)", ev.Signals.ToolCalls)
+	}
+	// cache-miss cost share must be in (0,1) for this priced, cache-heavy turn.
+	if ev.Signals.CacheMissCostShare <= 0 || ev.Signals.CacheMissCostShare >= 1 {
+		t.Fatalf("cache_miss_cost_share = %v, want in (0,1)", ev.Signals.CacheMissCostShare)
+	}
+}
+
+// TestParseCursorHookPayload_Signals confirms Cursor events also carry signals
+// (derived from the exact usage block) even though their tool summary is empty.
+func TestParseCursorHookPayload_Signals(t *testing.T) {
+	tbl := mustTable(t)
+	payload := []byte(`{"hook_event_name":"stop","model":"composer-2.5-fast","conversation_id":"c","generation_id":"g","input_tokens":300,"output_tokens":50,"cache_read_tokens":700,"cache_write_tokens":0,"workspace_roots":["/p"]}`)
+	ev, _, ok := ParseCursorHookPayload(payload, tbl)
+	if !ok {
+		t.Fatal("cursor payload should parse")
+	}
+	// denom = 300 + 700 + 0 = 1000 -> hit 0.7, input share 0.3.
+	if !approx(ev.Signals.CacheHitRate, 0.7) {
+		t.Fatalf("cursor cache_hit_rate = %v, want 0.7", ev.Signals.CacheHitRate)
+	}
+	if !approx(ev.Signals.InputTokenShare, 0.3) {
+		t.Fatalf("cursor input_token_share = %v, want 0.3", ev.Signals.InputTokenShare)
+	}
+	if ev.Signals.Tier != TierStandard {
+		t.Fatalf("composer tier = %q, want standard", ev.Signals.Tier)
+	}
+	if ev.Signals.ToolCalls != 0 {
+		t.Fatalf("cursor tool_calls = %d, want 0 (no tool summary)", ev.Signals.ToolCalls)
+	}
+}
+
+// TestSessionSignalsFromTotals verifies the session-level Signals are recomputed
+// from the accumulated totals (not averaged per turn). Two turns with very
+// different cache profiles must yield a signal derived from their SUM.
+func TestSessionSignalsFromTotals(t *testing.T) {
+	tbl := mustTable(t)
+	w := NewWatcher(tbl, nil, io.Discard, false)
+
+	// Turn 1: cache-cold (all input). Turn 2: cache-hot (all cache_read).
+	cold, _, ok := parseClaudeCodeLine([]byte(`{"type":"assistant","requestId":"c1","sessionId":"s","timestamp":"2026-06-24T00:00:00Z","cwd":"/p","message":{"model":"claude-opus-4-8","usage":{"input_tokens":1000,"output_tokens":10}}}`), tbl, "s")
+	if !ok {
+		t.Fatal("cold turn should parse")
+	}
+	hot, _, ok := parseClaudeCodeLine([]byte(`{"type":"assistant","requestId":"c2","sessionId":"s","timestamp":"2026-06-24T00:00:01Z","cwd":"/p","message":{"model":"claude-opus-4-8","usage":{"input_tokens":0,"output_tokens":10,"cache_read_input_tokens":3000}}}`), tbl, "s")
+	if !ok {
+		t.Fatal("hot turn should parse")
+	}
+	w.apply(cold)
+	w.apply(hot)
+
+	s, ok := w.LatestSummary()
+	if !ok {
+		t.Fatal("expected a session summary")
+	}
+	// Session cache_read 3000, input 1000, cache_creation 0 -> denom 4000.
+	wantHit := 3000.0 / 4000.0
+	if !approx(s.Signals.CacheHitRate, wantHit) {
+		t.Fatalf("session cache_hit_rate = %v, want %v (from summed totals)", s.Signals.CacheHitRate, wantHit)
+	}
+	if !approx(s.Signals.InputTokenShare, 0.25) {
+		t.Fatalf("session input_token_share = %v, want 0.25", s.Signals.InputTokenShare)
+	}
+	if s.Signals.Tier != TierPremium {
+		t.Fatalf("session tier = %q, want premium (dominant model)", s.Signals.Tier)
 	}
 }
 

--- a/internal/cost/cursor.go
+++ b/internal/cost/cursor.go
@@ -89,6 +89,18 @@ func ParseCursorHookPayload(raw []byte, table *PriceTable) (ev CostEvent, cwd st
 	// stable `generation_id` on them to join back to this final event. Rather
 	// than emit a wrong or partial count, we leave Tools zero-valued
 	// (Total: 0, ByName omitted) — correctness over completeness (see issue #70).
+	tokens := Tokens{
+		Input:      p.InputTokens,
+		Output:     p.OutputTokens,
+		CacheRead:  p.CacheReadTokens,
+		CacheWrite: cacheWriteTokens,
+	}
+
+	// Signals (schema v2) are derived from the token counts + costs this payload
+	// already carries, so Cursor gets them even though its tool summary is empty:
+	// CacheHitRate, cost shares, input share, and tier are all computable from
+	// the exact usage block. ToolCalls is 0 here (Tools is empty for Cursor —
+	// see the note above).
 	ev = CostEvent{
 		V:              SchemaVersion,
 		Kind:           "cost_event",
@@ -99,14 +111,10 @@ func ParseCursorHookPayload(raw []byte, table *PriceTable) (ev CostEvent, cwd st
 		Model:          p.Model,
 		ModelPriced:    priced,
 		Source:         SourceExact,
-		Tokens: Tokens{
-			Input:      p.InputTokens,
-			Output:     p.OutputTokens,
-			CacheRead:  p.CacheReadTokens,
-			CacheWrite: cacheWriteTokens,
-		},
-		Cost:    c,
-		CwdBase: filepath.Base(cwd),
+		Tokens:         tokens,
+		Cost:           c,
+		CwdBase:        filepath.Base(cwd),
+		Signals:        computeSignals(tokens, c, p.Model, priced, 0),
 	}
 	return ev, cwd, true
 }

--- a/internal/cost/event.go
+++ b/internal/cost/event.go
@@ -7,13 +7,18 @@
 // events the editor extension renders in the status bar.
 package cost
 
+import "strings"
+
 const (
 	// SchemaVersion is stamped on every emitted record so the extension can
 	// reject shapes it doesn't understand rather than mis-render them.
 	//
-	// v2 adds CostEvent.Tools (a content-free per-request tool-call summary).
-	// The editor extension's SCHEMA_VERSION (src/types.ts, tracked in #4) MUST
-	// be bumped to 2 to match before it reads the new field.
+	// v2 is the cost drill-down revision. It adds, together:
+	//   - CostEvent.Tools   — a content-free per-request tool-call summary (#70)
+	//   - CostEvent.Signals — derived cost-reduction metrics (#71)
+	// Both ship under the SAME version bump (1 -> 2); #71 deliberately does NOT
+	// bump again. The editor extension's SCHEMA_VERSION (src/types.ts, tracked in
+	// extension issue 1.3) MUST be bumped to 2 to match before it reads either.
 	SchemaVersion = 2
 
 	// Currency is the only currency v1 prices in; the pricing table is in USD.
@@ -50,6 +55,149 @@ type Cost struct {
 	CacheWrite float64 `json:"cache_write"`
 	Total      float64 `json:"total"`
 	Currency   string  `json:"currency"`
+}
+
+// Model tier labels (the `tier` signal). A coarse, content-free bucket derived
+// from the model name so the UI can group spend without a price lookup and so
+// cost-reduction tips can say "you're on a premium model" without the extension
+// re-deriving it. Unpriced/unknown models get TierUnknown.
+const (
+	TierPremium  = "premium"  // top-end frontier models (e.g. Opus, GPT-5/4.x flagship)
+	TierStandard = "standard" // mid-tier workhorse models (e.g. Sonnet, Composer)
+	TierEconomy  = "economy"  // small/cheap models (e.g. Haiku, mini/nano/flash)
+	TierUnknown  = "unknown"  // not priced / model name not recognized
+)
+
+// Signals is a content-free bundle of DERIVED cost-reduction metrics computed
+// from a turn's token counts and dollar costs. It exists so cost-saving tips in
+// the UI are driven by structured numbers the CLI emits, not re-derived (and
+// possibly diverging) inside the editor extension. Like every other field in
+// this package it carries NUMBERS ONLY — no prompt content, inputs, or paths.
+//
+// On a CostEvent these describe a single request; on a SessionSummary they are
+// recomputed from the session's accumulated totals (not averaged), so a session
+// signal is the same formula applied to summed tokens/costs.
+type Signals struct {
+	// CacheHitRate is the share of input-side tokens served from the prompt
+	// cache: cache_read / (cache_read + cache_creation + input). Range [0,1].
+	// Higher is cheaper — cached reads are ~10x cheaper than fresh input. A low
+	// rate on a long session is the headline "you could cache more" signal.
+	// 0 when there are no input-side tokens at all. Formula is implemented
+	// locally here (see cacheHitRate); it is not imported from any other code.
+	CacheHitRate float64 `json:"cache_hit_rate"`
+
+	// CacheMissCostShare is the fraction of this turn's TOTAL dollar cost spent
+	// on tokens that were NOT cache hits — i.e. fresh input plus cache-creation
+	// (cache_write) cost, over total cost. Range [0,1]. High share + low
+	// CacheHitRate together point at re-sending uncached context. 0 when total
+	// cost is 0 (unpriced model or no spend).
+	CacheMissCostShare float64 `json:"cache_miss_cost_share"`
+
+	// InputTokenShare is fresh input tokens as a fraction of all input-side
+	// tokens: input / (input + cache_read + cache_creation). Range [0,1]. It is
+	// the token-count complement to CacheHitRate (it ignores cache-creation vs
+	// read weighting) and answers "how much of what I fed the model was new?".
+	// 0 when there are no input-side tokens.
+	InputTokenShare float64 `json:"input_token_share"`
+
+	// Tier is the coarse model-cost bucket (premium/standard/economy/unknown).
+	// Paired with ModelPriced below so the UI can say "premium, priced" vs
+	// "unknown, unpriced" without its own model table.
+	Tier string `json:"tier"`
+
+	// ModelPriced mirrors CostEvent.ModelPriced into the signal bundle so a
+	// consumer reading only `signals` still knows whether the costs are real
+	// (true) or zero-because-unknown (false).
+	ModelPriced bool `json:"model_priced"`
+
+	// ToolCalls is the number of tool calls in this turn (== Tools.Total), lifted
+	// into the signal bundle as the "tool-call volume" reduction signal. Names
+	// live in CostEvent.Tools; this is the count only.
+	ToolCalls int `json:"tool_calls"`
+}
+
+// cacheHitRate implements the issue's formula locally:
+//
+//	cache_read / (cache_read + cache_creation + input)
+//
+// `cache_creation` is the total cache-write tokens (our Tokens.CacheWrite).
+// Output tokens are deliberately excluded — this measures input-side cache
+// effectiveness only. Returns 0 when the denominator is 0 (no input-side
+// tokens), avoiding a divide-by-zero. Implemented from the formula in #71; not
+// copied from any platform code.
+func cacheHitRate(input, cacheRead, cacheCreation int64) float64 {
+	denom := cacheRead + cacheCreation + input
+	if denom <= 0 {
+		return 0
+	}
+	return float64(cacheRead) / float64(denom)
+}
+
+// inputTokenShare is fresh input over all input-side tokens:
+//
+//	input / (input + cache_read + cache_creation)
+//
+// Same denominator as cacheHitRate; returns 0 when there are no input-side
+// tokens.
+func inputTokenShare(input, cacheRead, cacheCreation int64) float64 {
+	denom := input + cacheRead + cacheCreation
+	if denom <= 0 {
+		return 0
+	}
+	return float64(input) / float64(denom)
+}
+
+// cacheMissCostShare is the dollar share of a turn spent on non-cache-hit
+// tokens: (input cost + cache-write cost) / total cost. Returns 0 when total
+// cost is 0 (unpriced model or no spend).
+func cacheMissCostShare(c Cost) float64 {
+	if c.Total <= 0 {
+		return 0
+	}
+	return (c.Input + c.CacheWrite) / c.Total
+}
+
+// modelTier buckets a model name into a coarse cost tier (names only — no
+// pricing lookup). Unpriced models are always TierUnknown so the UI never
+// implies a tier for a model whose cost we couldn't compute. The match is a
+// lowercase substring check against well-known family markers; anything
+// unrecognized but priced falls through to TierStandard.
+func modelTier(model string, priced bool) string {
+	if !priced || model == "" {
+		return TierUnknown
+	}
+	m := strings.ToLower(model)
+	switch {
+	case strings.Contains(m, "haiku"),
+		strings.Contains(m, "mini"),
+		strings.Contains(m, "nano"),
+		strings.Contains(m, "flash"):
+		return TierEconomy
+	case strings.Contains(m, "opus"),
+		strings.Contains(m, "gpt-5"),
+		strings.Contains(m, "gpt-4"),
+		strings.Contains(m, "ultra"),
+		strings.Contains(m, "-pro"):
+		return TierPremium
+	default:
+		// Sonnet, Composer, and other recognized-but-mid models land here.
+		return TierStandard
+	}
+}
+
+// computeSignals derives the cost-reduction signal bundle from a turn's token
+// counts, dollar costs, model, priced-flag, and tool-call count. It is the
+// single source of the signal math, used for both per-request CostEvents and
+// (re-applied to session totals) the SessionSummary.
+func computeSignals(tok Tokens, c Cost, model string, priced bool, toolCalls int) Signals {
+	return Signals{
+		CacheHitRate:       cacheHitRate(tok.Input, tok.CacheRead, tok.CacheWrite),
+		CacheMissCostShare: cacheMissCostShare(c),
+		InputTokenShare:    inputTokenShare(tok.Input, tok.CacheRead, tok.CacheWrite),
+		Tier:               modelTier(model, priced),
+		ModelPriced:        priced,
+		ToolCalls:          toolCalls,
+	}
 }
 
 // ToolSummary is a content-free per-request tool-call summary: how many tool
@@ -98,6 +246,7 @@ type CostEvent struct {
 	Cost        Cost        `json:"cost"`
 	CwdBase     string      `json:"cwd_base"` // basename only — never the full path or prompt
 	Tools       ToolSummary `json:"tools"`    // names-only tool-call summary (schema v2+)
+	Signals     Signals     `json:"signals"`  // derived cost-reduction signals, numbers only (schema v2+)
 }
 
 // summarizeToolNames builds a ToolSummary from a flat list of tool-call names
@@ -162,6 +311,12 @@ type SessionSummary struct {
 	// events (names only; schema v2+). Empty for Cursor sessions, whose cost
 	// events don't carry tool names — see cursor.go.
 	Tools ToolSummary `json:"tools"`
+	// Signals is the session-level cost-reduction signal bundle (schema v2+),
+	// recomputed from the session's accumulated totals (not averaged across
+	// turns) so e.g. CacheHitRate reflects whole-session cache effectiveness.
+	// Tier here is the dominant model's tier (the costliest in ByModel). Numbers
+	// only — see Signals.
+	Signals Signals `json:"signals"`
 }
 
 // SessionTotal is the flattened token+cost total for a session.

--- a/internal/cost/watcher.go
+++ b/internal/cost/watcher.go
@@ -40,6 +40,11 @@ type Watcher struct {
 type sessionState struct {
 	summary SessionSummary
 	byModel map[string]*ModelTotal
+	// cost accumulates the per-component dollar breakdown across the session.
+	// SessionTotal only keeps a flat CostTotal, but the session-level Signals
+	// (cache-miss cost share) need the Input/CacheWrite components, so we sum
+	// them here as turns are applied.
+	cost Cost
 }
 
 // NewWatcher builds a watcher. Pass emitEvents=false for one-shot summaries
@@ -327,6 +332,14 @@ func (w *Watcher) apply(ev CostEvent) bool {
 	t.CostTotal += ev.Cost.Total
 	t.Currency = Currency
 
+	// Sum the per-component cost so session Signals can derive cache-miss cost
+	// share (which needs the input + cache-write components, not just the total).
+	st.cost.Input += ev.Cost.Input
+	st.cost.Output += ev.Cost.Output
+	st.cost.CacheRead += ev.Cost.CacheRead
+	st.cost.CacheWrite += ev.Cost.CacheWrite
+	st.cost.Total += ev.Cost.Total
+
 	st.summary.Tools.add(ev.Tools)
 
 	mt := st.byModel[ev.Model]
@@ -386,7 +399,28 @@ func (w *Watcher) LatestSummary() (SessionSummary, bool) {
 	sort.Slice(summary.ByModel, func(i, j int) bool {
 		return summary.ByModel[i].CostTotal > summary.ByModel[j].CostTotal
 	})
+	summary.Signals = sessionSignals(summary, st.cost)
 	return summary, true
+}
+
+// sessionSignals derives the session-level Signals from accumulated totals (not
+// by averaging per-turn signals): the cache/input rates are recomputed from the
+// summed token counts, and cache-miss cost share from the summed cost
+// components. Tier follows the dominant (costliest) model, which is ByModel[0]
+// after the caller sorts. accCost is the per-component cost sum kept in
+// sessionState. Must be called after ByModel is populated and sorted.
+func sessionSignals(s SessionSummary, accCost Cost) Signals {
+	tok := Tokens{
+		Input:      s.Totals.Input,
+		Output:     s.Totals.Output,
+		CacheRead:  s.Totals.CacheRead,
+		CacheWrite: s.Totals.CacheWrite,
+	}
+	model, priced := "", false
+	if len(s.ByModel) > 0 {
+		model, priced = s.ByModel[0].Model, s.ByModel[0].ModelPriced
+	}
+	return computeSignals(tok, accCost, model, priced, s.Tools.Total)
 }
 
 // emitSummary writes the current SessionSummary for a session.
@@ -402,11 +436,13 @@ func (w *Watcher) emitSummary(sessionID string) {
 	for _, mt := range st.byModel {
 		summary.ByModel = append(summary.ByModel, *mt)
 	}
+	accCost := st.cost
 	w.mu.Unlock()
 
 	sort.Slice(summary.ByModel, func(i, j int) bool {
 		return summary.ByModel[i].CostTotal > summary.ByModel[j].CostTotal
 	})
+	summary.Signals = sessionSignals(summary, accCost)
 	w.emitJSON(summary)
 }
 


### PR DESCRIPTION
Implements #71 — https://github.com/promptconduit/cli/issues/71

## Summary

Adds a content-free `signals` bundle of **derived cost-reduction metrics** to the local cost feed, so cost-saving tips in the UI are driven by structured numbers the CLI emits rather than re-computed (and possibly diverging) inside the editor extension. Like everything else in this package, the signals are **numbers only** — never prompt content, tool inputs, or file paths.

### Signals (per-request on `CostEvent`, per-session on `SessionSummary`)
- **`cache_hit_rate`** — `cache_read / (cache_read + cache_creation + input)`. Re-implemented locally in `cacheHitRate` (`event.go`); **not** copied from any platform code. Range [0,1], higher is cheaper.
- **`cache_miss_cost_share`** — fraction of total dollar cost spent on non-cache-hit tokens: `(input cost + cache-write cost) / total cost`.
- **`input_token_share`** — fresh input as a share of all input-side tokens: `input / (input + cache_read + cache_creation)`.
- **`tier` + `model_priced`** — coarse `premium`/`standard`/`economy` bucket derived from the model name (names only, no price lookup); unpriced/unknown models are always `unknown`.
- **`tool_calls`** — per-turn tool-call volume (mirrors `Tools.Total`).

Each signal is documented with a comment in `internal/cost/event.go`.

### Wiring
- Both the Claude Code path (`claudecode.go`) and the Cursor path (`cursor.go`) populate `signals` from the token counts + costs they already compute. Cursor's `tool_calls` is `0`, matching its empty tool summary.
- **Session-level** signals are recomputed from the session's **accumulated totals** (not averaged per turn). The watcher now sums per-component costs so `cache_miss_cost_share` is exact; `tier` follows the session's dominant (costliest) model.
- `cost watch --json` and `cost session --json` emit `signals` automatically (full record is serialized); `cost session` (human-readable) gains a `Signals:` line.

## Schema version

Folded into the **same** schema revision as #70 — `SchemaVersion` stays at **2**, no second bump (per the issue: "fold into the same schema version"). The change is additive; existing fields are unchanged.

## Dependency / sequencing

Built on top of #70 (`feat/cost-toolcalls`, PR #75), which must merge first — the two issues share one schema version and are not parallel-safe. This branch was cut from the finished toolcalls tip, so against `main` the diff currently includes the #70 commit until #75 lands.

## Tests

- `make build` — **passes**.
- `make test` / `go test ./...` — **green** (all packages pass).
- New unit tests: `TestSignalFormulas` (incl. divide-by-zero guards), `TestModelTier`, `TestParseClaudeCodeLine_Signals`, `TestParseCursorHookPayload_Signals`, `TestSessionSignalsFromTotals`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
