### PR TITLE
feat: update marker + reload guidance after extension reconcile

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -109,6 +109,13 @@ Detection is version-based (not a byte diff) because `vsce package` output isn't
 **bump the extension's `package.json` version whenever you change it**. (Opening the PR needs the
 repo's "Allow GitHub Actions to create and approve pull requests" setting.)
 
+After a successful post-upgrade reconcile, the CLI writes an update marker
+(`internal/extension/marker.go` → `~/.promptconduit/extension-update.json`) recording the newly
+installed version. The running extension watches that file and, when it names a newer version than
+the one it's running, offers a one-click **Reload Window** — a reload (not a restart) so the editor's
+pty host survives and terminals running Claude Code keep their sessions. Keep the JSON field names in
+sync with `editor-extension/src/updatePrompt.ts`.
+
 ## Key Design Decisions
 
 - **Server-side adapters**: The CLI sends raw events; all transformation happens in platform adapters

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -178,8 +178,15 @@ func reconcileCostExtension(cmd *cobra.Command) {
 			continue
 		}
 		if res.Updated {
+			// Drop a marker the running extension watches so it can offer a
+			// one-click reload. Best-effort — the terminal notice below is the
+			// fallback for anyone who doesn't see the in-editor toast.
+			_ = extension.WriteUpdateMarker(res.Bundled, res.Editor)
 			_, _ = fmt.Fprintf(cmd.ErrOrStderr(),
-				"promptconduit: updated the %s cost extension to v%s\n", res.Editor, res.Bundled)
+				"promptconduit: updated the %s cost extension to v%s\n"+
+					"  → Reload %s to apply: press Cmd/Ctrl+R, or run \"Developer: Reload Window\".\n"+
+					"    A full restart isn't needed — and would close terminals running Claude Code.\n",
+				res.Editor, res.Bundled, res.Editor)
 		}
 	}
 }

--- a/internal/extension/marker.go
+++ b/internal/extension/marker.go
@@ -1,0 +1,70 @@
+package extension
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/promptconduit/cli/internal/eventlog"
+)
+
+// markerFileName is the drop file the CLI writes after it updates the editor's
+// installed cost extension on disk. The running extension watches it and, when
+// the recorded version is newer than the version it's currently running, offers
+// a one-click **Reload Window** (not a restart) to apply the update. It lives in
+// ~/.promptconduit/ next to events.jsonl — the folder the extension already
+// watches — so detection is nearly free.
+const markerFileName = "extension-update.json"
+
+// UpdateMarker is the on-disk contract shared with the editor extension. Keep
+// the JSON field names in sync with editor-extension/src/updatePrompt.ts.
+type UpdateMarker struct {
+	Version   string `json:"version"`    // extension version now installed on disk
+	Editor    string `json:"editor"`     // human label, e.g. "Cursor"
+	UpdatedAt string `json:"updated_at"` // RFC3339 UTC timestamp of the update
+}
+
+// MarkerPath is the absolute path of the update marker file.
+func MarkerPath() string { return filepath.Join(eventlog.Dir(), markerFileName) }
+
+// WriteUpdateMarker records that the on-disk cost extension was updated to
+// version for editor, so a running extension can detect the drift and prompt a
+// reload. Written atomically (temp file + rename) so the extension never reads a
+// half-written file. Best-effort: the returned error is for the caller to log or
+// ignore — a failed marker only means the user misses the in-editor toast, not
+// that the update itself failed.
+func WriteUpdateMarker(version, editor string) error {
+	dir := eventlog.Dir()
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return err
+	}
+	data, err := json.MarshalIndent(UpdateMarker{
+		Version:   version,
+		Editor:    editor,
+		UpdatedAt: time.Now().UTC().Format(time.RFC3339),
+	}, "", "  ")
+	if err != nil {
+		return err
+	}
+	tmp, err := os.CreateTemp(dir, markerFileName+"-*.tmp")
+	if err != nil {
+		// Fall back to a direct write rather than dropping the marker.
+		return os.WriteFile(MarkerPath(), data, 0o644)
+	}
+	tmpName := tmp.Name()
+	if _, err := tmp.Write(data); err != nil {
+		_ = tmp.Close()
+		_ = os.Remove(tmpName)
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		_ = os.Remove(tmpName)
+		return err
+	}
+	if err := os.Rename(tmpName, MarkerPath()); err != nil {
+		_ = os.Remove(tmpName)
+		return err
+	}
+	return nil
+}

