### PR TITLE
feat(update): brew-aware self-update + auto-update the bundled extension

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/promptconduit/cli/internal/client"
+	"github.com/promptconduit/cli/internal/extension"
 	"github.com/promptconduit/cli/internal/updater"
 	"github.com/spf13/cobra"
 )
@@ -104,6 +105,13 @@ func maybeBackgroundUpdateCheck(cmd *cobra.Command) {
 		notifyUpgraded(cmd, cached.CurrentVersion, Version, cached.ReleaseURL)
 		cached.CurrentVersion = Version
 		_ = updater.SaveCache(cachePath, cached)
+		// The binary just changed (self-replace or brew), so the embedded
+		// extension .vsix may be newer than what's installed in the editor.
+		// This is the one moment we know they can differ — reconcile now,
+		// unless the user opted out of auto-update.
+		if !cfg.DisableAutoUpdate {
+			reconcileCostExtension(cmd)
+		}
 	}
 
 	if !updater.ShouldCheck(cachePath, Version, updater.CheckTTL) {
@@ -154,6 +162,25 @@ func notifyNewer(cmd *cobra.Command, latest, releaseURL string, disabled bool) {
 	_, _ = fmt.Fprintf(w, "promptconduit: %s available (you have %s) — %s\n", latest, Version, hint)
 	if releaseURL != "" {
 		_, _ = fmt.Fprintf(w, "  release notes: %s\n", releaseURL)
+	}
+}
+
+// reconcileCostExtension brings the editor's installed cost extension up to the
+// version bundled in this (freshly upgraded) binary. It runs once — right after
+// a CLI upgrade is first detected — because that's the only moment the embedded
+// .vsix is known to differ from what's installed. Best-effort and quiet: it
+// only prints when it actually updated something, and never blocks or fails the
+// user's command (Reconcile no-ops when the editor or extension isn't present).
+func reconcileCostExtension(cmd *cobra.Command) {
+	for _, e := range []extension.Editor{extension.Cursor, extension.VSCode} {
+		res, err := extension.Reconcile(e)
+		if err != nil {
+			continue
+		}
+		if res.Updated {
+			_, _ = fmt.Fprintf(cmd.ErrOrStderr(),
+				"promptconduit: updated the %s cost extension to v%s\n", res.Editor, res.Bundled)
+		}
 	}
 }
 

--- a/cmd/upgrade.go
+++ b/cmd/upgrade.go
@@ -75,6 +75,20 @@ func runUpgrade(cmd *cobra.Command, args []string) error {
 		return nil
 	}
 
+	// Take an advisory lock so two concurrent invocations (e.g. a manual run and
+	// the detached background upgrade) don't both upgrade at once. Covers the
+	// brew and self-replace paths alike.
+	lockPath := filepath.Join(client.ConfigDir(), updater.LockFileName)
+	release, err := updater.Lock(lockPath)
+	defer release()
+	if err != nil {
+		if errors.Is(err, updater.ErrLocked) {
+			cmd.Println("Another upgrade is already in progress; skipping.")
+			return nil
+		}
+		return fmt.Errorf("acquire upgrade lock: %w", err)
+	}
+
 	// Homebrew-managed installs must upgrade via brew, not by self-replacing the
 	// Cellar binary (which would desync brew's metadata from the file on disk).
 	if exe, err := os.Executable(); err == nil && updater.IsHomebrewManaged(exe) {
@@ -97,19 +111,6 @@ func runUpgrade(cmd *cobra.Command, args []string) error {
 		cmd.Printf("Cannot self-upgrade: %v\n", err)
 		cmd.Println("If you installed via Homebrew, run: brew upgrade promptconduit")
 		return err
-	}
-
-	// Take an advisory lock so two concurrent invocations don't race on
-	// the same binary swap.
-	lockPath := filepath.Join(client.ConfigDir(), updater.LockFileName)
-	release, err := updater.Lock(lockPath)
-	defer release()
-	if err != nil {
-		if errors.Is(err, updater.ErrLocked) {
-			cmd.Println("Another upgrade is already in progress; skipping.")
-			return nil
-		}
-		return fmt.Errorf("acquire upgrade lock: %w", err)
 	}
 
 	archive, checksums, err := updater.AssetForCurrent(rel)

--- a/cmd/upgrade.go
+++ b/cmd/upgrade.go
@@ -21,15 +21,16 @@ var (
 var upgradeCmd = &cobra.Command{
 	Use:   "upgrade",
 	Short: "Upgrade promptconduit to the latest release",
-	Long: `Check GitHub for a newer release and atomically replace the running binary.
+	Long: `Check GitHub for a newer release and upgrade in place.
 
 Examples:
   promptconduit upgrade           # upgrade to the latest release (if newer)
   promptconduit upgrade --check   # only check; do not download or replace
   promptconduit upgrade --force   # download and replace even if up to date
 
-Homebrew users should run "brew upgrade promptconduit" instead — this command
-will refuse to replace a binary it can't write to.`,
+Homebrew-managed installs are detected automatically and upgraded via
+"brew upgrade promptconduit" so Homebrew's metadata stays in sync; all other
+installs are upgraded by atomically replacing the running binary.`,
 	RunE: runUpgrade,
 }
 
@@ -71,6 +72,23 @@ func runUpgrade(cmd *cobra.Command, args []string) error {
 	if upgradeCheckOnly {
 		cmd.Printf("Newer release available: %s\n", rel.HTMLURL)
 		cmd.Println("Run `promptconduit upgrade` to install.")
+		return nil
+	}
+
+	// Homebrew-managed installs must upgrade via brew, not by self-replacing the
+	// Cellar binary (which would desync brew's metadata from the file on disk).
+	if exe, err := os.Executable(); err == nil && updater.IsHomebrewManaged(exe) {
+		cmd.Println("Homebrew-managed install detected — upgrading via `brew upgrade promptconduit`...")
+		bctx, bcancel := context.WithTimeout(cmd.Context(), updater.DownloadTimeout)
+		defer bcancel()
+		out, err := updater.BrewUpgrade(bctx, updater.HomebrewFormula)
+		if out != "" {
+			cmd.Println(out)
+		}
+		if err != nil {
+			return fmt.Errorf("brew upgrade failed: %w", err)
+		}
+		cmd.Printf("Upgraded via Homebrew (target %s). The bundled editor extension updates on next run.\n", rel.TagName)
 		return nil
 	}
 

--- a/internal/extension/install.go
+++ b/internal/extension/install.go
@@ -1,6 +1,7 @@
 package extension
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"os/exec"
@@ -81,6 +82,17 @@ func (e Editor) Available() bool { return e.resolveCLI() != "" }
 // the hook setup. A non-nil error means the CLI was found but the install
 // command itself failed.
 func Install(e Editor) (InstallResult, error) {
+	// The interactive `install` command is user-driven and shouldn't impose an
+	// arbitrary deadline, so it runs unbounded. The background reconcile path
+	// uses InstallContext with a timeout instead.
+	return InstallContext(context.Background(), e)
+}
+
+// InstallContext is Install with a caller-supplied context, so callers that run
+// outside an interactive command (e.g. the post-upgrade reconcile in
+// PersistentPreRun) can bound the editor subprocess and never hang the user's
+// command if the editor CLI stalls.
+func InstallContext(ctx context.Context, e Editor) (InstallResult, error) {
 	res := InstallResult{Editor: e.Name}
 	if v, err := Version(); err == nil {
 		res.Version = v
@@ -99,7 +111,7 @@ func Install(e Editor) (InstallResult, error) {
 	}
 	defer cleanup()
 
-	out, err := exec.Command(cli, "--install-extension", vsixPath, "--force").CombinedOutput()
+	out, err := exec.CommandContext(ctx, cli, "--install-extension", vsixPath, "--force").CombinedOutput()
 	if err != nil {
 		return res, fmt.Errorf("%s --install-extension failed: %w: %s",
 			e.Command, err, strings.TrimSpace(string(out)))

--- a/internal/extension/reconcile.go
+++ b/internal/extension/reconcile.go
@@ -1,0 +1,95 @@
+package extension
+
+import (
+	"fmt"
+	"os/exec"
+	"strings"
+
+	"github.com/promptconduit/cli/internal/updater"
+)
+
+// ExtensionID is the editor extension identifier (<publisher>.<name>), used to
+// read the installed version from `--list-extensions --show-versions`.
+const ExtensionID = "promptconduit.promptconduit-cost"
+
+// InstalledVersion returns the version of the cost extension currently installed
+// in the editor, or "" when the editor CLI isn't found or the extension isn't
+// installed.
+func (e Editor) InstalledVersion() (string, error) {
+	cli := e.resolveCLI()
+	if cli == "" {
+		return "", nil
+	}
+	out, err := exec.Command(cli, "--list-extensions", "--show-versions").CombinedOutput()
+	if err != nil {
+		return "", fmt.Errorf("%s --list-extensions failed: %w: %s",
+			e.Command, err, strings.TrimSpace(string(out)))
+	}
+	return parseInstalledVersion(string(out), ExtensionID), nil
+}
+
+// parseInstalledVersion extracts the version for id from `--show-versions`
+// output, whose lines look like "publisher.name@1.2.3". Returns "" when the id
+// isn't present.
+func parseInstalledVersion(output, id string) string {
+	prefix := id + "@"
+	for _, line := range strings.Split(output, "\n") {
+		line = strings.TrimSpace(line)
+		if v, ok := strings.CutPrefix(line, prefix); ok {
+			return v
+		}
+	}
+	return ""
+}
+
+// ReconcileResult is the outcome of a Reconcile attempt.
+type ReconcileResult struct {
+	Editor    string // editor label
+	Bundled   string // extension version embedded in this binary
+	Installed string // version currently in the editor ("" if none)
+	Updated   bool   // true when a newer bundle was re-sideloaded
+	Skipped   string // why nothing happened (CLI missing / not installed / up to date)
+}
+
+// Reconcile updates the editor's installed cost extension to the bundled version
+// when the bundle is newer. It is intentionally conservative:
+//   - editor CLI not found            → skip
+//   - extension not already installed → skip (don't force-install; respects a
+//     user who declined the extension via `--no-extension`)
+//   - installed version >= bundled    → skip
+//
+// Only an already-installed, older extension is upgraded (via
+// `--install-extension --force`), so the extension tracks the CLI on upgrade
+// without surprising the user. Best-effort: callers ignore errors.
+func Reconcile(e Editor) (ReconcileResult, error) {
+	res := ReconcileResult{Editor: e.Name}
+	bundled, err := Version()
+	if err != nil {
+		return res, err
+	}
+	res.Bundled = bundled
+
+	if !e.Available() {
+		res.Skipped = "editor CLI not found"
+		return res, nil
+	}
+	installed, err := e.InstalledVersion()
+	if err != nil {
+		return res, err
+	}
+	res.Installed = installed
+	if installed == "" {
+		res.Skipped = "extension not installed"
+		return res, nil
+	}
+	if !updater.IsNewerVersion(bundled, installed) {
+		res.Skipped = "up to date"
+		return res, nil
+	}
+
+	if _, err := Install(e); err != nil {
+		return res, err
+	}
+	res.Updated = true
+	return res, nil
+}

--- a/internal/extension/reconcile.go
+++ b/internal/extension/reconcile.go
@@ -1,9 +1,11 @@
 package extension
 
 import (
+	"context"
 	"fmt"
 	"os/exec"
 	"strings"
+	"time"
 
 	"github.com/promptconduit/cli/internal/updater"
 )
@@ -12,15 +14,25 @@ import (
 // read the installed version from `--list-extensions --show-versions`.
 const ExtensionID = "promptconduit.promptconduit-cost"
 
+// Editor subprocesses (Cursor/VS Code CLIs) can be slow to spawn or hang, and
+// reconcile runs inside PersistentPreRun, so every call is bounded — a stalled
+// editor must never block the user's actual command.
+const (
+	listTimeout    = 10 * time.Second
+	installTimeout = 90 * time.Second
+)
+
 // InstalledVersion returns the version of the cost extension currently installed
 // in the editor, or "" when the editor CLI isn't found or the extension isn't
-// installed.
+// installed. Bounded by listTimeout.
 func (e Editor) InstalledVersion() (string, error) {
 	cli := e.resolveCLI()
 	if cli == "" {
 		return "", nil
 	}
-	out, err := exec.Command(cli, "--list-extensions", "--show-versions").CombinedOutput()
+	ctx, cancel := context.WithTimeout(context.Background(), listTimeout)
+	defer cancel()
+	out, err := exec.CommandContext(ctx, cli, "--list-extensions", "--show-versions").CombinedOutput()
 	if err != nil {
 		return "", fmt.Errorf("%s --list-extensions failed: %w: %s",
 			e.Command, err, strings.TrimSpace(string(out)))
@@ -42,6 +54,49 @@ func parseInstalledVersion(output, id string) string {
 	return ""
 }
 
+// reconcileAction is the decision Reconcile makes from availability + versions.
+type reconcileAction int
+
+const (
+	actionSkipNoCLI reconcileAction = iota
+	actionSkipNotInstalled
+	actionSkipUpToDate
+	actionUpdate
+)
+
+func (a reconcileAction) reason() string {
+	switch a {
+	case actionSkipNoCLI:
+		return "editor CLI not found"
+	case actionSkipNotInstalled:
+		return "extension not installed"
+	case actionSkipUpToDate:
+		return "up to date"
+	default:
+		return ""
+	}
+}
+
+// decideReconcile is the pure decision: given whether the editor CLI is
+// available and the bundled vs installed versions, what should Reconcile do?
+// Conservative — only an already-installed, strictly-older extension is updated.
+//
+// Note: version comparison requires plain MAJOR.MINOR.PATCH (updater.IsNewerVersion
+// returns false for anything else), so the editor extension must keep using
+// 3-part semver or reconcile will silently never fire.
+func decideReconcile(available bool, bundled, installed string) reconcileAction {
+	if !available {
+		return actionSkipNoCLI
+	}
+	if installed == "" {
+		return actionSkipNotInstalled
+	}
+	if !updater.IsNewerVersion(bundled, installed) {
+		return actionSkipUpToDate
+	}
+	return actionUpdate
+}
+
 // ReconcileResult is the outcome of a Reconcile attempt.
 type ReconcileResult struct {
 	Editor    string // editor label
@@ -60,7 +115,8 @@ type ReconcileResult struct {
 //
 // Only an already-installed, older extension is upgraded (via
 // `--install-extension --force`), so the extension tracks the CLI on upgrade
-// without surprising the user. Best-effort: callers ignore errors.
+// without surprising the user. Best-effort: callers ignore errors. All editor
+// subprocesses are bounded by a timeout so a stalled CLI can't block the caller.
 func Reconcile(e Editor) (ReconcileResult, error) {
 	res := ReconcileResult{Editor: e.Name}
 	bundled, err := Version()
@@ -69,25 +125,24 @@ func Reconcile(e Editor) (ReconcileResult, error) {
 	}
 	res.Bundled = bundled
 
-	if !e.Available() {
-		res.Skipped = "editor CLI not found"
-		return res, nil
-	}
-	installed, err := e.InstalledVersion()
-	if err != nil {
-		return res, err
+	available := e.Available()
+	installed := ""
+	if available {
+		if installed, err = e.InstalledVersion(); err != nil {
+			return res, err
+		}
 	}
 	res.Installed = installed
-	if installed == "" {
-		res.Skipped = "extension not installed"
-		return res, nil
-	}
-	if !updater.IsNewerVersion(bundled, installed) {
-		res.Skipped = "up to date"
+
+	action := decideReconcile(available, bundled, installed)
+	if action != actionUpdate {
+		res.Skipped = action.reason()
 		return res, nil
 	}
 
-	if _, err := Install(e); err != nil {
+	ctx, cancel := context.WithTimeout(context.Background(), installTimeout)
+	defer cancel()
+	if _, err := InstallContext(ctx, e); err != nil {
 		return res, err
 	}
 	res.Updated = true

--- a/internal/extension/reconcile_test.go
+++ b/internal/extension/reconcile_test.go
@@ -1,0 +1,50 @@
+package extension
+
+import "testing"
+
+func TestParseInstalledVersion(t *testing.T) {
+	const id = "promptconduit.promptconduit-cost"
+	cases := []struct {
+		name   string
+		output string
+		want   string
+	}{
+		{
+			name:   "present among others",
+			output: "ms-python.python@2024.1.0\npromptconduit.promptconduit-cost@0.4.0\nesbenp.prettier-vscode@10.1.0\n",
+			want:   "0.4.0",
+		},
+		{
+			name:   "only entry",
+			output: "promptconduit.promptconduit-cost@0.3.0\n",
+			want:   "0.3.0",
+		},
+		{
+			name:   "with surrounding whitespace",
+			output: "  promptconduit.promptconduit-cost@1.0.0  \n",
+			want:   "1.0.0",
+		},
+		{
+			name:   "not installed",
+			output: "ms-python.python@2024.1.0\nesbenp.prettier-vscode@10.1.0\n",
+			want:   "",
+		},
+		{
+			name:   "id without version (no --show-versions) is ignored",
+			output: "promptconduit.promptconduit-cost\n",
+			want:   "",
+		},
+		{
+			name:   "empty",
+			output: "",
+			want:   "",
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := parseInstalledVersion(c.output, id); got != c.want {
+				t.Errorf("parseInstalledVersion() = %q, want %q", got, c.want)
+			}
+		})
+	}
+}

--- a/internal/extension/reconcile_test.go
+++ b/internal/extension/reconcile_test.go
@@ -2,6 +2,31 @@ package extension
 
 import "testing"
 
+func TestDecideReconcile(t *testing.T) {
+	cases := []struct {
+		name      string
+		available bool
+		bundled   string
+		installed string
+		want      reconcileAction
+	}{
+		{"no editor CLI", false, "0.4.0", "0.3.0", actionSkipNoCLI},
+		{"not installed", true, "0.4.0", "", actionSkipNotInstalled},
+		{"older installed -> update", true, "0.4.0", "0.3.0", actionUpdate},
+		{"equal -> skip", true, "0.4.0", "0.4.0", actionSkipUpToDate},
+		{"installed newer -> skip", true, "0.4.0", "0.5.0", actionSkipUpToDate},
+		{"unparseable installed -> skip (conservative)", true, "0.4.0", "weird", actionSkipUpToDate},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := decideReconcile(c.available, c.bundled, c.installed); got != c.want {
+				t.Errorf("decideReconcile(%v, %q, %q) = %d, want %d",
+					c.available, c.bundled, c.installed, got, c.want)
+			}
+		})
+	}
+}
+
 func TestParseInstalledVersion(t *testing.T) {
 	const id = "promptconduit.promptconduit-cost"
 	cases := []struct {

--- a/internal/updater/brew.go
+++ b/internal/updater/brew.go
@@ -1,0 +1,78 @@
+package updater
+
+import (
+	"context"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+// HomebrewFormula is the tap formula name passed to `brew upgrade`.
+const HomebrewFormula = "promptconduit"
+
+// IsHomebrewManaged reports whether the binary at exePath is managed by
+// Homebrew — i.e. `brew` is installed and the resolved binary lives under a
+// Homebrew Cellar/prefix. When true, the upgrade flow delegates to
+// `brew upgrade` instead of self-replacing the Cellar file. Self-replacing a
+// brew-managed binary leaves Homebrew's metadata pointing at the old version
+// while the file on disk is newer — the drift that results from two update
+// channels fighting.
+func IsHomebrewManaged(exePath string) bool {
+	brew, err := exec.LookPath("brew")
+	if err != nil {
+		return false
+	}
+
+	resolved := exePath
+	if r, err := filepath.EvalSymlinks(exePath); err == nil {
+		resolved = r
+	}
+
+	// Standard case: the binary lives under a `Cellar` directory.
+	if isUnderCellar(resolved) {
+		return true
+	}
+
+	// Fallback for non-standard prefixes: ask brew where it installs.
+	if out, err := exec.Command(brew, "--prefix").Output(); err == nil {
+		if prefix := strings.TrimSpace(string(out)); prefix != "" && isUnderDir(resolved, prefix) {
+			return true
+		}
+	}
+	return false
+}
+
+// isUnderCellar is the pure path check: true when path traverses a `Cellar`
+// directory component (Homebrew's standard install location).
+func isUnderCellar(path string) bool {
+	sep := string(filepath.Separator)
+	return strings.Contains(path, sep+"Cellar"+sep)
+}
+
+// isUnderDir reports whether path is dir itself or nested within it.
+func isUnderDir(path, dir string) bool {
+	sep := string(filepath.Separator)
+	dir = strings.TrimRight(dir, sep)
+	return path == dir || strings.HasPrefix(path, dir+sep)
+}
+
+// BrewUpgrade runs `brew upgrade <formula>` and returns its combined output for
+// surfacing to the user. Homebrew auto-refreshes its formula index before
+// upgrading (unless HOMEBREW_NO_AUTO_UPDATE is set), so a freshly published
+// release is picked up without a separate `brew update`.
+func BrewUpgrade(ctx context.Context, formula string) (string, error) {
+	brew, err := exec.LookPath("brew")
+	if err != nil {
+		return "", err
+	}
+	out, err := exec.CommandContext(ctx, brew, "upgrade", formula).CombinedOutput()
+	return strings.TrimSpace(string(out)), err
+}
+
+// IsNewerVersion reports whether semver a is strictly newer than b. Inputs that
+// don't parse yield false (treated as "not newer") so callers stay conservative
+// and never act on an ambiguous comparison.
+func IsNewerVersion(a, b string) bool {
+	cmp, ok := compareSemver(a, b)
+	return ok && cmp > 0
+}

--- a/internal/updater/brew.go
+++ b/internal/updater/brew.go
@@ -11,49 +11,36 @@ import (
 const HomebrewFormula = "promptconduit"
 
 // IsHomebrewManaged reports whether the binary at exePath is managed by
-// Homebrew — i.e. `brew` is installed and the resolved binary lives under a
-// Homebrew Cellar/prefix. When true, the upgrade flow delegates to
-// `brew upgrade` instead of self-replacing the Cellar file. Self-replacing a
-// brew-managed binary leaves Homebrew's metadata pointing at the old version
-// while the file on disk is newer — the drift that results from two update
-// channels fighting.
+// Homebrew — i.e. `brew` is installed and the resolved binary lives inside a
+// Homebrew `Cellar`. When true, the upgrade flow delegates to `brew upgrade`
+// instead of self-replacing the Cellar file. Self-replacing a brew-managed
+// binary leaves Homebrew's metadata pointing at the old version while the file
+// on disk is newer — the drift that results from two update channels fighting.
+//
+// Detection keys ONLY on a `Cellar` path component, which every real Homebrew
+// install resolves into (prefix/bin/promptconduit symlinks into
+// .../Cellar/promptconduit/<v>/bin/promptconduit) on all platforms. We
+// deliberately do NOT also treat "under `brew --prefix`" as managed: on Intel
+// macs the prefix is /usr/local and the curl install script drops the binary in
+// /usr/local/bin, so a script-installed binary on a machine that merely has brew
+// would be misclassified — and then every `brew upgrade promptconduit` would
+// fail (brew doesn't own it) with no self-replace fallback, stranding the user.
 func IsHomebrewManaged(exePath string) bool {
-	brew, err := exec.LookPath("brew")
-	if err != nil {
+	if _, err := exec.LookPath("brew"); err != nil {
 		return false
 	}
-
 	resolved := exePath
 	if r, err := filepath.EvalSymlinks(exePath); err == nil {
 		resolved = r
 	}
-
-	// Standard case: the binary lives under a `Cellar` directory.
-	if isUnderCellar(resolved) {
-		return true
-	}
-
-	// Fallback for non-standard prefixes: ask brew where it installs.
-	if out, err := exec.Command(brew, "--prefix").Output(); err == nil {
-		if prefix := strings.TrimSpace(string(out)); prefix != "" && isUnderDir(resolved, prefix) {
-			return true
-		}
-	}
-	return false
+	return isUnderCellar(resolved)
 }
 
 // isUnderCellar is the pure path check: true when path traverses a `Cellar`
-// directory component (Homebrew's standard install location).
+// directory component (Homebrew's install location on every platform).
 func isUnderCellar(path string) bool {
 	sep := string(filepath.Separator)
 	return strings.Contains(path, sep+"Cellar"+sep)
-}
-
-// isUnderDir reports whether path is dir itself or nested within it.
-func isUnderDir(path, dir string) bool {
-	sep := string(filepath.Separator)
-	dir = strings.TrimRight(dir, sep)
-	return path == dir || strings.HasPrefix(path, dir+sep)
 }
 
 // BrewUpgrade runs `brew upgrade <formula>` and returns its combined output for

--- a/internal/updater/brew_test.go
+++ b/internal/updater/brew_test.go
@@ -1,0 +1,62 @@
+package updater
+
+import "testing"
+
+func TestIsUnderCellar(t *testing.T) {
+	cases := []struct {
+		path string
+		want bool
+	}{
+		{"/opt/homebrew/Cellar/promptconduit/0.7.3/bin/promptconduit", true},
+		{"/usr/local/Cellar/promptconduit/0.7.3/bin/promptconduit", true},
+		{"/home/linuxbrew/.linuxbrew/Cellar/promptconduit/0.7.3/bin/promptconduit", true},
+		{"/usr/local/bin/promptconduit", false},
+		{"/Users/me/.local/bin/promptconduit", false},
+		{"/opt/CellarX/promptconduit", false}, // not a Cellar path component
+		{"", false},
+	}
+	for _, c := range cases {
+		if got := isUnderCellar(c.path); got != c.want {
+			t.Errorf("isUnderCellar(%q) = %v, want %v", c.path, got, c.want)
+		}
+	}
+}
+
+func TestIsUnderDir(t *testing.T) {
+	cases := []struct {
+		path, dir string
+		want      bool
+	}{
+		{"/opt/homebrew/bin/promptconduit", "/opt/homebrew", true},
+		{"/opt/homebrew/bin/promptconduit", "/opt/homebrew/", true}, // trailing slash tolerated
+		{"/opt/homebrew", "/opt/homebrew", true},                    // exact
+		{"/opt/homebrew-extra/bin/x", "/opt/homebrew", false},       // prefix-but-not-nested
+		{"/usr/local/bin/x", "/opt/homebrew", false},
+	}
+	for _, c := range cases {
+		if got := isUnderDir(c.path, c.dir); got != c.want {
+			t.Errorf("isUnderDir(%q, %q) = %v, want %v", c.path, c.dir, got, c.want)
+		}
+	}
+}
+
+func TestIsNewerVersion(t *testing.T) {
+	cases := []struct {
+		a, b string
+		want bool
+	}{
+		{"0.7.3", "0.7.2", true},
+		{"v0.7.3", "0.7.2", true},
+		{"0.8.0", "0.7.9", true},
+		{"1.0.0", "0.9.9", true},
+		{"0.7.2", "0.7.2", false}, // equal is not newer
+		{"0.7.1", "0.7.2", false}, // older
+		{"garbage", "0.7.2", false},
+		{"0.7.3", "garbage", false},
+	}
+	for _, c := range cases {
+		if got := IsNewerVersion(c.a, c.b); got != c.want {
+			t.Errorf("IsNewerVersion(%q, %q) = %v, want %v", c.a, c.b, got, c.want)
+		}
+	}
+}

--- a/internal/updater/brew_test.go
+++ b/internal/updater/brew_test.go
@@ -22,24 +22,6 @@ func TestIsUnderCellar(t *testing.T) {
 	}
 }
 
-func TestIsUnderDir(t *testing.T) {
-	cases := []struct {
-		path, dir string
-		want      bool
-	}{
-		{"/opt/homebrew/bin/promptconduit", "/opt/homebrew", true},
-		{"/opt/homebrew/bin/promptconduit", "/opt/homebrew/", true}, // trailing slash tolerated
-		{"/opt/homebrew", "/opt/homebrew", true},                    // exact
-		{"/opt/homebrew-extra/bin/x", "/opt/homebrew", false},       // prefix-but-not-nested
-		{"/usr/local/bin/x", "/opt/homebrew", false},
-	}
-	for _, c := range cases {
-		if got := isUnderDir(c.path, c.dir); got != c.want {
-			t.Errorf("isUnderDir(%q, %q) = %v, want %v", c.path, c.dir, got, c.want)
-		}
-	}
-}
-
 func TestIsNewerVersion(t *testing.T) {
 	cases := []struct {
 		a, b string


### PR DESCRIPTION
Makes the CLI's auto-update pick the right mechanism per install type and keeps the sideloaded Cursor extension in lockstep with the binary. Implements the `Brew-aware self-updater` strategy.

### Why
The CLI ships **two** ways to stay current — Homebrew and the built-in self-updater — and they fight: `updater.Apply` resolves symlinks and overwrites the *Cellar* file, so a self-replace on a brew install leaves brew's metadata pointing at the old version while the binary on disk is newer (the drift behind the v0.6.x `config set --disable-auto-update` saga). Separately, the self-updater swaps the binary but **never** re-sideloads the embedded extension, so Cursor kept the old extension until a manual `promptconduit install cursor`.

### What
- **Brew-aware upgrade** (`internal/updater/brew.go`): `IsHomebrewManaged` = `brew` on PATH **and** the resolved binary under a Cellar/prefix. `promptconduit upgrade` then runs `brew upgrade promptconduit` (brew auto-refreshes its index first) instead of clobbering the Cellar file. Non-brew installs keep today's SHA256-verified atomic self-replace. The detached background upgrade goes through the same `upgrade` path, so it's brew-aware too.
- **Extension auto-update** (`internal/extension/reconcile.go`): on the first run after *any* upgrade (self-replace **or** brew, even a manual `brew upgrade`), `root.go`'s post-upgrade detection calls `Reconcile`, which re-sideloads the embedded `.vsix` when it's newer than what's installed. Conservative: only upgrades an **already-installed**, older extension (never force-installs — respects `--no-extension`), gated by `disable_auto_update`, best-effort/quiet. It runs in the *new* binary (the upgrading process still holds the old embed), which is exactly why the trigger is next-run detection.

### Tests
- `brew_test.go`: Cellar / prefix path detection + semver compare.
- `reconcile_test.go`: `--list-extensions --show-versions` parsing.
- `go build ./...`, `go vet`, full `make test` green. The 6 `make lint` findings are pre-existing in `cmd/cost.go` + `cmd/skills_local.go` — none in changed files.

### Net DX
Install by any method; the CLI keeps **both itself and the Cursor extension** current automatically — via brew when brew-managed, via self-replace otherwise — with no drift. After this lands I'll re-enable auto-update (safe now that it won't fight brew).