### PR TITLE
chore: fix safe lint issues (errcheck/staticcheck/unused/ineffassign)

### DIFF
--- a/cmd/collect.go
+++ b/cmd/collect.go
@@ -64,10 +64,10 @@ func runCollect(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("init collector: %w", err)
 	}
 
-	fmt.Fprintf(cmd.ErrOrStderr(), "OTLP receiver:  http://%s/v1/traces\n", collectOTLPAddr)
-	fmt.Fprintf(cmd.ErrOrStderr(), "Dashboard:      http://%s\n", collectDashboardAddr)
-	fmt.Fprintf(cmd.ErrOrStderr(), "Store:          %s\n", srv.StoreDir())
-	fmt.Fprintln(cmd.ErrOrStderr(), "Ctrl-C to stop.")
+	_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "OTLP receiver:  http://%s/v1/traces\n", collectOTLPAddr)
+	_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Dashboard:      http://%s\n", collectDashboardAddr)
+	_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Store:          %s\n", srv.StoreDir())
+	_, _ = fmt.Fprintln(cmd.ErrOrStderr(), "Ctrl-C to stop.")
 
 	return srv.Run(ctx)
 }

--- a/cmd/cost.go
+++ b/cmd/cost.go
@@ -117,7 +117,7 @@ func init() {
 
 func runCostRefreshPricing(cmd *cobra.Command, args []string) error {
 	out := cmd.OutOrStdout()
-	fmt.Fprintf(cmd.ErrOrStderr(), "Fetching public price table (no data sent): %s\n", litellmPricingURL)
+	_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Fetching public price table (no data sent): %s\n", litellmPricingURL)
 
 	client := &http.Client{Timeout: 20 * time.Second}
 	req, err := http.NewRequestWithContext(cmd.Context(), http.MethodGet, litellmPricingURL, nil)
@@ -128,7 +128,7 @@ func runCostRefreshPricing(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return fmt.Errorf("fetch pricing: %w", err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 	if resp.StatusCode != http.StatusOK {
 		return fmt.Errorf("fetch pricing: HTTP %d", resp.StatusCode)
 	}
@@ -150,8 +150,8 @@ func runCostRefreshPricing(cmd *cobra.Command, args []string) error {
 	if err := os.WriteFile(path, data, 0o644); err != nil {
 		return err
 	}
-	fmt.Fprintf(out, "Cached %d model prices to %s\n", n, path)
-	fmt.Fprintln(out, "Built-in curated rates still take precedence; cached rates fill gaps.")
+	_, _ = fmt.Fprintf(out, "Cached %d model prices to %s\n", n, path)
+	_, _ = fmt.Fprintln(out, "Built-in curated rates still take precedence; cached rates fill gaps.")
 	return nil
 }
 
@@ -181,11 +181,11 @@ func runCostWatch(cmd *cobra.Command, args []string) error {
 	// the live stream the extension depends on.
 	store, err := cost.OpenStore()
 	if err != nil {
-		fmt.Fprintf(cmd.ErrOrStderr(), "cost: local store unavailable (%v); continuing without history\n", err)
+		_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "cost: local store unavailable (%v); continuing without history\n", err)
 		store = nil
 	}
 	if store != nil {
-		defer store.Close()
+		defer func() { _ = store.Close() }()
 	}
 
 	ctx, cancel := signal.NotifyContext(cmd.Context(), os.Interrupt, syscall.SIGTERM)
@@ -197,7 +197,7 @@ func runCostWatch(cmd *cobra.Command, args []string) error {
 	if costAll {
 		scope = "all projects"
 	}
-	fmt.Fprintf(cmd.ErrOrStderr(), "cost: watching %s (Claude Code + Cursor) — local only, Ctrl-C to stop.\n", scope)
+	_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "cost: watching %s (Claude Code + Cursor) — local only, Ctrl-C to stop.\n", scope)
 
 	// Under --all, let the watcher rescan the Cursor feed dir for workspaces
 	// that come online after startup.
@@ -230,8 +230,8 @@ func runCostSession(cmd *cobra.Command, args []string) error {
 	summary, ok := w.LatestSummary()
 	out := cmd.OutOrStdout()
 	if !ok {
-		fmt.Fprintln(out, "No AI session cost recorded yet for this workspace.")
-		fmt.Fprintln(out, "Use Claude Code here, or run `promptconduit install cursor` and use Cursor, then try again.")
+		_, _ = fmt.Fprintln(out, "No AI session cost recorded yet for this workspace.")
+		_, _ = fmt.Fprintln(out, "Use Claude Code here, or run `promptconduit install cursor` and use Cursor, then try again.")
 		return nil
 	}
 	if costJSON {
@@ -239,7 +239,7 @@ func runCostSession(cmd *cobra.Command, args []string) error {
 		if err != nil {
 			return err
 		}
-		fmt.Fprintln(out, string(data))
+		_, _ = fmt.Fprintln(out, string(data))
 		return nil
 	}
 	renderSessionHuman(out, summary)
@@ -248,14 +248,14 @@ func runCostSession(cmd *cobra.Command, args []string) error {
 
 // renderSessionHuman prints a friendly one-screen cost summary.
 func renderSessionHuman(out io.Writer, s cost.SessionSummary) {
-	fmt.Fprintf(out, "AI session cost — %s  (%s)\n", s.Tool, s.Source)
-	fmt.Fprintf(out, "  Total: $%.4f %s\n", s.Totals.CostTotal, s.Totals.Currency)
+	_, _ = fmt.Fprintf(out, "AI session cost — %s  (%s)\n", s.Tool, s.Source)
+	_, _ = fmt.Fprintf(out, "  Total: $%.4f %s\n", s.Totals.CostTotal, s.Totals.Currency)
 	for _, m := range s.ByModel {
 		costStr := fmt.Sprintf("$%.4f", m.CostTotal)
 		if !m.ModelPriced {
 			costStr = "unpriced"
 		}
-		fmt.Fprintf(out, "    %-22s %-10s  in %d · out %d · cache-read %d · cache-write %d\n",
+		_, _ = fmt.Fprintf(out, "    %-22s %-10s  in %d · out %d · cache-read %d · cache-write %d\n",
 			m.Model, costStr, m.Tokens.Input, m.Tokens.Output, m.Tokens.CacheRead, m.Tokens.CacheWrite)
 	}
 }
@@ -300,28 +300,28 @@ func runCostHistory(cmd *cobra.Command, args []string) error {
 
 	out := cmd.OutOrStdout()
 	if costJSON {
-		fmt.Fprint(out, "[")
+		_, _ = fmt.Fprint(out, "[")
 		for i, dt := range days {
 			if i > 0 {
-				fmt.Fprint(out, ",")
+				_, _ = fmt.Fprint(out, ",")
 			}
-			fmt.Fprintf(out, `{"day":%q,"cost_total":%.6f,"input":%d,"output":%d,"currency":%q}`,
+			_, _ = fmt.Fprintf(out, `{"day":%q,"cost_total":%.6f,"input":%d,"output":%d,"currency":%q}`,
 				dt.day, dt.cost, dt.in, dt.out, cost.Currency)
 		}
-		fmt.Fprintln(out, "]")
+		_, _ = fmt.Fprintln(out, "]")
 		return nil
 	}
 
 	if len(days) == 0 {
-		fmt.Fprintln(out, "No cost history yet. Run `promptconduit cost watch` during a session.")
+		_, _ = fmt.Fprintln(out, "No cost history yet. Run `promptconduit cost watch` during a session.")
 		return nil
 	}
-	fmt.Fprintf(out, "%-12s %12s %12s %12s\n", "DAY", "COST (USD)", "INPUT", "OUTPUT")
+	_, _ = fmt.Fprintf(out, "%-12s %12s %12s %12s\n", "DAY", "COST (USD)", "INPUT", "OUTPUT")
 	var total float64
 	for _, dt := range days {
-		fmt.Fprintf(out, "%-12s %12.4f %12d %12d\n", dt.day, dt.cost, dt.in, dt.out)
+		_, _ = fmt.Fprintf(out, "%-12s %12.4f %12d %12d\n", dt.day, dt.cost, dt.in, dt.out)
 		total += dt.cost
 	}
-	fmt.Fprintf(out, "%-12s %12.4f\n", "TOTAL", total)
+	_, _ = fmt.Fprintf(out, "%-12s %12.4f\n", "TOTAL", total)
 	return nil
 }

--- a/cmd/hook.go
+++ b/cmd/hook.go
@@ -431,7 +431,7 @@ func outputContinueResponse() {
 func debugLog(format string, args ...interface{}) {
 	cfg := client.LoadConfig()
 	if cfg.Debug {
-		fmt.Fprintf(os.Stderr, "[promptconduit] "+format+"\n", args...)
+		_, _ = fmt.Fprintf(os.Stderr, "[promptconduit] "+format+"\n", args...)
 	}
 }
 
@@ -547,6 +547,6 @@ func writeLocalEvent(hookEvent, cwd, sessionID string) {
 	if err != nil {
 		return
 	}
-	defer f.Close()
-	f.WriteString(event + "\n")
+	defer func() { _ = f.Close() }()
+	_, _ = f.WriteString(event + "\n")
 }

--- a/cmd/install.go
+++ b/cmd/install.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -68,16 +67,16 @@ func runInstall(cmd *cobra.Command, args []string) error {
 		return err
 	}
 	if len(tools) == 0 {
-		fmt.Fprintln(cmd.ErrOrStderr(), "No tools selected.")
+		_, _ = fmt.Fprintln(cmd.ErrOrStderr(), "No tools selected.")
 		return nil
 	}
 
 	if installLocalOnly {
 		if err := persistLocalOnly(true); err != nil {
-			fmt.Fprintf(cmd.ErrOrStderr(), "warning: could not save local-only setting: %v\n", err)
+			_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "warning: could not save local-only setting: %v\n", err)
 		} else {
-			fmt.Fprintln(cmd.OutOrStdout(), "Free / local-only mode enabled — events are captured locally and never sent.")
-			fmt.Fprintln(cmd.OutOrStdout())
+			_, _ = fmt.Fprintln(cmd.OutOrStdout(), "Free / local-only mode enabled — events are captured locally and never sent.")
+			_, _ = fmt.Fprintln(cmd.OutOrStdout())
 		}
 	}
 
@@ -92,7 +91,7 @@ func runInstall(cmd *cobra.Command, args []string) error {
 
 	for i, tool := range tools {
 		if i > 0 {
-			fmt.Fprintln(cmd.OutOrStdout())
+			_, _ = fmt.Fprintln(cmd.OutOrStdout())
 		}
 		if err := installTool(tool, exePath); err != nil {
 			return fmt.Errorf("install %s: %w", tool, err)
@@ -217,11 +216,11 @@ func resolveInstallTools(cmd *cobra.Command, args []string) ([]string, error) {
 // selectToolsInteractive prompts the user to pick tools by number or name.
 func selectToolsInteractive(cmd *cobra.Command) ([]string, error) {
 	out := cmd.OutOrStdout()
-	fmt.Fprintln(out, "Which AI tools should PromptConduit set up?")
+	_, _ = fmt.Fprintln(out, "Which AI tools should PromptConduit set up?")
 	for i, t := range installableTools {
-		fmt.Fprintf(out, "  %d) %s\n", i+1, t.label)
+		_, _ = fmt.Fprintf(out, "  %d) %s\n", i+1, t.label)
 	}
-	fmt.Fprint(out, "Enter numbers (e.g. 1,2), names, or 'all': ")
+	_, _ = fmt.Fprint(out, "Enter numbers (e.g. 1,2), names, or 'all': ")
 
 	line, err := bufio.NewReader(cmd.InOrStdin()).ReadString('\n')
 	if err != nil && strings.TrimSpace(line) == "" {
@@ -660,12 +659,6 @@ func buildGeminiHooks(hookCmd string) map[string]interface{} {
 		// System alerts
 		"Notification": plainEvent(),
 	}
-}
-
-// isCommandAvailable checks if a command exists in PATH
-func isCommandAvailable(name string) bool {
-	_, err := exec.LookPath(name)
-	return err == nil
 }
 
 // installCodex registers our hook handler with OpenAI Codex CLI.

--- a/cmd/logs.go
+++ b/cmd/logs.go
@@ -97,7 +97,7 @@ func followLog(cmd *cobra.Command) error {
 		return fmt.Errorf("create log dir: %w", err)
 	}
 	if f, err := os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644); err == nil {
-		f.Close()
+		_ = f.Close()
 	}
 
 	if tailPath, err := exec.LookPath("tail"); err == nil {
@@ -131,6 +131,6 @@ func pollFollow(cmd *cobra.Command, path string) error {
 				offset += int64(len(data))
 			}
 		}
-		f.Close()
+		_ = f.Close()
 	}
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -151,17 +151,17 @@ func notifyNewer(cmd *cobra.Command, latest, releaseURL string, disabled bool) {
 		hint = "downloading in background; next invocation will use the new version"
 	}
 	w := cmd.ErrOrStderr()
-	fmt.Fprintf(w, "promptconduit: %s available (you have %s) — %s\n", latest, Version, hint)
+	_, _ = fmt.Fprintf(w, "promptconduit: %s available (you have %s) — %s\n", latest, Version, hint)
 	if releaseURL != "" {
-		fmt.Fprintf(w, "  release notes: %s\n", releaseURL)
+		_, _ = fmt.Fprintf(w, "  release notes: %s\n", releaseURL)
 	}
 }
 
 func notifyUpgraded(cmd *cobra.Command, from, to, releaseURL string) {
 	w := cmd.ErrOrStderr()
-	fmt.Fprintf(w, "promptconduit: upgraded %s → %s\n", from, to)
+	_, _ = fmt.Fprintf(w, "promptconduit: upgraded %s → %s\n", from, to)
 	if releaseURL != "" {
-		fmt.Fprintf(w, "  release notes: %s\n", releaseURL)
+		_, _ = fmt.Fprintf(w, "  release notes: %s\n", releaseURL)
 	}
 }
 

--- a/cmd/skills.go
+++ b/cmd/skills.go
@@ -171,9 +171,10 @@ func runSkillsList(cmd *cobra.Command, args []string) error {
 		wantNullOnly = true
 	case "all", "":
 		// honor legacy --approved when --filter is "all" (its default)
-		if skillsApproved == "true" {
+		switch skillsApproved {
+		case "true":
 			approvedFilter = "true"
-		} else if skillsApproved == "false" || skillsApproved == "pending" {
+		case "false", "pending":
 			approvedFilter = "false"
 		}
 	default:
@@ -318,11 +319,7 @@ func runSkillsSync(cmd *cobra.Command, args []string) error {
 
 		id, _ := skill["id"].(string)
 		name, _ := skill["name"].(string)
-		displayName, _ := skill["display_name"].(string)
 		repoName, _ := skill["repo_name"].(string)
-		if displayName == "" {
-			displayName = name
-		}
 
 		if id == "" || name == "" {
 			continue

--- a/cmd/skills_local.go
+++ b/cmd/skills_local.go
@@ -516,7 +516,7 @@ func doAnthropicRequest(apiKey string, body interface{}) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("Anthropic API request failed: %w", err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	respBody, err := io.ReadAll(resp.Body)
 	if err != nil {
@@ -581,7 +581,7 @@ func callViaOpenAI(apiKey, userPrompt string) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("OpenAI API request failed: %w", err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	respBody, err := io.ReadAll(resp.Body)
 	if err != nil {
@@ -817,7 +817,7 @@ func outputLocalSkillsGenerated(skills []localDetectedSkill, written map[string]
 
 	if len(errs) > 0 {
 		for _, e := range errs {
-			fmt.Fprintf(os.Stderr, "  warning: %s\n", e)
+			_, _ = fmt.Fprintf(os.Stderr, "  warning: %s\n", e)
 		}
 		fmt.Println()
 	}
@@ -833,7 +833,7 @@ func outputLocalSkillsGenerated(skills []localDetectedSkill, written map[string]
 			successCount, total, pluralS(total), skills[0].Name)
 		fmt.Println("Review and delete ~/.claude/skills/<name>/ for any you don't want.")
 	} else {
-		fmt.Fprintln(os.Stderr, "No skills written. Check that ~/.claude/skills/ is writable.")
+		_, _ = fmt.Fprintln(os.Stderr, "No skills written. Check that ~/.claude/skills/ is writable.")
 	}
 }
 

--- a/cmd/sync.go
+++ b/cmd/sync.go
@@ -108,8 +108,6 @@ func runSync(cmd *cobra.Command, args []string) error {
 	// Create API client
 	apiClient := client.NewClient(config, Version)
 
-	// Track results
-	var results []sync.SyncResult
 	totalSynced := 0
 	totalSkipped := 0
 	totalErrors := 0
@@ -150,11 +148,6 @@ func runSync(cmd *cobra.Command, args []string) error {
 					displayName = "..." + displayName[len(displayName)-57:]
 				}
 				fmt.Printf("  ❌ Parse error: %s: %v\n", displayName, err)
-				results = append(results, sync.SyncResult{
-					FilePath: filePath,
-					Status:   "error",
-					Error:    err,
-				})
 				totalErrors++
 				continue
 			}
@@ -207,11 +200,6 @@ func runSync(cmd *cobra.Command, args []string) error {
 					chunkInfo = fmt.Sprintf(" [chunked: %d chunks, %s]", numChunks, reason)
 				}
 				fmt.Printf("  [dry-run] Would sync: %s (%d messages)%s\n", displayName, len(conversation.Messages), chunkInfo)
-				results = append(results, sync.SyncResult{
-					FilePath:     filePath,
-					MessageCount: len(conversation.Messages),
-					Status:       "dry-run",
-				})
 				totalSynced++
 				continue
 			}
@@ -234,11 +222,6 @@ func runSync(cmd *cobra.Command, args []string) error {
 
 			if err != nil {
 				fmt.Printf("  ❌ %s: %v\n", displayName, err)
-				results = append(results, sync.SyncResult{
-					FilePath: filePath,
-					Status:   "error",
-					Error:    err,
-				})
 				totalErrors++
 				continue
 			}
@@ -256,12 +239,6 @@ func runSync(cmd *cobra.Command, args []string) error {
 			}
 			fmt.Printf("  %s %s: %s (%d messages)\n", statusIcon, resp.Status, displayName, resp.MessageCount)
 
-			results = append(results, sync.SyncResult{
-				FilePath:       filePath,
-				ConversationID: resp.ConversationID,
-				MessageCount:   resp.MessageCount,
-				Status:         resp.Status,
-			})
 			totalSynced++
 			syncedThisRun++
 		}
@@ -362,7 +339,7 @@ func syncChunked(apiClient *client.Client, conv *sync.ParsedConversation, stateM
 			ChunksUploaded: 0,
 		})
 		// Save state immediately so we can resume if interrupted
-		stateManager.Save()
+		_ = stateManager.Save()
 	}
 
 	// Step 2: Upload chunks (starting from where we left off)
@@ -393,7 +370,7 @@ func syncChunked(apiClient *client.Client, conv *sync.ParsedConversation, stateM
 		if err != nil {
 			// Save progress before returning error so we can resume later
 			stateManager.UpdatePendingUploadProgress(filePath, chunkIndex)
-			stateManager.Save()
+			_ = stateManager.Save()
 			return nil, fmt.Errorf("failed to upload chunk %d/%d: %w", chunkIndex+1, numChunks, err)
 		}
 
@@ -405,7 +382,7 @@ func syncChunked(apiClient *client.Client, conv *sync.ParsedConversation, stateM
 	}
 
 	// Save final chunk progress before completing
-	stateManager.Save()
+	_ = stateManager.Save()
 
 	// Step 3: Complete upload
 	completeReq := &client.ChunkedCompleteRequest{
@@ -451,7 +428,7 @@ func runSingleFileSync(config *client.Config, stateManager *sync.StateManager, f
 	conversation, err := parser.ParseFile(filePath)
 	if err != nil {
 		stateManager.AddFailedSync(filepath.Base(filePath), filePath, err.Error())
-		stateManager.Save()
+		_ = stateManager.Save()
 		return fmt.Errorf("failed to parse transcript: %w", err)
 	}
 
@@ -484,7 +461,7 @@ func runSingleFileSync(config *client.Config, stateManager *sync.StateManager, f
 	if err != nil {
 		// Track failure for retry
 		stateManager.AddFailedSync(conversation.SessionID, filePath, err.Error())
-		stateManager.Save()
+		_ = stateManager.Save()
 		return fmt.Errorf("failed to sync: %w", err)
 	}
 
@@ -495,7 +472,7 @@ func runSingleFileSync(config *client.Config, stateManager *sync.StateManager, f
 		MessageCount:   resp.MessageCount,
 	})
 	stateManager.ClearFailedSync(conversation.SessionID)
-	stateManager.Save()
+	_ = stateManager.Save()
 
 	return nil
 }

--- a/cmd/watch.go
+++ b/cmd/watch.go
@@ -59,7 +59,7 @@ func runWatch(cmd *cobra.Command, args []string) error {
 	ctx, cancel := signal.NotifyContext(cmd.Context(), os.Interrupt, syscall.SIGTERM)
 	defer cancel()
 
-	fmt.Fprintf(cmd.ErrOrStderr(), "Watching %s — Ctrl-C to stop.\n", path)
+	_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Watching %s — Ctrl-C to stop.\n", path)
 
 	lines := outbound.Tail(ctx, path, watchLines)
 	for raw := range lines {
@@ -67,10 +67,10 @@ func runWatch(cmd *cobra.Command, args []string) error {
 		if err != nil {
 			// Best-effort: show the unparseable raw line so the user
 			// can still see something went through.
-			fmt.Fprintln(cmd.OutOrStdout(), string(raw))
+			_, _ = fmt.Fprintln(cmd.OutOrStdout(), string(raw))
 			continue
 		}
-		fmt.Fprintln(cmd.OutOrStdout(), outbound.RenderSummary(entry, watchVerbose, color))
+		_, _ = fmt.Fprintln(cmd.OutOrStdout(), outbound.RenderSummary(entry, watchVerbose, color))
 	}
 
 	// Ctrl-C / SIGTERM is the normal way to leave watch; treat as a

--- a/internal/client/api.go
+++ b/internal/client/api.go
@@ -118,7 +118,7 @@ func (c *Client) SendEnvelopeWithAttachments(env *envelope.RawEventEnvelope, att
 		if err != nil {
 			continue
 		}
-		part.Write(att.Data)
+		_, _ = part.Write(att.Data)
 	}
 
 	if err := writer.Close(); err != nil {
@@ -155,7 +155,7 @@ func (c *Client) SendEnvelopeWithAttachments(env *envelope.RawEventEnvelope, att
 			Error:   fmt.Sprintf("request failed: %v", err),
 		}
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	respBody, _ := io.ReadAll(resp.Body)
 
@@ -260,9 +260,8 @@ func (c *Client) sendAsyncUnix(envJSON []byte) error {
 		return c.sendEnvelopeBlocking(envJSON)
 	}
 
-	if err := cmd.Process.Release(); err != nil {
-		// Process already started, ignore error
-	}
+	// Process already started, ignore error
+	_ = cmd.Process.Release()
 
 	return nil
 }
@@ -331,7 +330,7 @@ func (c *Client) sendEnvelopeBlocking(envJSON []byte) error {
 		recordEventSend(envJSON, 0, time.Since(start), 1, err)
 		return err
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		body, _ := io.ReadAll(resp.Body)
@@ -374,7 +373,7 @@ func (c *Client) sendRequest(path string, payload interface{}) *APIResponse {
 			Error:   fmt.Sprintf("request failed: %v", err),
 		}
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	body, _ := io.ReadAll(resp.Body)
 
@@ -468,7 +467,7 @@ func (c *Client) SyncTranscriptRaw(req *RawTranscriptSyncRequest) (*TranscriptSy
 	if err != nil {
 		return nil, fmt.Errorf("request failed: %w", err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
@@ -545,7 +544,7 @@ func (c *Client) InitChunkedUpload(req *ChunkedInitRequest) (*ChunkedInitRespons
 	if err != nil {
 		return nil, fmt.Errorf("request failed: %w", err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
@@ -585,7 +584,7 @@ func (c *Client) UploadChunk(req *ChunkedUploadRequest) (*ChunkedUploadResponse,
 	if err != nil {
 		return nil, fmt.Errorf("request failed: %w", err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
@@ -625,7 +624,7 @@ func (c *Client) CompleteChunkedUpload(req *ChunkedCompleteRequest) (*Transcript
 	if err != nil {
 		return nil, fmt.Errorf("request failed: %w", err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
@@ -679,7 +678,7 @@ func (c *Client) Get(path string, query map[string]string) *APIResponse {
 			Error:   fmt.Sprintf("request failed: %v", err),
 		}
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	body, _ := io.ReadAll(resp.Body)
 
@@ -798,7 +797,7 @@ func (c *Client) GenerateSkills(force bool, repoName string) *APIResponse {
 	if err != nil {
 		return &APIResponse{Success: false, Error: fmt.Sprintf("request failed: %v", err)}
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	body2, err := io.ReadAll(resp.Body)
 	if err != nil {
@@ -811,7 +810,7 @@ func (c *Client) GenerateSkills(force bool, repoName string) *APIResponse {
 	}
 
 	if resp.StatusCode >= 400 {
-		errMsg := "request failed"
+		var errMsg string
 		if detail, ok := data["detail"].(string); ok {
 			errMsg = fmt.Sprintf("HTTP %d: %s", resp.StatusCode, detail)
 		} else {
@@ -867,7 +866,7 @@ func (c *Client) GetSkillCommandFile(id string) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("request failed: %w", err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
@@ -896,7 +895,7 @@ func (c *Client) deleteRequest(path string) *APIResponse {
 	if err != nil {
 		return &APIResponse{Success: false, Error: fmt.Sprintf("request failed: %v", err)}
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	body, _ := io.ReadAll(resp.Body)
 	result := &APIResponse{StatusCode: resp.StatusCode, Success: resp.StatusCode >= 200 && resp.StatusCode < 300}
@@ -932,7 +931,7 @@ func (c *Client) patchRequest(path string, payload interface{}) *APIResponse {
 	if err != nil {
 		return &APIResponse{Success: false, Error: fmt.Sprintf("request failed: %v", err)}
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	body, _ := io.ReadAll(resp.Body)
 	result := &APIResponse{StatusCode: resp.StatusCode, Success: resp.StatusCode >= 200 && resp.StatusCode < 300}

--- a/internal/client/config_test.go
+++ b/internal/client/config_test.go
@@ -9,10 +9,10 @@ import (
 func TestConfigPath(t *testing.T) {
 	// Save original env vars
 	origXDG := os.Getenv(EnvXDGConfigHome)
-	defer os.Setenv(EnvXDGConfigHome, origXDG)
+	defer func() { _ = os.Setenv(EnvXDGConfigHome, origXDG) }()
 
 	// Test 1: No XDG_CONFIG_HOME set - should return ~/.config/promptconduit/config.json
-	os.Unsetenv(EnvXDGConfigHome)
+	_ = os.Unsetenv(EnvXDGConfigHome)
 	path := ConfigPath()
 	home, _ := os.UserHomeDir()
 	expectedDefault := filepath.Join(home, ".config", ConfigDirName, ConfigFileName)
@@ -23,7 +23,7 @@ func TestConfigPath(t *testing.T) {
 	// Test 2: XDG_CONFIG_HOME set - should use custom location
 	tmpDir := t.TempDir()
 	xdgDir := filepath.Join(tmpDir, "xdg-config")
-	os.Setenv(EnvXDGConfigHome, xdgDir)
+	_ = os.Setenv(EnvXDGConfigHome, xdgDir)
 
 	path = ConfigPath()
 	expectedCustom := filepath.Join(xdgDir, ConfigDirName, ConfigFileName)
@@ -64,15 +64,15 @@ func withIsolatedConfig(t *testing.T) string {
 	saved := make(map[string]string, len(keys))
 	for _, k := range keys {
 		saved[k] = os.Getenv(k)
-		os.Unsetenv(k)
+		_ = os.Unsetenv(k)
 	}
-	os.Setenv(EnvXDGConfigHome, dir)
+	_ = os.Setenv(EnvXDGConfigHome, dir)
 	t.Cleanup(func() {
 		for k, v := range saved {
 			if v == "" {
-				os.Unsetenv(k)
+				_ = os.Unsetenv(k)
 			} else {
-				os.Setenv(k, v)
+				_ = os.Setenv(k, v)
 			}
 		}
 	})
@@ -81,7 +81,7 @@ func withIsolatedConfig(t *testing.T) string {
 
 func TestLoadConfigLocalOnlyFromEnv(t *testing.T) {
 	withIsolatedConfig(t)
-	os.Setenv(EnvLocalOnly, "1")
+	_ = os.Setenv(EnvLocalOnly, "1")
 
 	if cfg := LoadConfig(); !cfg.LocalOnly {
 		t.Error("LocalOnly should be true when PROMPTCONDUIT_LOCAL_ONLY=1")
@@ -111,9 +111,9 @@ func TestLoadConfigDefaultsToCloudMode(t *testing.T) {
 func TestAllConfigPaths(t *testing.T) {
 	// Save original env vars
 	origXDG := os.Getenv(EnvXDGConfigHome)
-	defer os.Setenv(EnvXDGConfigHome, origXDG)
+	defer func() { _ = os.Setenv(EnvXDGConfigHome, origXDG) }()
 
-	os.Unsetenv(EnvXDGConfigHome)
+	_ = os.Unsetenv(EnvXDGConfigHome)
 
 	paths := AllConfigPaths()
 	if len(paths) != 1 {

--- a/internal/collect/otlp_test.go
+++ b/internal/collect/otlp_test.go
@@ -40,13 +40,13 @@ func TestOTLPTracesHandler(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer os.RemoveAll(dir)
+	defer func() { _ = os.RemoveAll(dir) }()
 
 	store, err := OpenStore(dir)
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer store.Close()
+	defer func() { _ = store.Close() }()
 
 	handler := newOTLPHandler(store, signalTraces)
 	req := httptest.NewRequest(http.MethodPost, "/v1/traces", bytes.NewReader([]byte(sampleTraces)))
@@ -105,9 +105,9 @@ func TestOTLPTracesHandler(t *testing.T) {
 
 func TestOTLPRejectsNonJSON(t *testing.T) {
 	dir, _ := os.MkdirTemp("", "collect-test-*")
-	defer os.RemoveAll(dir)
+	defer func() { _ = os.RemoveAll(dir) }()
 	store, _ := OpenStore(dir)
-	defer store.Close()
+	defer func() { _ = store.Close() }()
 
 	handler := newOTLPHandler(store, signalTraces)
 	req := httptest.NewRequest(http.MethodPost, "/v1/traces", bytes.NewReader([]byte{0x08, 0x01}))
@@ -121,9 +121,9 @@ func TestOTLPRejectsNonJSON(t *testing.T) {
 
 func TestOTLPRejectsGET(t *testing.T) {
 	dir, _ := os.MkdirTemp("", "collect-test-*")
-	defer os.RemoveAll(dir)
+	defer func() { _ = os.RemoveAll(dir) }()
 	store, _ := OpenStore(dir)
-	defer store.Close()
+	defer func() { _ = store.Close() }()
 
 	handler := newOTLPHandler(store, signalTraces)
 	req := httptest.NewRequest(http.MethodGet, "/v1/traces", nil)

--- a/internal/collect/store.go
+++ b/internal/collect/store.go
@@ -151,7 +151,7 @@ func (s *Store) ReadSpans(limit int, traceID string) ([]SpanRow, error) {
 		}
 		return nil, err
 	}
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 
 	var rows []SpanRow
 	scanner := bufio.NewScanner(f)

--- a/internal/correlation/store.go
+++ b/internal/correlation/store.go
@@ -121,9 +121,9 @@ func (s *Store) LoadOrCreateTrace(sessionID string) (*TraceRecord, error) {
 		return nil, fmt.Errorf("correlation: tempfile: %w", err)
 	}
 	tmpName := tmp.Name()
-	defer os.Remove(tmpName)
+	defer func() { _ = os.Remove(tmpName) }()
 	if _, err := tmp.Write(data); err != nil {
-		tmp.Close()
+		_ = tmp.Close()
 		return nil, fmt.Errorf("correlation: write tempfile: %w", err)
 	}
 	if err := tmp.Close(); err != nil {
@@ -341,12 +341,12 @@ func writeJSONAtomic(path string, v interface{}) error {
 	}
 	tmpName := tmp.Name()
 	if _, err := tmp.Write(data); err != nil {
-		tmp.Close()
-		os.Remove(tmpName)
+		_ = tmp.Close()
+		_ = os.Remove(tmpName)
 		return err
 	}
 	if err := tmp.Close(); err != nil {
-		os.Remove(tmpName)
+		_ = os.Remove(tmpName)
 		return err
 	}
 	return os.Rename(tmpName, path)

--- a/internal/cost/claudecode.go
+++ b/internal/cost/claudecode.go
@@ -104,7 +104,7 @@ func firstLineCwd(path string) string {
 	if err != nil {
 		return ""
 	}
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 	buf := make([]byte, 8192)
 	n, _ := f.Read(buf)
 	line := buf[:n]

--- a/internal/cost/cursor.go
+++ b/internal/cost/cursor.go
@@ -132,7 +132,7 @@ func AppendCursorEvent(ev CostEvent, cwd string) error {
 	if err != nil {
 		return err
 	}
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 	_, err = f.Write(append(data, '\n'))
 	return err
 }

--- a/internal/cost/store.go
+++ b/internal/cost/store.go
@@ -133,7 +133,7 @@ func ReadEvents() ([]CostEvent, error) {
 		}
 		return nil, err
 	}
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 
 	// Dedup by request id: separate `cost watch` runs each re-seed and re-append
 	// a session's turns, so the same request can appear many times on disk.

--- a/internal/cost/watcher.go
+++ b/internal/cost/watcher.go
@@ -211,7 +211,7 @@ func (w *Watcher) seedFile(path string) {
 	if err != nil {
 		return
 	}
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 
 	sessionFallback := sessionIDFromPath(path)
 	scanner := bufio.NewScanner(f)
@@ -236,7 +236,7 @@ func (w *Watcher) seedCursorFeed(path string) {
 	if err != nil {
 		return
 	}
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 
 	scanner := bufio.NewScanner(f)
 	scanner.Buffer(make([]byte, 0, 64*1024), 8*1024*1024)

--- a/internal/eventlog/eventlog.go
+++ b/internal/eventlog/eventlog.go
@@ -133,7 +133,7 @@ func appendLine(path string, line []byte, rotateAt int64) {
 	if err != nil {
 		return
 	}
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 
 	_, _ = f.Write(line)
 	_, _ = f.Write([]byte{'\n'})

--- a/internal/logger/logger.go
+++ b/internal/logger/logger.go
@@ -137,7 +137,7 @@ func write(level, format string, args ...interface{}) {
 	if err != nil {
 		return
 	}
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 
 	msg := fmt.Sprintf(format, args...)
 	pid := os.Getpid()
@@ -194,7 +194,7 @@ func CopyTo(w io.Writer) error {
 		}
 		return err
 	}
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 	_, err = io.Copy(w, f)
 	return err
 }

--- a/internal/outbound/locking_unix.go
+++ b/internal/outbound/locking_unix.go
@@ -29,7 +29,7 @@ func appendLine(path string, line []byte) error {
 	if err != nil {
 		return err
 	}
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 
 	needFlock := len(line)+1 > 4096
 	if needFlock {
@@ -37,7 +37,7 @@ func appendLine(path string, line []byte) error {
 			return err
 		}
 		// LOCK_UN is implicit on file close, but be explicit for clarity.
-		defer syscall.Flock(int(f.Fd()), syscall.LOCK_UN)
+		defer func() { _ = syscall.Flock(int(f.Fd()), syscall.LOCK_UN) }()
 	}
 
 	// One Write call so the kernel sees the line+newline as a unit.

--- a/internal/outbound/mirror_test.go
+++ b/internal/outbound/mirror_test.go
@@ -36,7 +36,7 @@ func TestMirror_RoundTrip(t *testing.T) {
 		t.Fatalf("Do: %v", err)
 	}
 	body, _ := io.ReadAll(resp.Body)
-	resp.Body.Close()
+	_ = resp.Body.Close()
 	if string(body) != `{"ok":true}` {
 		t.Errorf("downstream caller saw wrong body: %q", body)
 	}

--- a/internal/outbound/tail.go
+++ b/internal/outbound/tail.go
@@ -35,7 +35,7 @@ func Tail(ctx context.Context, path string, backfill int) <-chan []byte {
 		if err != nil {
 			return
 		}
-		defer f.Close()
+		defer func() { _ = f.Close() }()
 
 		offset := int64(0)
 		if backfill > 0 {

--- a/internal/sync/claudecode.go
+++ b/internal/sync/claudecode.go
@@ -74,7 +74,7 @@ func (p *ClaudeCodeParser) ParseFile(path string) (*ParsedConversation, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to open file: %w", err)
 	}
-	defer file.Close()
+	defer func() { _ = file.Close() }()
 
 	// Calculate file hash
 	hash, err := calculateFileHash(path)
@@ -117,13 +117,13 @@ func (p *ClaudeCodeParser) ParseFile(path string) (*ParsedConversation, error) {
 		// Get type
 		var msgType string
 		if typeRaw, ok := raw["type"]; ok {
-			json.Unmarshal(typeRaw, &msgType)
+			_ = json.Unmarshal(typeRaw, &msgType)
 		}
 
 		// Get timestamp
 		var timestamp string
 		if tsRaw, ok := raw["timestamp"]; ok {
-			json.Unmarshal(tsRaw, &timestamp)
+			_ = json.Unmarshal(tsRaw, &timestamp)
 		}
 		if timestamp == "" {
 			timestamp = time.Now().UTC().Format(time.RFC3339)
@@ -139,10 +139,10 @@ func (p *ClaudeCodeParser) ParseFile(path string) (*ParsedConversation, error) {
 		switch msgType {
 		case "summary":
 			if summaryRaw, ok := raw["summary"]; ok {
-				json.Unmarshal(summaryRaw, &summary)
+				_ = json.Unmarshal(summaryRaw, &summary)
 			}
 			if leafRaw, ok := raw["leafTitle"]; ok {
-				json.Unmarshal(leafRaw, &title)
+				_ = json.Unmarshal(leafRaw, &title)
 			}
 			continue // Don't add summary as a message
 
@@ -182,10 +182,10 @@ func (p *ClaudeCodeParser) ParseFile(path string) (*ParsedConversation, error) {
 
 		// Extract context from any message that has it
 		if cwdRaw, ok := raw["cwd"]; ok && workingDirectory == "" {
-			json.Unmarshal(cwdRaw, &workingDirectory)
+			_ = json.Unmarshal(cwdRaw, &workingDirectory)
 		}
 		if versionRaw, ok := raw["cliVersion"]; ok && cliVersion == "" {
-			json.Unmarshal(versionRaw, &cliVersion)
+			_ = json.Unmarshal(versionRaw, &cliVersion)
 		}
 	}
 
@@ -249,13 +249,13 @@ func parseUserMessage(raw map[string]json.RawMessage, sequence int, timestamp st
 	isToolResult := false
 
 	if uuidRaw, ok := raw["uuid"]; ok {
-		json.Unmarshal(uuidRaw, &uuid)
+		_ = json.Unmarshal(uuidRaw, &uuid)
 	}
 	if parentRaw, ok := raw["parentUuid"]; ok {
-		json.Unmarshal(parentRaw, &parentUUID)
+		_ = json.Unmarshal(parentRaw, &parentUUID)
 	}
 	if cwdRaw, ok := raw["cwd"]; ok {
-		json.Unmarshal(cwdRaw, &cwd)
+		_ = json.Unmarshal(cwdRaw, &cwd)
 	}
 
 	// Try to extract content from message.content
@@ -379,10 +379,10 @@ func parseAssistantMessage(raw map[string]json.RawMessage, sequence int, timesta
 	var toolInput string
 
 	if uuidRaw, ok := raw["uuid"]; ok {
-		json.Unmarshal(uuidRaw, &uuid)
+		_ = json.Unmarshal(uuidRaw, &uuid)
 	}
 	if parentRaw, ok := raw["parentUuid"]; ok {
-		json.Unmarshal(parentRaw, &parentUUID)
+		_ = json.Unmarshal(parentRaw, &parentUUID)
 	}
 
 	// Get model from message or costUSD.modelId
@@ -398,11 +398,11 @@ func parseAssistantMessage(raw map[string]json.RawMessage, sequence int, timesta
 			// Parse content
 			for _, c := range msg.Content {
 				var contentItem struct {
-					Type     string `json:"type"`
-					Text     string `json:"text"`
-					Thinking string `json:"thinking"`
-					Name     string `json:"name"`
-					ID       string `json:"id"`
+					Type     string          `json:"type"`
+					Text     string          `json:"text"`
+					Thinking string          `json:"thinking"`
+					Name     string          `json:"name"`
+					ID       string          `json:"id"`
 					Input    json.RawMessage `json:"input"`
 				}
 				if err := json.Unmarshal(c, &contentItem); err == nil {
@@ -447,7 +447,7 @@ func parseAssistantMessage(raw map[string]json.RawMessage, sequence int, timesta
 func parseFileSnapshot(raw map[string]json.RawMessage, sequence int, timestamp string, rawJSON string) *ParsedMessage {
 	var uuid string
 	if uuidRaw, ok := raw["uuid"]; ok {
-		json.Unmarshal(uuidRaw, &uuid)
+		_ = json.Unmarshal(uuidRaw, &uuid)
 	}
 	if uuid == "" {
 		uuid = fmt.Sprintf("snapshot-%d", sequence)
@@ -467,7 +467,7 @@ func parseGenericMessage(raw map[string]json.RawMessage, msgType string, sequenc
 	var content string
 
 	if uuidRaw, ok := raw["uuid"]; ok {
-		json.Unmarshal(uuidRaw, &uuid)
+		_ = json.Unmarshal(uuidRaw, &uuid)
 	}
 	if uuid == "" {
 		uuid = fmt.Sprintf("%s-%d", msgType, sequence)
@@ -475,7 +475,7 @@ func parseGenericMessage(raw map[string]json.RawMessage, msgType string, sequenc
 
 	// Try to get any text content
 	if contentRaw, ok := raw["content"]; ok {
-		json.Unmarshal(contentRaw, &content)
+		_ = json.Unmarshal(contentRaw, &content)
 	}
 
 	return &ParsedMessage{
@@ -537,7 +537,7 @@ func calculateFileHash(path string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	defer file.Close()
+	defer func() { _ = file.Close() }()
 
 	hasher := sha256.New()
 	if _, err := io.Copy(hasher, file); err != nil {

--- a/internal/sync/codex.go
+++ b/internal/sync/codex.go
@@ -64,7 +64,7 @@ func (p *CodexParser) ParseFile(path string) (*ParsedConversation, error) {
 	if err != nil {
 		return nil, err
 	}
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 
 	hash, err := calculateFileHash(path)
 	if err != nil {

--- a/internal/sync/copilot.go
+++ b/internal/sync/copilot.go
@@ -74,7 +74,7 @@ func (p *CopilotParser) ParseFile(path string) (*ParsedConversation, error) {
 	if err != nil {
 		return nil, err
 	}
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 
 	hash, err := calculateFileHash(path)
 	if err != nil {

--- a/internal/sync/state.go
+++ b/internal/sync/state.go
@@ -33,7 +33,7 @@ func NewStateManager() (*StateManager, error) {
 
 	// Load existing state if available
 	if data, err := os.ReadFile(statePath); err == nil {
-		json.Unmarshal(data, sm.state)
+		_ = json.Unmarshal(data, sm.state)
 		// Ensure maps are initialized even after loading
 		if sm.state.SyncedFiles == nil {
 			sm.state.SyncedFiles = make(map[string]SyncedFileInfo)

--- a/internal/transcript/transcript.go
+++ b/internal/transcript/transcript.go
@@ -163,7 +163,7 @@ func extractAttachmentsForPrompt(transcriptPath, expectedPrompt string) (bool, [
 	if err != nil {
 		return false, nil, fmt.Errorf("failed to open transcript: %w", err)
 	}
-	defer file.Close()
+	defer func() { _ = file.Close() }()
 
 	var matchingMessage *MessageWithContent
 	scanner := bufio.NewScanner(file)
@@ -277,7 +277,7 @@ func extractAttachmentsFromFile(transcriptPath string) ([]Attachment, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to open transcript: %w", err)
 	}
-	defer file.Close()
+	defer func() { _ = file.Close() }()
 
 	// Read all lines to find the LAST user message (regardless of whether it has attachments)
 	// We only extract attachments if the LAST message contains them - this prevents
@@ -392,7 +392,7 @@ func ExtractPromptText(transcriptPath string) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("failed to open transcript: %w", err)
 	}
-	defer file.Close()
+	defer func() { _ = file.Close() }()
 
 	var lastText string
 	scanner := bufio.NewScanner(file)
@@ -419,7 +419,7 @@ func ExtractPromptText(transcriptPath string) (string, error) {
 					rawContent = content.Content
 				}
 			} else if msg.Content != nil {
-				json.Unmarshal(msg.Content, &rawContent)
+				_ = json.Unmarshal(msg.Content, &rawContent)
 			}
 
 			// Only process actual user prompts (skip tool_result messages)

--- a/internal/updater/integration_test.go
+++ b/internal/updater/integration_test.go
@@ -138,7 +138,7 @@ func TestApply_EndToEnd(t *testing.T) {
 	if err != nil {
 		t.Fatalf("downloadAndHash: %v", err)
 	}
-	defer os.Remove(tmpArchive)
+	defer func() { _ = os.Remove(tmpArchive) }()
 	if !strings.EqualFold(gotSum, wantSum) {
 		t.Fatalf("checksum mismatch: got %s, want %s", gotSum, wantSum)
 	}
@@ -189,7 +189,7 @@ func TestApply_ChecksumMismatch(t *testing.T) {
 	if err != nil {
 		t.Fatalf("downloadAndHash: %v", err)
 	}
-	defer os.Remove(tmpArchive)
+	defer func() { _ = os.Remove(tmpArchive) }()
 	if strings.EqualFold(gotSum, wantSum) {
 		t.Fatal("expected wrong bytes to produce a different sum")
 	}

--- a/internal/updater/updater.go
+++ b/internal/updater/updater.go
@@ -164,7 +164,7 @@ func CheckLatest(ctx context.Context, currentVersion string) (*Release, bool, er
 	if err != nil {
 		return nil, false, err
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
 		return nil, false, fmt.Errorf("github releases API returned %s", resp.Status)
@@ -202,10 +202,10 @@ func AssetForCurrent(rel *Release) (*Asset, *Asset, error) {
 	var archive, checksums *Asset
 	for i := range rel.Assets {
 		a := &rel.Assets[i]
-		switch {
-		case a.Name == wantArchive:
+		switch a.Name {
+		case wantArchive:
 			archive = a
-		case a.Name == "checksums.txt":
+		case "checksums.txt":
 			checksums = a
 		}
 	}
@@ -248,7 +248,7 @@ func Apply(ctx context.Context, archive, checksums *Asset) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("download archive: %w", err)
 	}
-	defer os.Remove(tmpArchive)
+	defer func() { _ = os.Remove(tmpArchive) }()
 
 	if !strings.EqualFold(gotSum, wantSum) {
 		return "", fmt.Errorf("checksum mismatch: got %s, want %s", gotSum, wantSum)
@@ -266,7 +266,7 @@ func Apply(ctx context.Context, archive, checksums *Asset) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("extract binary: %w", err)
 	}
-	defer os.Remove(tmpBinary)
+	defer func() { _ = os.Remove(tmpBinary) }()
 
 	if err := os.Chmod(tmpBinary, 0o755); err != nil {
 		return "", fmt.Errorf("chmod new binary: %w", err)
@@ -350,7 +350,7 @@ func fetchChecksum(ctx context.Context, c *http.Client, url, assetName string) (
 	if err != nil {
 		return "", err
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 	if resp.StatusCode != http.StatusOK {
 		return "", fmt.Errorf("status %s", resp.Status)
 	}
@@ -383,7 +383,7 @@ func downloadAndHash(ctx context.Context, c *http.Client, url string) (string, s
 	if err != nil {
 		return "", "", err
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 	if resp.StatusCode != http.StatusOK {
 		return "", "", fmt.Errorf("status %s", resp.Status)
 	}
@@ -392,11 +392,11 @@ func downloadAndHash(ctx context.Context, c *http.Client, url string) (string, s
 	if err != nil {
 		return "", "", err
 	}
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 
 	hash := sha256.New()
 	if _, err := io.Copy(io.MultiWriter(f, hash), resp.Body); err != nil {
-		os.Remove(f.Name())
+		_ = os.Remove(f.Name())
 		return "", "", err
 	}
 	return f.Name(), hex.EncodeToString(hash.Sum(nil)), nil
@@ -414,7 +414,7 @@ func isZip(path string) bool {
 	if err != nil {
 		return false
 	}
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 	var sig [4]byte
 	if _, err := io.ReadFull(f, sig[:]); err != nil {
 		return false
@@ -427,13 +427,13 @@ func extractTarGzBinary(archivePath, binaryName, targetDir string) (string, erro
 	if err != nil {
 		return "", err
 	}
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 
 	gzr, err := gzip.NewReader(f)
 	if err != nil {
 		return "", err
 	}
-	defer gzr.Close()
+	defer func() { _ = gzr.Close() }()
 
 	tr := tar.NewReader(gzr)
 	for {
@@ -452,12 +452,12 @@ func extractTarGzBinary(archivePath, binaryName, targetDir string) (string, erro
 			return "", err
 		}
 		if _, err := io.Copy(out, tr); err != nil {
-			out.Close()
-			os.Remove(out.Name())
+			_ = out.Close()
+			_ = os.Remove(out.Name())
 			return "", err
 		}
 		if err := out.Close(); err != nil {
-			os.Remove(out.Name())
+			_ = os.Remove(out.Name())
 			return "", err
 		}
 		return out.Name(), nil
@@ -470,7 +470,7 @@ func extractZipBinary(archivePath, binaryName, targetDir string) (string, error)
 	if err != nil {
 		return "", err
 	}
-	defer zr.Close()
+	defer func() { _ = zr.Close() }()
 
 	for _, file := range zr.File {
 		if filepath.Base(file.Name) != binaryName {
@@ -482,18 +482,18 @@ func extractZipBinary(archivePath, binaryName, targetDir string) (string, error)
 		}
 		out, err := os.CreateTemp(targetDir, BinaryName+"-new-*")
 		if err != nil {
-			rc.Close()
+			_ = rc.Close()
 			return "", err
 		}
 		if _, err := io.Copy(out, rc); err != nil {
-			rc.Close()
-			out.Close()
-			os.Remove(out.Name())
+			_ = rc.Close()
+			_ = out.Close()
+			_ = os.Remove(out.Name())
 			return "", err
 		}
-		rc.Close()
+		_ = rc.Close()
 		if err := out.Close(); err != nil {
-			os.Remove(out.Name())
+			_ = os.Remove(out.Name())
 			return "", err
 		}
 		return out.Name(), nil


### PR DESCRIPTION
## Summary

Mechanical, **behavior-preserving** lint cleanup so `make lint` (`golangci-lint run`) goes from 119 issues to 4. No public API changes and no behavior changes — every fix only makes an already-ignored error explicit, removes genuinely dead code, or applies an idiomatic-equivalent rewrite.

`golangci-lint`'s default display caps (`max-issues-per-linter=50`, `max-same-issues=3`) hid the true counts; the numbers below are the full, uncapped totals.

### Fix categories

- **errcheck (113 → 0):** assigned already-ignored error returns to blanks (`_ =` / `_, _ =`) and wrapped `defer X.Close()` as `defer func() { _ = X.Close() }()`. Covers `fmt.Fprint*`, `*.Close`, `os.Remove`/`os.RemoveAll`, `os.Setenv`/`os.Unsetenv`, `json.Unmarshal`, `syscall.Flock`, `*.WriteString`, `*.Write`, etc. across `cmd/` and `internal/` (incl. test files).
- **staticcheck SA4010 (3 → 0), `cmd/sync.go`:** the `results []sync.SyncResult` slice was appended to in 4 places but **never read**. Removed the dead variable and its appends. Summary output is driven by the `totalSynced`/`totalSkipped`/`totalErrors` counters, so behavior is unchanged.
- **staticcheck SA9003 (1 → 0), `internal/client/api.go`:** collapsed the empty `if err := cmd.Process.Release(); err != nil {}` to `_ = cmd.Process.Release()`.
- **staticcheck QF1002/QF1003 (2 → 0):** converted tagless `switch { case x == ... }` to tagged `switch x` in `internal/updater/updater.go` and `cmd/skills.go`.
- **unused (1 → 0), `cmd/install.go`:** removed the unreferenced `isCommandAvailable` (confirmed no callers anywhere in the repo) plus the now-unused `os/exec` import.
- **ineffassign (2 → 0):** `errMsg` in `api.go` was always overwritten before use → `var errMsg string`; removed the dead `displayName` fallback in `cmd/skills.go` (its value was never read).
- Ran `gofmt` to normalize a **pre-existing** struct-tag alignment in `internal/sync/claudecode.go` that the diff touched.

### Intentionally left (4 issues)

- **staticcheck ST1005 ×4, `cmd/skills_local.go`** — "error strings should not be capitalized" on `fmt.Errorf("Anthropic API ...")`. Lowercasing the **brand name** in user-facing error text is a copy/behavior change outside a safe-only cleanup, so left untouched. (Not in the requested scope.)

### Verification

- `make build` — passes
- `make test` — passes (uncached, all packages)
- `go vet ./...` — clean
- `make lint` — 4 remaining (the ST1005 above); all other categories resolved

🤖 Generated with [Claude Code](https://claude.com/claude-code)