### PR TITLE
feat: reconstruct & reopen recent AI sessions (sessions + resume)

### DIFF
--- a/cmd/resume.go
+++ b/cmd/resume.go
@@ -1,0 +1,119 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+
+	"github.com/promptconduit/cli/internal/sessions"
+	"github.com/spf13/cobra"
+)
+
+// resumeLookback is generous — `resume` is an explicit action, so a session from
+// a couple of days ago is fair game (unlike the tighter default for `sessions`).
+const resumeLookback = 72 * time.Hour
+
+var resumePrintOnly bool
+
+var resumeCmd = &cobra.Command{
+	Use:   "resume [session-id]",
+	Short: "Reopen an AI coding session in the directory it ran in",
+	Long: `Reopen a Claude Code session, changing into the exact directory it ran in
+(worktree-aware) and running 'claude --resume <id>'.
+
+With no argument it resumes the most recently active session. A partial session
+id is accepted as long as it's unambiguous. Use 'promptconduit sessions' to see
+what's available, or --print to print the command instead of running it (handy
+for shell integration).`,
+	Args: cobra.MaximumNArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		list, err := sessions.ReadRecent(resumeLookback, time.Now())
+		if err != nil {
+			return fmt.Errorf("read sessions: %w", err)
+		}
+		if len(list) == 0 {
+			return fmt.Errorf("no recent sessions found in the event log")
+		}
+
+		var target sessions.Session
+		if len(args) == 0 {
+			target = list[0] // newest-active first
+		} else {
+			match, err := pickSession(list, args[0])
+			if err != nil {
+				return err
+			}
+			target = match
+		}
+
+		if _, err := os.Stat(target.Cwd); err != nil {
+			return fmt.Errorf("session directory %q is no longer present: %w", target.Cwd, err)
+		}
+
+		claude, err := exec.LookPath("claude")
+		if err != nil {
+			return fmt.Errorf("the `claude` CLI wasn't found on PATH — install Claude Code, then retry")
+		}
+
+		if resumePrintOnly {
+			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "cd %s && claude --resume %s\n",
+				shellQuote(target.Cwd), target.SessionID)
+			return nil
+		}
+
+		_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Resuming %s in %s …\n",
+			shortID(target.SessionID), prettyDir(target.Cwd))
+
+		child := exec.Command(claude, "--resume", target.SessionID)
+		child.Dir = target.Cwd
+		child.Stdin = os.Stdin
+		child.Stdout = os.Stdout
+		child.Stderr = os.Stderr
+		if err := child.Run(); err != nil {
+			// Propagate the child's exit code rather than wrapping it.
+			if exitErr, ok := err.(*exec.ExitError); ok {
+				os.Exit(exitErr.ExitCode())
+			}
+			return fmt.Errorf("run claude: %w", err)
+		}
+		return nil
+	},
+}
+
+// pickSession resolves a user-supplied id (exact or unambiguous prefix) to a
+// single session.
+func pickSession(list []sessions.Session, id string) (sessions.Session, error) {
+	var matches []sessions.Session
+	for _, s := range list {
+		if s.SessionID == id {
+			return s, nil // exact wins outright
+		}
+		if strings.HasPrefix(s.SessionID, id) {
+			matches = append(matches, s)
+		}
+	}
+	switch len(matches) {
+	case 1:
+		return matches[0], nil
+	case 0:
+		return sessions.Session{}, fmt.Errorf("no session matches %q (try `promptconduit sessions`)", id)
+	default:
+		return sessions.Session{}, fmt.Errorf("%q is ambiguous — it matches %d sessions; use more characters", id, len(matches))
+	}
+}
+
+// shellQuote single-quotes a path for the --print form so directories with
+// spaces paste correctly.
+func shellQuote(s string) string {
+	if !strings.ContainsAny(s, " \t'\"\\$") {
+		return s
+	}
+	return "'" + strings.ReplaceAll(s, "'", `'\''`) + "'"
+}
+
+func init() {
+	resumeCmd.Flags().BoolVar(&resumePrintOnly, "print", false, "print the resume command instead of running it")
+	rootCmd.AddCommand(resumeCmd)
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -227,7 +227,10 @@ func skipUpdateCheckFor(cmd *cobra.Command) bool {
 	}
 	name := commandPathRoot(cmd)
 	switch name {
-	case "hook", "upgrade", "watch", "collect", "cost":
+	case "hook", "upgrade", "watch", "collect", "cost", "sessions", "resume":
+		// sessions/resume are called programmatically (the editor extension's
+		// auto-restore) and resume execs straight into claude — keep them quiet
+		// and fast, no update banner.
 		return true
 	}
 	return false

--- a/cmd/sessions.go
+++ b/cmd/sessions.go
@@ -1,0 +1,162 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"text/tabwriter"
+	"time"
+
+	"github.com/promptconduit/cli/internal/sessions"
+	"github.com/spf13/cobra"
+)
+
+var (
+	sessionsSince     time.Duration
+	sessionsJSON      bool
+	sessionsAll       bool // include sessions that are still running
+	sessionsUnderPath string
+)
+
+var sessionsCmd = &cobra.Command{
+	Use:   "sessions",
+	Short: "List recent, resumable AI coding sessions",
+	Long: `List AI coding sessions reconstructed from the local event log, newest first.
+
+Each session records the exact working directory it ran in (worktree-aware) and
+its session id, so it can be reopened with 'promptconduit resume <id>' or
+'claude --resume <id>'. Sessions with a live process are marked (running) and,
+unless --all is given, hidden — the common use is finding sessions that were
+interrupted (e.g. when the editor restarted and closed their terminals).
+
+This is the engine behind the editor extension's automatic session restore;
+--json emits the machine-readable form it consumes.`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		list, err := sessions.ReadRecent(sessionsSince, time.Now())
+		if err != nil {
+			return fmt.Errorf("read sessions: %w", err)
+		}
+		sessions.MarkAlive(list, sessions.LiveClaudeCwds())
+
+		if sessionsUnderPath != "" {
+			base, err := filepath.Abs(sessionsUnderPath)
+			if err == nil {
+				list = filterUnder(list, base)
+			}
+		}
+		if !sessionsAll {
+			list = filterInterrupted(list)
+		}
+
+		if sessionsJSON {
+			enc := json.NewEncoder(cmd.OutOrStdout())
+			enc.SetIndent("", "  ")
+			if list == nil {
+				list = []sessions.Session{}
+			}
+			return enc.Encode(list)
+		}
+		printSessionsTable(cmd, list)
+		return nil
+	},
+}
+
+// filterUnder keeps sessions whose cwd is base or a descendant of it — used to
+// scope restore to the current workspace.
+func filterUnder(list []sessions.Session, base string) []sessions.Session {
+	out := make([]sessions.Session, 0, len(list))
+	for _, s := range list {
+		if s.Cwd == base || isUnder(base, s.Cwd) {
+			out = append(out, s)
+		}
+	}
+	return out
+}
+
+func isUnder(base, path string) bool {
+	rel, err := filepath.Rel(base, path)
+	if err != nil {
+		return false
+	}
+	return rel != ".." && !hasDotDotPrefix(rel) && !filepath.IsAbs(rel)
+}
+
+func hasDotDotPrefix(rel string) bool {
+	return len(rel) >= 3 && rel[0] == '.' && rel[1] == '.' && (rel[2] == filepath.Separator)
+}
+
+func filterInterrupted(list []sessions.Session) []sessions.Session {
+	out := make([]sessions.Session, 0, len(list))
+	for _, s := range list {
+		if !s.Alive {
+			out = append(out, s)
+		}
+	}
+	return out
+}
+
+func printSessionsTable(cmd *cobra.Command, list []sessions.Session) {
+	if len(list) == 0 {
+		_, _ = fmt.Fprintln(cmd.OutOrStdout(), "No recent resumable sessions.")
+		return
+	}
+	tw := tabwriter.NewWriter(cmd.OutOrStdout(), 0, 2, 2, ' ', 0)
+	_, _ = fmt.Fprintln(tw, "ACTIVE\tBRANCH\tDIRECTORY\tSESSION\tPROMPT")
+	now := time.Now()
+	for _, s := range list {
+		branch := s.Branch
+		if branch == "" {
+			branch = "-"
+		}
+		state := humanAgo(now.Sub(s.LastActive))
+		if s.Alive {
+			state += " (running)"
+		}
+		_, _ = fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%s\n",
+			state, branch, prettyDir(s.Cwd), shortID(s.SessionID), s.LastPrompt)
+	}
+	_ = tw.Flush()
+}
+
+func humanAgo(d time.Duration) string {
+	switch {
+	case d < time.Minute:
+		return "just now"
+	case d < time.Hour:
+		return fmt.Sprintf("%dm ago", int(d.Minutes()))
+	case d < 24*time.Hour:
+		return fmt.Sprintf("%dh ago", int(d.Hours()))
+	default:
+		return fmt.Sprintf("%dd ago", int(d.Hours()/24))
+	}
+}
+
+func prettyDir(p string) string {
+	if home, err := os.UserHomeDir(); err == nil && home != "" {
+		if p == home {
+			return "~"
+		}
+		if isUnder(home, p) {
+			if rel, err := filepath.Rel(home, p); err == nil {
+				return "~/" + rel
+			}
+		}
+	}
+	return p
+}
+
+func shortID(id string) string {
+	if len(id) > 8 {
+		return id[:8]
+	}
+	return id
+}
+
+func init() {
+	sessionsCmd.Flags().DurationVar(&sessionsSince, "since", 12*time.Hour, "only sessions active within this window")
+	sessionsCmd.Flags().BoolVar(&sessionsJSON, "json", false, "emit machine-readable JSON")
+	sessionsCmd.Flags().BoolVar(&sessionsAll, "all", false, "include sessions that are still running")
+	sessionsCmd.Flags().StringVar(&sessionsUnderPath, "under", "", "only sessions whose directory is under this path")
+	rootCmd.AddCommand(sessionsCmd)
+}

