### PR TITLE
feat: detect git worktree in captured git context

### DIFF
--- a/internal/envelope/envelope.go
+++ b/internal/envelope/envelope.go
@@ -115,6 +115,12 @@ type GitContext struct {
 	RemoteURL        string `json:"remote_url,omitempty"`
 	WorkingDirectory string `json:"working_directory,omitempty"`
 	IsDetachedHead   bool   `json:"is_detached_head,omitempty"`
+	// IsWorktree is true when the working directory is a linked git worktree
+	// (not the main checkout). This is the robust worktree signal for coaching:
+	// the WorktreeCreate hook only fires when the agent creates one, missing
+	// sessions started inside an existing worktree.
+	IsWorktree   bool   `json:"is_worktree,omitempty"`
+	WorktreePath string `json:"worktree_path,omitempty"`
 }
 
 // New creates a new RawEventEnvelope with the given enrichment block.

--- a/internal/git/context.go
+++ b/internal/git/context.go
@@ -65,6 +65,14 @@ func ExtractContext(workingDir string) *envelope.GitContext {
 		ctx.RemoteURL = remote
 	}
 
+	// Worktree detection: a linked worktree has a per-worktree git dir that
+	// differs from the shared common dir. This catches sessions started *inside*
+	// an existing worktree, which the WorktreeCreate hook never reports.
+	if isWorktree, path := detectWorktree(workingDir); isWorktree {
+		ctx.IsWorktree = true
+		ctx.WorktreePath = path
+	}
+
 	// Ahead/behind counts
 	if counts := runGitCmd(workingDir, "rev-list", "--left-right", "--count", "@{upstream}...HEAD"); counts != "" {
 		ahead, behind := parseAheadBehind(counts)
@@ -73,6 +81,24 @@ func ExtractContext(workingDir string) *envelope.GitContext {
 	}
 
 	return ctx
+}
+
+// detectWorktree reports whether workingDir is a linked git worktree and, if so,
+// the worktree's top-level path. A linked worktree's `--git-dir` (e.g.
+// .git/worktrees/<name>) differs from its `--git-common-dir` (the main .git);
+// in the main checkout the two resolve to the same directory.
+func detectWorktree(workingDir string) (bool, string) {
+	gitDir := runGitCmd(workingDir, "rev-parse", "--absolute-git-dir")
+	commonDir := runGitCmd(workingDir, "rev-parse", "--path-format=absolute", "--git-common-dir")
+	if gitDir == "" || commonDir == "" {
+		return false, ""
+	}
+	if filepath.Clean(gitDir) == filepath.Clean(commonDir) {
+		return false, ""
+	}
+	// Linked worktree. Its top-level dir is the most useful path to report.
+	top := runGitCmd(workingDir, "rev-parse", "--show-toplevel")
+	return true, top
 }
 
 // runGitCmd executes a git command with timeout and returns trimmed stdout

