### PR TITLE
chore: rename editor ExtensionID to promptconduit.promptconduit

### DIFF
--- a/internal/extension/reconcile.go
+++ b/internal/extension/reconcile.go
@@ -12,7 +12,7 @@ import (
 
 // ExtensionID is the editor extension identifier (<publisher>.<name>), used to
 // read the installed version from `--list-extensions --show-versions`.
-const ExtensionID = "promptconduit.promptconduit-cost"
+const ExtensionID = "promptconduit.promptconduit"
 
 // Editor subprocesses (Cursor/VS Code CLIs) can be slow to spawn or hang, and
 // reconcile runs inside PersistentPreRun, so every call is bounded — a stalled

--- a/internal/extension/reconcile_test.go
+++ b/internal/extension/reconcile_test.go
@@ -28,7 +28,7 @@ func TestDecideReconcile(t *testing.T) {
 }
 
 func TestParseInstalledVersion(t *testing.T) {
-	const id = "promptconduit.promptconduit-cost"
+	const id = "promptconduit.promptconduit"
 	cases := []struct {
 		name   string
 		output string
@@ -36,17 +36,17 @@ func TestParseInstalledVersion(t *testing.T) {
 	}{
 		{
 			name:   "present among others",
-			output: "ms-python.python@2024.1.0\npromptconduit.promptconduit-cost@0.4.0\nesbenp.prettier-vscode@10.1.0\n",
+			output: "ms-python.python@2024.1.0\npromptconduit.promptconduit@0.4.0\nesbenp.prettier-vscode@10.1.0\n",
 			want:   "0.4.0",
 		},
 		{
 			name:   "only entry",
-			output: "promptconduit.promptconduit-cost@0.3.0\n",
+			output: "promptconduit.promptconduit@0.3.0\n",
 			want:   "0.3.0",
 		},
 		{
 			name:   "with surrounding whitespace",
-			output: "  promptconduit.promptconduit-cost@1.0.0  \n",
+			output: "  promptconduit.promptconduit@1.0.0  \n",
 			want:   "1.0.0",
 		},
 		{
@@ -56,7 +56,15 @@ func TestParseInstalledVersion(t *testing.T) {
 		},
 		{
 			name:   "id without version (no --show-versions) is ignored",
-			output: "promptconduit.promptconduit-cost\n",
+			output: "promptconduit.promptconduit\n",
+			want:   "",
+		},
+		{
+			// Guard the rebrand: the legacy id is a prefix of the new id, but the
+			// trailing "@" in the match prefix must keep them distinct so a lingering
+			// promptconduit-cost install is never mistaken for the new extension.
+			name:   "legacy -cost id is not matched",
+			output: "promptconduit.promptconduit-cost@0.5.0\n",
 			want:   "",
 		},
 		{


### PR DESCRIPTION
## Summary

Tracks the editor extension's umbrella rebrand (`promptconduit-cost` → `promptconduit`, see promptconduit/editor-extension#41) by updating the single hardcoded marketplace id the CLI uses to detect the installed extension. Without this, `reconcile` would never match the renamed listing and would silently treat the extension as "not installed" forever, so the bundled-vsix auto-update would never fire.

Closes #88

> **Cross-repo:** the companion is promptconduit/editor-extension (PR for #41). Land them together.

## Changes

### `internal/extension/reconcile.go`
- `ExtensionID`: `promptconduit.promptconduit-cost` → `promptconduit.promptconduit`.

### `internal/extension/reconcile_test.go`
- Updated `parseInstalledVersion` fixtures to the new id.
- **New regression test**: the legacy id is a *prefix* of the new id, so a `promptconduit.promptconduit-cost@x` line must NOT match `promptconduit.promptconduit` — the trailing `@` in the match prefix (`id + "@"`) keeps the collision safe. This matters because old installs coexist after the rename (the CLI never uninstalls the extension).

The embedded `.vsix` filename (`promptconduit-cost.vsix`) is an internal build artifact controlled by the Makefile `--out` and is **intentionally left unchanged** — renaming it would mean a committed-binary `git mv` across `embed.go`/Makefile/workflow for zero user benefit. `refresh-extension.yml` keys change-detection on the extension's `version` (now `0.6.0`), not its name, so it is unaffected.

## Testing
- `go test ./internal/extension/...` → ok (includes the new prefix-collision guard).

## Agent Review Context
- **change-type**: chore
- **risk-level**: low
- **key-files**: `internal/extension/reconcile.go`, `internal/extension/reconcile_test.go`
- **testing-confidence**: high

## Checklist
- [x] Tests pass
- [x] No breaking changes
- [x] Code follows project conventions

🤖 Generated with [Claude Code](https://claude.com/claude-code)