--- a/internal/sessions/live.go
+++ b/internal/sessions/live.go
@@ -1,0 +1,69 @@
+package sessions
+
+import (
+	"context"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+// liveProbeTimeout bounds the process inspection so `sessions` never hangs on a
+// slow lsof.
+const liveProbeTimeout = 3 * time.Second
+
+// LiveClaudeCwds returns the set of working directories that currently have a
+// running `claude` process. Used to mark sessions Alive so restore never opens
+// a second terminal on top of a session that's still going. Best-effort: on any
+// error (no pgrep/lsof, permission, non-Unix) it returns an empty set, so the
+// caller degrades to "assume nothing is alive" rather than failing.
+func LiveClaudeCwds() map[string]bool {
+	ctx, cancel := context.WithTimeout(context.Background(), liveProbeTimeout)
+	defer cancel()
+
+	cwds := map[string]bool{}
+	for _, pid := range claudePIDs(ctx) {
+		if cwd := procCwd(ctx, pid); cwd != "" {
+			cwds[cwd] = true
+		}
+	}
+	return cwds
+}
+
+// MarkAlive sets Alive on each session whose Cwd has a live claude process.
+func MarkAlive(list []Session, liveCwds map[string]bool) {
+	for i := range list {
+		if liveCwds[list[i].Cwd] {
+			list[i].Alive = true
+		}
+	}
+}
+
+func claudePIDs(ctx context.Context) []string {
+	// -x: match the exact process name, so we don't catch "claude-something".
+	out, err := exec.CommandContext(ctx, "pgrep", "-x", "claude").Output()
+	if err != nil {
+		return nil
+	}
+	var pids []string
+	for _, line := range strings.Split(strings.TrimSpace(string(out)), "\n") {
+		if p := strings.TrimSpace(line); p != "" {
+			pids = append(pids, p)
+		}
+	}
+	return pids
+}
+
+// procCwd returns the current working directory of a pid via lsof's field
+// output (-Fn prints an "n<path>" line for the cwd fd).
+func procCwd(ctx context.Context, pid string) string {
+	out, err := exec.CommandContext(ctx, "lsof", "-a", "-p", pid, "-d", "cwd", "-Fn").Output()
+	if err != nil {
+		return ""
+	}
+	for _, line := range strings.Split(string(out), "\n") {
+		if strings.HasPrefix(line, "n") {
+			return strings.TrimSpace(line[1:])
+		}
+	}
+	return ""
+}

--- a/internal/sessions/sessions.go
+++ b/internal/sessions/sessions.go
@@ -1,0 +1,196 @@
+// Package sessions reconstructs resumable AI coding sessions from the local
+// event log (~/.promptconduit/events.jsonl). It answers "what sessions were
+// recently active, and where did they live?" — the substrate for reopening a
+// session that was interrupted (e.g. when the editor restarted and took its
+// terminals down with it).
+package sessions
+
+import (
+	"encoding/json"
+	"os"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/promptconduit/cli/internal/eventlog"
+)
+
+// Session is a resumable session reconstructed from the event log. It carries
+// everything needed to reopen it: the exact working directory it ran in
+// (worktree-aware — this is the real cwd, so a worktree session points at the
+// worktree path) and the session id to hand to `claude --resume`.
+type Session struct {
+	SessionID  string    `json:"session_id"`
+	Tool       string    `json:"tool"`
+	Cwd        string    `json:"cwd"`
+	Repo       string    `json:"repo,omitempty"`
+	Branch     string    `json:"branch,omitempty"`
+	LastPrompt string    `json:"last_prompt,omitempty"`
+	LastActive time.Time `json:"last_active"`
+	EventCount int       `json:"event_count"`
+	Alive      bool      `json:"alive"` // a live process is already running in Cwd
+}
+
+// resumableTools are the CLI tools whose sessions can be reopened with a resume
+// command. Cursor's built-in agent is intentionally excluded — it's not a CLI
+// and has no equivalent to `claude --resume`.
+var resumableTools = map[string]bool{
+	"claude-code": true,
+}
+
+// envelope is the minimal slice of an events.jsonl line we need. The event log
+// stores far more; we only decode the resume-relevant fields.
+type envelope struct {
+	Tool       string `json:"tool"`
+	HookEvent  string `json:"hook_event"`
+	CapturedAt string `json:"captured_at"`
+	Native     struct {
+		SessionID string `json:"session_id"`
+		Cwd       string `json:"cwd"`
+		Prompt    string `json:"prompt"`
+	} `json:"native_payload"`
+	Git struct {
+		RepoName string `json:"repo_name"`
+		Branch   string `json:"branch"`
+	} `json:"git"`
+}
+
+// Aggregate folds a chronological run of event lines into one Session per
+// session id, keeping the newest cwd/branch/tool and the most recent prompt
+// seen. Lines that don't parse, lack a session id or cwd, or belong to a
+// non-resumable tool are skipped. Result is sorted newest-active first.
+func Aggregate(lines []string) []Session {
+	bySession := map[string]*Session{}
+	for _, line := range lines {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		var e envelope
+		if err := json.Unmarshal([]byte(line), &e); err != nil {
+			continue
+		}
+		sid := e.Native.SessionID
+		if sid == "" || e.Native.Cwd == "" || !resumableTools[e.Tool] {
+			continue
+		}
+		t, _ := time.Parse(time.RFC3339, e.CapturedAt)
+
+		s := bySession[sid]
+		if s == nil {
+			s = &Session{SessionID: sid, Tool: e.Tool}
+			bySession[sid] = s
+		}
+		s.EventCount++
+		// Keep the fields from the latest event so cwd/branch reflect where the
+		// session ended up (it can move between worktrees mid-session).
+		if !t.IsZero() && !t.Before(s.LastActive) {
+			s.LastActive = t
+			s.Cwd = e.Native.Cwd
+			s.Repo = e.Git.RepoName
+			s.Branch = e.Git.Branch
+		} else if s.Cwd == "" {
+			// No usable timestamp yet — still capture a cwd so the session is
+			// restorable.
+			s.Cwd = e.Native.Cwd
+			s.Repo = e.Git.RepoName
+			s.Branch = e.Git.Branch
+		}
+		// Use the event's prompt as a human label, but skip system/tool-injected
+		// messages (task notifications, tool XML) that start with "<" — they're
+		// not something the user typed and make for a confusing label.
+		if p := strings.TrimSpace(e.Native.Prompt); p != "" && !strings.HasPrefix(p, "<") {
+			s.LastPrompt = truncate(p, 140)
+		}
+	}
+
+	out := make([]Session, 0, len(bySession))
+	for _, s := range bySession {
+		out = append(out, *s)
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].LastActive.Equal(out[j].LastActive) {
+			return out[i].SessionID < out[j].SessionID
+		}
+		return out[i].LastActive.After(out[j].LastActive)
+	})
+	return out
+}
+
+// Filter keeps only sessions active at or after cutoff.
+func Filter(all []Session, cutoff time.Time) []Session {
+	out := make([]Session, 0, len(all))
+	for _, s := range all {
+		if !s.LastActive.Before(cutoff) {
+			out = append(out, s)
+		}
+	}
+	return out
+}
+
+// Default bound on the tail read of the event log. The newest bytes hold the
+// recent sessions; reading the whole (potentially 100MB+) file on every call
+// would be wasteful. Tens of thousands of events fit in 16MB.
+const defaultMaxBytes int64 = 16 * 1024 * 1024
+
+// ReadRecent returns sessions active within `since` of `now`, newest first. It
+// reads only the tail of the event log for speed. A missing log yields an empty
+// slice, not an error (Free/local-only users with logging on still have it; a
+// user who disabled logging simply has nothing to restore).
+func ReadRecent(since time.Duration, now time.Time) ([]Session, error) {
+	return readRecentFrom(eventlog.EventsJSONLPath(), since, now, defaultMaxBytes)
+}
+
+func readRecentFrom(path string, since time.Duration, now time.Time, maxBytes int64) ([]Session, error) {
+	lines, err := tailLines(path, maxBytes)
+	if err != nil {
+		return nil, err
+	}
+	all := Aggregate(lines)
+	return Filter(all, now.Add(-since)), nil
+}
+
+// tailLines reads the last maxBytes of path and returns complete lines. When the
+// read starts mid-file the leading partial line is dropped. A missing file is
+// not an error — it returns no lines.
+func tailLines(path string, maxBytes int64) ([]string, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	defer f.Close()
+
+	fi, err := f.Stat()
+	if err != nil {
+		return nil, err
+	}
+	size := fi.Size()
+	if size == 0 {
+		return nil, nil
+	}
+	start := int64(0)
+	if size > maxBytes {
+		start = size - maxBytes
+	}
+	buf := make([]byte, size-start)
+	if _, err := f.ReadAt(buf, start); err != nil && err.Error() != "EOF" {
+		return nil, err
+	}
+	parts := strings.Split(string(buf), "\n")
+	if start > 0 && len(parts) > 0 {
+		parts = parts[1:] // drop the leading partial line
+	}
+	return parts, nil
+}
+
+func truncate(s string, n int) string {
+	s = strings.ReplaceAll(strings.ReplaceAll(s, "\n", " "), "\r", " ")
+	r := []rune(s)
+	if len(r) <= n {
+		return s
+	}
+	return string(r[:n-1]) + "…"
+}