--- a/internal/extension/marker_test.go
+++ b/internal/extension/marker_test.go
@@ -1,0 +1,75 @@
+package extension
+
+import (
+	"encoding/json"
+	"os"
+	"testing"
+
+	"github.com/promptconduit/cli/internal/eventlog"
+)
+
+func TestWriteUpdateMarker(t *testing.T) {
+	dir := t.TempDir()
+	eventlog.SetDirForTest(dir)
+	t.Cleanup(func() { eventlog.SetDirForTest("") })
+
+	if err := WriteUpdateMarker("1.2.3", "Cursor"); err != nil {
+		t.Fatalf("WriteUpdateMarker: %v", err)
+	}
+
+	data, err := os.ReadFile(MarkerPath())
+	if err != nil {
+		t.Fatalf("read marker: %v", err)
+	}
+	var m UpdateMarker
+	if err := json.Unmarshal(data, &m); err != nil {
+		t.Fatalf("marker is not valid JSON: %v", err)
+	}
+	if m.Version != "1.2.3" {
+		t.Errorf("version = %q, want 1.2.3", m.Version)
+	}
+	if m.Editor != "Cursor" {
+		t.Errorf("editor = %q, want Cursor", m.Editor)
+	}
+	if m.UpdatedAt == "" {
+		t.Error("updated_at is empty; want an RFC3339 timestamp")
+	}
+}
+
+func TestWriteUpdateMarkerOverwrites(t *testing.T) {
+	dir := t.TempDir()
+	eventlog.SetDirForTest(dir)
+	t.Cleanup(func() { eventlog.SetDirForTest("") })
+
+	if err := WriteUpdateMarker("1.0.0", "VS Code"); err != nil {
+		t.Fatalf("first write: %v", err)
+	}
+	if err := WriteUpdateMarker("2.0.0", "Cursor"); err != nil {
+		t.Fatalf("second write: %v", err)
+	}
+
+	data, err := os.ReadFile(MarkerPath())
+	if err != nil {
+		t.Fatalf("read marker: %v", err)
+	}
+	var m UpdateMarker
+	if err := json.Unmarshal(data, &m); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if m.Version != "2.0.0" || m.Editor != "Cursor" {
+		t.Errorf("latest write not reflected: got version=%q editor=%q", m.Version, m.Editor)
+	}
+
+	// A single marker file, not a pile of leftover temp files.
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("readdir: %v", err)
+	}
+	if len(entries) != 1 {
+		names := make([]string, 0, len(entries))
+		for _, e := range entries {
+			names = append(names, e.Name())
+		}
+		t.Errorf("expected exactly one file (the marker), got %d: %v", len(entries), names)
+	}
+}


### PR DESCRIPTION
## Why

When a post-upgrade reconcile updates the editor's cost extension on disk, the extension running in the current window is **stale until a reload**. The CLI printed a terse "updated" line and left the user to figure out how to apply it — and a full editor **restart** (the intuitive move) tears down the pty host and **kills terminals running Claude Code**.

## What

- `internal/extension/marker.go` — `WriteUpdateMarker` atomically writes `~/.promptconduit/extension-update.json` `{version, editor, updated_at}`. The running extension watches this file and offers a one-click **Reload Window** when the version is newer than what it's running.
- `cmd/root.go` — write the marker on a successful reconcile, and replace the notice with explicit, terminal-safe guidance:

  ```
  promptconduit: updated the Cursor cost extension to v0.9.0
    → Reload Cursor to apply: press Cmd/Ctrl+R, or run "Developer: Reload Window".
      A full restart isn't needed — and would close terminals running Claude Code.
  ```

Reload preserves the pty host, so Claude Code sessions survive; a restart closes them.

## Notes

- `--force` on `--install-extension` is retained: it only affects the **on-disk** install (it's what lets an already-installed older copy update at all) and never touches the running session. The fix is owning the *apply* step, not changing the *install*.
- Best-effort: a failed marker write only means the user misses the in-editor toast, never that the update failed. The terminal notice is the fallback.
- Marker JSON field names kept in sync with the extension's `updatePrompt.ts`.
- New unit tests for the marker (full suite passes; `go vet` clean).

## Paired with

- promptconduit/editor-extension#47 — the in-editor Reload Window prompt that consumes this marker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)