### PR TITLE
fix(ci): version-gate the bundled-extension refresh

### DIFF
--- a/.github/workflows/refresh-extension.yml
+++ b/.github/workflows/refresh-extension.yml
@@ -50,36 +50,60 @@ jobs:
         with:
           go-version: "1.21"
 
+      # Change-detection is by extension VERSION, not by diffing the rebuilt
+      # .vsix bytes: `vsce package` is non-deterministic (zip embeds mtimes), so
+      # a byte diff would fire on every run. So: bump the extension's version
+      # whenever you change it — that's the signal this workflow keys on.
+      - name: Compare bundled vs. upstream extension version
+        id: check
+        run: |
+          set -euo pipefail
+          new_ver=$(python3 -c "import json;print(json.load(open('editor-extension/package.json'))['version'])")
+          cur_ver=$(unzip -p internal/extension/embedded/promptconduit-cost.vsix extension/package.json \
+                    | python3 -c "import sys,json;print(json.load(sys.stdin)['version'])")
+          echo "upstream=$new_ver bundled=$cur_ver"
+          echo "new_ver=$new_ver" >> "$GITHUB_OUTPUT"
+          if [ "$new_ver" = "$cur_ver" ]; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            echo "Bundled extension is already v$cur_ver — nothing to do."
+          else
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Refresh bundled .vsix
+        if: steps.check.outputs.changed == 'true'
         run: make refresh-extension EXTENSION_DIR=editor-extension
 
       - name: Verify CLI still builds with the new .vsix
+        if: steps.check.outputs.changed == 'true'
         run: |
           make build
           go test ./internal/extension/...
 
-      - name: Open PR if the bundled extension changed
+      - name: Open refresh PR
+        if: steps.check.outputs.changed == 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NEW_VER: ${{ steps.check.outputs.new_ver }}
         run: |
           set -euo pipefail
           vsix="internal/extension/embedded/promptconduit-cost.vsix"
+          # Defensive: only commit if the artifact actually changed on disk.
           if git diff --quiet -- "$vsix"; then
-            echo "Bundled extension is already up to date — nothing to do."
+            echo "::warning::Version changed to v${NEW_VER} but the .vsix did not — skipping."
             exit 0
           fi
-          ver=$(unzip -p "$vsix" extension/package.json | python3 -c "import sys,json;print(json.load(sys.stdin)['version'])")
-          branch="chore/refresh-bundled-extension-v${ver}-${GITHUB_RUN_ID}"
+          branch="chore/refresh-bundled-extension-v${NEW_VER}-${GITHUB_RUN_ID}"
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git checkout -b "$branch"
           git add "$vsix"
-          git commit -m "chore(extension): refresh bundled cost extension to v${ver}"
+          git commit -m "chore(extension): refresh bundled cost extension to v${NEW_VER}"
           git push origin "$branch"
           if gh pr create --base main --head "$branch" \
-              --title "chore(extension): refresh bundled cost extension to v${ver}" \
-              --body "Automated refresh of the embedded cost extension \`.vsix\` from \`promptconduit/editor-extension\` main (v${ver}), opened by the **Refresh bundled extension** workflow. CLI build + extension tests passed on this artifact."; then
-            echo "Opened PR for v${ver}."
+              --title "chore(extension): refresh bundled cost extension to v${NEW_VER}" \
+              --body "Automated refresh of the embedded cost extension \`.vsix\` from \`promptconduit/editor-extension\` main (v${NEW_VER}), opened by the **Refresh bundled extension** workflow. CLI build + extension tests passed on this artifact."; then
+            echo "Opened PR for v${NEW_VER}."
           else
             echo "::warning::Could not open the PR automatically (enable 'Allow GitHub Actions to create and approve pull requests', or open one from branch ${branch})."
           fi

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -103,9 +103,11 @@ repo `.gitignore` excludes) and is a committed build artifact that `go:embed` re
 
 Instead of refreshing locally, the **Refresh bundled extension** workflow
 (`.github/workflows/refresh-extension.yml`) rebuilds the `.vsix` from `editor-extension` main and
-opens a PR when it changed — run it from the Actions tab (`workflow_dispatch`), weekly via schedule,
-or via a `repository_dispatch` from the extension repo. (Opening the PR needs the repo's "Allow
-GitHub Actions to create and approve pull requests" setting.)
+opens a PR when the extension **version** changed — run it from the Actions tab
+(`workflow_dispatch`), weekly via schedule, or via a `repository_dispatch` from the extension repo.
+Detection is version-based (not a byte diff) because `vsce package` output isn't deterministic, so
+**bump the extension's `package.json` version whenever you change it**. (Opening the PR needs the
+repo's "Allow GitHub Actions to create and approve pull requests" setting.)
 
 ## Key Design Decisions
 


### PR DESCRIPTION
## Summary

Fixes a determinism bug in the **Refresh bundled extension** workflow (#84, just merged). `vsce package` output is **not byte-deterministic** — the `.vsix` is a zip that embeds file mtimes — so the original raw-byte change-detection would treat *every* run as "changed" and open a spurious refresh PR on every weekly tick.

Switches change-detection to the extension **version**: rebuild + commit + PR only when `editor-extension` main's `package.json` version differs from the version inside the bundled `.vsix`. Deterministic, and aligned with the "bump the version when you change the extension" discipline (documented in CLAUDE.md).

## Changes

- `.github/workflows/refresh-extension.yml` — add a version-compare step; gate the refresh/build/PR steps on `changed == 'true'`; keep a defensive on-disk diff check before committing.
- `CLAUDE.md` — note that detection is version-based and to bump the extension version on changes.

Caught before the first scheduled (Monday) run, so no spurious PRs were created.

🤖 Generated with [Claude Code](https://claude.com/claude-code)