--- a/internal/sessions/sessions_test.go
+++ b/internal/sessions/sessions_test.go
@@ -1,0 +1,139 @@
+package sessions
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// line builds one events.jsonl envelope line for the fields Aggregate reads.
+func line(tool, sid, cwd, branch, repo, at, prompt string) string {
+	var b strings.Builder
+	b.WriteString(`{"tool":"` + tool + `","captured_at":"` + at + `","native_payload":{"session_id":"` + sid + `","cwd":"` + cwd + `"`)
+	if prompt != "" {
+		b.WriteString(`,"prompt":"` + prompt + `"`)
+	}
+	b.WriteString(`},"git":{"repo_name":"` + repo + `","branch":"` + branch + `"}}`)
+	return b.String()
+}
+
+func TestAggregate_GroupsAndKeepsLatest(t *testing.T) {
+	lines := []string{
+		line("claude-code", "s1", "/repo/a", "main", "a", "2026-07-01T10:00:00Z", "first prompt"),
+		line("claude-code", "s1", "/repo/a-worktree", "feat/x", "a", "2026-07-01T10:05:00Z", ""),
+		line("claude-code", "s2", "/repo/b", "main", "b", "2026-07-01T09:00:00Z", ""),
+	}
+	got := Aggregate(lines)
+	if len(got) != 2 {
+		t.Fatalf("got %d sessions, want 2", len(got))
+	}
+	// Newest-active first → s1.
+	if got[0].SessionID != "s1" {
+		t.Errorf("first session = %s, want s1 (newest active)", got[0].SessionID)
+	}
+	// Latest event's cwd/branch win (session moved into a worktree).
+	if got[0].Cwd != "/repo/a-worktree" || got[0].Branch != "feat/x" {
+		t.Errorf("s1 cwd/branch = %s/%s, want /repo/a-worktree/feat/x", got[0].Cwd, got[0].Branch)
+	}
+	if got[0].EventCount != 2 {
+		t.Errorf("s1 event count = %d, want 2", got[0].EventCount)
+	}
+	// The prompt seen earlier is retained as the last-known prompt.
+	if got[0].LastPrompt != "first prompt" {
+		t.Errorf("s1 last prompt = %q, want %q", got[0].LastPrompt, "first prompt")
+	}
+}
+
+func TestAggregate_SkipsUnusableAndNonResumable(t *testing.T) {
+	lines := []string{
+		`not json`,
+		line("cursor", "c1", "/repo/a", "main", "a", "2026-07-01T10:00:00Z", ""),      // non-resumable tool
+		line("claude-code", "", "/repo/a", "main", "a", "2026-07-01T10:00:00Z", ""),   // no session id
+		line("claude-code", "s3", "", "main", "a", "2026-07-01T10:00:00Z", ""),        // no cwd
+		line("claude-code", "s4", "/repo/c", "main", "c", "2026-07-01T10:00:00Z", ""), // keep
+	}
+	got := Aggregate(lines)
+	if len(got) != 1 || got[0].SessionID != "s4" {
+		t.Fatalf("got %+v, want only s4", got)
+	}
+}
+
+func TestFilter_ByCutoff(t *testing.T) {
+	now := time.Date(2026, 7, 1, 12, 0, 0, 0, time.UTC)
+	all := []Session{
+		{SessionID: "recent", LastActive: now.Add(-30 * time.Minute)},
+		{SessionID: "old", LastActive: now.Add(-25 * time.Hour)},
+	}
+	got := Filter(all, now.Add(-12*time.Hour))
+	if len(got) != 1 || got[0].SessionID != "recent" {
+		t.Fatalf("got %+v, want only recent", got)
+	}
+}
+
+func TestReadRecentFrom_TailAndFilter(t *testing.T) {
+	now := time.Date(2026, 7, 1, 12, 0, 0, 0, time.UTC)
+	dir := t.TempDir()
+	path := filepath.Join(dir, "events.jsonl")
+	content := strings.Join([]string{
+		line("claude-code", "old", "/repo/a", "main", "a", "2026-06-20T10:00:00Z", ""),
+		line("claude-code", "fresh", "/repo/b", "main", "b", "2026-07-01T11:30:00Z", ""),
+		"", // trailing newline
+	}, "\n")
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	got, err := readRecentFrom(path, 12*time.Hour, now, defaultMaxBytes)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 1 || got[0].SessionID != "fresh" {
+		t.Fatalf("got %+v, want only fresh", got)
+	}
+}
+
+func TestReadRecentFrom_MissingFileIsEmpty(t *testing.T) {
+	got, err := readRecentFrom(filepath.Join(t.TempDir(), "nope.jsonl"), time.Hour, time.Now(), defaultMaxBytes)
+	if err != nil {
+		t.Fatalf("missing file should not error: %v", err)
+	}
+	if len(got) != 0 {
+		t.Fatalf("got %d, want 0", len(got))
+	}
+}
+
+func TestTailLines_DropsLeadingPartial(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "f.jsonl")
+	// Three lines; a tiny cap forces a mid-file start so the first (partial)
+	// line must be dropped.
+	if err := os.WriteFile(path, []byte("AAAA\nBBBB\nCCCC\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	lines, err := tailLines(path, 9) // covers "BB\nCCCC\n" region → starts mid-file
+	if err != nil {
+		t.Fatal(err)
+	}
+	joined := strings.Join(lines, "|")
+	if strings.Contains(joined, "A") {
+		t.Fatalf("leading partial line not dropped: %v", lines)
+	}
+	if !strings.Contains(joined, "CCCC") {
+		t.Fatalf("expected complete final record CCCC, got %v", lines)
+	}
+}
+
+func TestTruncate(t *testing.T) {
+	if got := truncate("hello\nworld", 100); got != "hello world" {
+		t.Errorf("newlines not flattened: %q", got)
+	}
+	long := strings.Repeat("x", 200)
+	got := truncate(long, 10)
+	if len([]rune(got)) != 10 {
+		t.Errorf("truncated len = %d runes, want 10 (%q)", len([]rune(got)), got)
+	}
+	if !strings.HasSuffix(got, "…") {
+		t.Errorf("expected ellipsis suffix, got %q", got)
+	}
+}


### PR DESCRIPTION
## Why

When the editor restarts it takes its terminals — and the `claude` processes in them — down with it. The data to bring them back is already in the local event log: every event records the session's **exact cwd (worktree-aware)** and **session id**. This adds the engine to reconstruct and reopen them.

## What

- **`internal/sessions`** — reconstructs one `Session` per `session_id` from `~/.promptconduit/events.jsonl` (bounded tail read), keeping the newest cwd/branch + a human prompt label. Marks a session `alive` when a live `claude` process is running in its cwd (`pgrep` + `lsof`, best-effort).
- **`promptconduit sessions [--json] [--since] [--all] [--under]`** — lists recent resumable sessions, newest first; interrupted-only by default. `--json` is the machine form the editor extension's auto-restore consumes.
- **`promptconduit resume [id] [--print]`** — reopens a session by cd-ing into its recorded directory and running `claude --resume <id>`. No arg = most recent; partial id accepted if unambiguous; `--print` emits the command for shell use.

Both are exempted from the update-check pre-run so they stay fast/quiet.

## Real output (this machine)

```
ACTIVE    BRANCH                DIRECTORY                                    SESSION   PROMPT
just now  feat/session-restore  ~/…/promptconduit/cli                        3acb7815  ok cool, but regarding this…
8h ago    main                  ~/…/promptconduit/platform                   a16cc7d6  run the backfill now
8h ago    -                     ~/…/TumblingTimmy/.claude/worktrees/breezy…  d87cebee
```

Worktree sessions resolve to the worktree path, so restore lands in the right place with no manual `cd`.

## Notes

- Only **Claude Code** sessions are resumable (Cursor's built-in agent has no CLI resume) — intentional.
- Unit-tested: aggregation, latest-wins cwd/branch, filtering, tail read (leading-partial drop), rune-safe truncation. `go vet`/`gofmt` clean; full suite passes.

## Paired with

- promptconduit/editor-extension#48 — automatic in-editor restore that consumes `sessions --json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
