### PR TITLE
chore(ci): pin GoReleaser to ~> v2 and modernize workflow actions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,19 +13,19 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version: '1.21'
 
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v6
+        uses: goreleaser/goreleaser-action@v7
         with:
-          version: latest
+          version: '~> v2'
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,10 +11,10 @@ jobs:
     name: Test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version: '1.21'
           cache: true


### PR DESCRIPTION
## Summary

Clears the two warnings that surfaced on the v0.7.0 release run:

1. **GoReleaser `latest` → `~> v2`** — the release used `version: latest`, which would silently pull a future GoReleaser **v3** and could break releases without warning. Pinning to `~> v2` keeps us on the current major. (Real-value fix.)
2. **Node 20 deprecation** — `actions/checkout@v4`, `actions/setup-go@v5`, and `goreleaser/goreleaser-action@v6` target the deprecated Node 20 runtime (the runner was force-migrating them to Node 24). Bumped to current Node 24-native majors.

## Changes

| Action | Before | After |
|--------|--------|-------|
| actions/checkout | v4 | **v7** |
| actions/setup-go | v5 | **v6** |
| goreleaser/goreleaser-action | v6 | **v7** |
| GoReleaser `version:` | `latest` | `'~> v2'` |

Applied across `test.yml` (checkout + setup-go) and `release.yml` (all four). Inputs are unchanged (`fetch-depth`, `go-version`, `args`), so no behavior change to build or release.

## Testing

- YAML validated.
- **This PR's own CI (`test.yml`) exercises `checkout@v7` + `setup-go@v6` for real** — if either major broke our usage, this PR's checks fail before merge.
- `release.yml` (goreleaser-action@v7 + `~> v2`) only runs on a `v*` tag, so it's validated on the next release. v0.7.0 just shipped fine on the old versions, so rollback is a one-line revert if ever needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)