--- a/internal/git/context.go
+++ b/internal/git/context.go
@@ -67,10 +67,11 @@ func ExtractContext(workingDir string) *envelope.GitContext {
 
 	// Worktree detection: a linked worktree has a per-worktree git dir that
 	// differs from the shared common dir. This catches sessions started *inside*
-	// an existing worktree, which the WorktreeCreate hook never reports.
-	if isWorktree, path := detectWorktree(workingDir); isWorktree {
+	// an existing worktree, which the WorktreeCreate hook never reports. Reuse
+	// repoRoot (already the worktree's top-level) for the path — no extra call.
+	if detectWorktree(workingDir) {
 		ctx.IsWorktree = true
-		ctx.WorktreePath = path
+		ctx.WorktreePath = repoRoot
 	}
 
 	// Ahead/behind counts
@@ -83,22 +84,35 @@ func ExtractContext(workingDir string) *envelope.GitContext {
 	return ctx
 }
 
-// detectWorktree reports whether workingDir is a linked git worktree and, if so,
-// the worktree's top-level path. A linked worktree's `--git-dir` (e.g.
-// .git/worktrees/<name>) differs from its `--git-common-dir` (the main .git);
-// in the main checkout the two resolve to the same directory.
-func detectWorktree(workingDir string) (bool, string) {
-	gitDir := runGitCmd(workingDir, "rev-parse", "--absolute-git-dir")
-	commonDir := runGitCmd(workingDir, "rev-parse", "--path-format=absolute", "--git-common-dir")
+// detectWorktree reports whether workingDir is a linked git worktree (not the
+// main checkout). A linked worktree's per-worktree git dir
+// (.git/worktrees/<name>) differs from the shared common dir; in the main
+// checkout the two are identical.
+//
+// Both paths come from a SINGLE `git rev-parse --git-dir --git-common-dir`
+// invocation so they're resolved with identical semantics — this avoids
+// false positives from symlink/case differences between two separate
+// subcommands, needs no `--path-format` (so it works on git >= 2.5), and adds
+// just one subprocess to the latency-sensitive hook path.
+func detectWorktree(workingDir string) bool {
+	out := runGitCmd(workingDir, "rev-parse", "--git-dir", "--git-common-dir")
+	lines := strings.Split(out, "\n")
+	if len(lines) < 2 {
+		return false
+	}
+	gitDir, commonDir := strings.TrimSpace(lines[0]), strings.TrimSpace(lines[1])
 	if gitDir == "" || commonDir == "" {
-		return false, ""
+		return false
 	}
-	if filepath.Clean(gitDir) == filepath.Clean(commonDir) {
-		return false, ""
+	// Resolve both relative to workingDir for a stable comparison (git may emit
+	// either path relative to the cwd).
+	abs := func(p string) string {
+		if !filepath.IsAbs(p) {
+			p = filepath.Join(workingDir, p)
+		}
+		return filepath.Clean(p)
 	}
-	// Linked worktree. Its top-level dir is the most useful path to report.
-	top := runGitCmd(workingDir, "rev-parse", "--show-toplevel")
-	return true, top
+	return abs(gitDir) != abs(commonDir)
 }
 
 // runGitCmd executes a git command with timeout and returns trimmed stdout

--- a/internal/git/context_test.go
+++ b/internal/git/context_test.go
@@ -1,0 +1,68 @@
+package git
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+)
+
+func git(t *testing.T, dir string, args ...string) {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	cmd.Env = append(os.Environ(),
+		"GIT_AUTHOR_NAME=t", "GIT_AUTHOR_EMAIL=t@t",
+		"GIT_COMMITTER_NAME=t", "GIT_COMMITTER_EMAIL=t@t",
+	)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git %v: %v\n%s", args, err, out)
+	}
+}
+
+// A main checkout is not a worktree; a linked worktree is, and its path is
+// reported. This is the signal coaching relies on for "ran in a worktree".
+func TestDetectWorktree(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+	root := t.TempDir()
+	main := filepath.Join(root, "main")
+	if err := os.MkdirAll(main, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	git(t, main, "init", "-q", "-b", "main")
+	if err := os.WriteFile(filepath.Join(main, "f.txt"), []byte("hi"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	git(t, main, "add", ".")
+	git(t, main, "commit", "-q", "-m", "init")
+
+	// Main checkout: not a worktree.
+	if isWt, _ := detectWorktree(main); isWt {
+		t.Errorf("main checkout reported as worktree")
+	}
+	if ctx := ExtractContext(main); ctx == nil || ctx.IsWorktree {
+		t.Errorf("ExtractContext(main).IsWorktree = true, want false")
+	}
+
+	// Linked worktree: detected, with its top-level path.
+	wt := filepath.Join(root, "wt")
+	git(t, main, "worktree", "add", "-q", "-b", "feat", wt)
+
+	isWt, path := detectWorktree(wt)
+	if !isWt {
+		t.Fatalf("linked worktree not detected")
+	}
+	if filepath.Base(path) != "wt" {
+		t.Errorf("worktree path = %q, want .../wt", path)
+	}
+	ctx := ExtractContext(wt)
+	if ctx == nil || !ctx.IsWorktree {
+		t.Fatalf("ExtractContext(wt).IsWorktree = false, want true")
+	}
+	if ctx.WorktreePath == "" {
+		t.Errorf("ExtractContext(wt).WorktreePath empty")
+	}
+}

--- a/internal/git/context_test.go
+++ b/internal/git/context_test.go
@@ -40,29 +40,25 @@ func TestDetectWorktree(t *testing.T) {
 	git(t, main, "commit", "-q", "-m", "init")
 
 	// Main checkout: not a worktree.
-	if isWt, _ := detectWorktree(main); isWt {
+	if detectWorktree(main) {
 		t.Errorf("main checkout reported as worktree")
 	}
 	if ctx := ExtractContext(main); ctx == nil || ctx.IsWorktree {
 		t.Errorf("ExtractContext(main).IsWorktree = true, want false")
 	}
 
-	// Linked worktree: detected, with its top-level path.
+	// Linked worktree: detected, with its top-level path (reused from repoRoot).
 	wt := filepath.Join(root, "wt")
 	git(t, main, "worktree", "add", "-q", "-b", "feat", wt)
 
-	isWt, path := detectWorktree(wt)
-	if !isWt {
+	if !detectWorktree(wt) {
 		t.Fatalf("linked worktree not detected")
-	}
-	if filepath.Base(path) != "wt" {
-		t.Errorf("worktree path = %q, want .../wt", path)
 	}
 	ctx := ExtractContext(wt)
 	if ctx == nil || !ctx.IsWorktree {
 		t.Fatalf("ExtractContext(wt).IsWorktree = false, want true")
 	}
-	if ctx.WorktreePath == "" {
-		t.Errorf("ExtractContext(wt).WorktreePath empty")
+	if filepath.Base(ctx.WorktreePath) != "wt" {
+		t.Errorf("ExtractContext(wt).WorktreePath = %q, want .../wt", ctx.WorktreePath)
 	}
 }


### PR DESCRIPTION
## Detect git worktrees in captured git context

Adds `IsWorktree` / `WorktreePath` to `GitContext`, populated by `ExtractContext` by comparing `git rev-parse --git-dir` against `--git-common-dir` (they differ in a linked worktree).

### Why
This is the robust "ran in a worktree" signal for the agent-coaching report. The Claude Code `WorktreeCreate` hook only fires when the agent *creates* a worktree — it misses sessions started *inside* an existing worktree. CLI-side git detection covers that case for every event.

### Notes
- Additive envelope fields (`is_worktree`, `worktree_path` under `enrichment.git`); the platform reads them opportunistically.
- New `internal/git/context_test.go` builds a real linked worktree and asserts main-checkout vs worktree detection.
- `go build` + `go test ./internal/git ./internal/envelope` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
