### PR TITLE
fix(config): honor top-level opt-out flags in multi-environment configs

### DIFF
--- a/internal/client/config.go
+++ b/internal/client/config.go
@@ -160,10 +160,19 @@ func (fc *FileConfig) GetCurrentConfig() *Config {
 		return nil
 	}
 
-	// If we have environments and a current env, use that
+	// If we have environments and a current env, use that. Top-level opt-out
+	// flags act as GLOBAL DEFAULTS across all environments — that's where
+	// `config set --disable-auto-update/--disable-event-log/--local-only` writes
+	// them (see cmd/config.go), so OR them into the active env's config. A per-env
+	// true still wins. We return a copy so the loaded Environments map isn't
+	// mutated (and the global isn't accidentally persisted into one env).
 	if fc.CurrentEnv != "" && fc.Environments != nil {
-		if cfg, ok := fc.Environments[fc.CurrentEnv]; ok {
-			return cfg
+		if cfg, ok := fc.Environments[fc.CurrentEnv]; ok && cfg != nil {
+			merged := *cfg
+			merged.DisableAutoUpdate = merged.DisableAutoUpdate || fc.DisableAutoUpdate
+			merged.DisableEventLog = merged.DisableEventLog || fc.DisableEventLog
+			merged.LocalOnly = merged.LocalOnly || fc.LocalOnly
+			return &merged
 		}
 	}
 

--- a/internal/client/config_test.go
+++ b/internal/client/config_test.go
@@ -176,3 +176,61 @@ func TestLoadConfig_AutoUpdateOptOut(t *testing.T) {
 		})
 	}
 }
+
+// Regression: in a multi-environment config, top-level opt-out flags (where
+// `config set --disable-auto-update/--disable-event-log/--local-only` writes
+// them) were ignored because GetCurrentConfig returned the active env's config
+// without merging the globals — so the toggle was a silent no-op.
+func TestGetCurrentConfig_RootOptOutsApplyToActiveEnv(t *testing.T) {
+	mk := func() *FileConfig {
+		return &FileConfig{
+			CurrentEnv: "prod",
+			Environments: map[string]*Config{
+				"prod": {APIKey: "sk_prod", APIURL: "https://api.example.com"},
+				"dev":  {APIKey: "sk_dev"},
+			},
+		}
+	}
+
+	t.Run("root globals apply to the active env", func(t *testing.T) {
+		fc := mk()
+		fc.DisableAutoUpdate = true
+		fc.DisableEventLog = true
+		fc.LocalOnly = true
+		got := fc.GetCurrentConfig()
+		if got == nil {
+			t.Fatal("GetCurrentConfig returned nil")
+		}
+		if !got.DisableAutoUpdate || !got.DisableEventLog || !got.LocalOnly {
+			t.Errorf("root globals not applied: auto=%v eventlog=%v local=%v",
+				got.DisableAutoUpdate, got.DisableEventLog, got.LocalOnly)
+		}
+		if got.APIKey != "sk_prod" {
+			t.Errorf("active env not preserved: APIKey = %q, want sk_prod", got.APIKey)
+		}
+	})
+
+	t.Run("per-env true wins even when root is false", func(t *testing.T) {
+		fc := mk()
+		fc.Environments["prod"].DisableAutoUpdate = true
+		if got := fc.GetCurrentConfig(); !got.DisableAutoUpdate {
+			t.Error("per-env DisableAutoUpdate should be honored")
+		}
+	})
+
+	t.Run("all false when neither root nor env set them", func(t *testing.T) {
+		got := mk().GetCurrentConfig()
+		if got.DisableAutoUpdate || got.DisableEventLog || got.LocalOnly {
+			t.Error("expected all opt-outs false")
+		}
+	})
+
+	t.Run("does not mutate the stored env config", func(t *testing.T) {
+		fc := mk()
+		fc.DisableAutoUpdate = true
+		_ = fc.GetCurrentConfig()
+		if fc.Environments["prod"].DisableAutoUpdate {
+			t.Error("root global leaked into the stored env Config (should return a copy)")
+		}
+	})
+}


### PR DESCRIPTION
## Problem
On a multi-environment config (`current_env` + `environments{}`), `promptconduit config set --disable-auto-update=true` (and `--disable-event-log`, `--local-only`) is a **silent no-op**. `config set` prints "Auto-update: disabled" but `config show` keeps reading "enabled", and the background self-updater keeps running.

## Root cause
`config set` writes the flags to the **top-level** `FileConfig` fields and saves (`cmd/config.go:145/149/153`). But `FileConfig.GetCurrentConfig()` returns `Environments[CurrentEnv]` and **early-returns before reading the top-level flags** — those are only honored in the legacy flat-config fallback (`internal/client/config.go`). So for multi-env users the toggle never reaches the effective `Config`.

## Fix
Treat the top-level opt-out flags as **global defaults**: OR `DisableAutoUpdate` / `DisableEventLog` / `LocalOnly` into the active env's config (a per-env `true` still wins). Return a **copy** so the loaded `Environments` map isn't mutated. This makes the existing `config set` (which writes the root) work in both single- and multi-env layouts, and stops `config show` from contradicting `config set`.

## Test
Adds `TestGetCurrentConfig_RootOptOutsApplyToActiveEnv`: root globals apply to the active env; per-env `true` wins; all-false stays false; and a copy-semantics check (no mutation of the stored env). Verified as a real regression guard — it **fails without the fix** ("root globals not applied: auto=false …") and passes with it. `go build ./...` and `go test ./...` are green.

## Notes
- Discovered while disabling auto-update on a multi-env install. Backward-compatible — no schema change, no behavior change for single-env/legacy configs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)