### PR TITLE
feat(enrich): subagent, tools, diff slugs + env.os_version

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,9 +52,18 @@ to what's POSTed to `/v1/events/raw` and stored in the platform bucket.
   "tool": "claude-code", "hook_event": "PostToolUse", "captured_at": "…",
   "cli_version": "…",
   "raw_event": { /* native hook payload, untouched */ },
-  "enrichments": { "env": {…}, "trace": {…}, "vcs": {…}, "prompt": {…}, "cost": {…} }
+  "enrichments": { "env": {…}, "trace": {…}, "vcs": {…}, "prompt": {…}, "cost": {…},
+                   "tools": {…}, "diff": {…}, "subagent": {…} }
 }
 ```
+
+Well-known slugs: `env` (host/os/os_version/arch/cwd, every event) · `trace`
+(W3C correlation, every event) · `vcs` (normalized provider/repo/branch/PR,
+git repos) · `prompt` (count/shape, UserPromptSubmit) · `cost` (priced
+requests, Stop / cursor stop) · `tools` (normalized tool-call list,
+PostToolUse/Failure/Batch) · `diff` (working-tree shortstat vs HEAD,
+Stop/SessionEnd) · `subagent` (Start/Stop join with duration + per-agent
+tokens/USD from the agent transcript, SubagentStart/Stop).
 
 **Adding an enrichment** = one new file in `internal/enrich/` implementing
 `Enricher` (Slug/Applies/Enrich) plus `Register()` in its `init()`. Rules:

--- a/internal/enrich/diff.go
+++ b/internal/enrich/diff.go
@@ -1,0 +1,38 @@
+package enrich
+
+import "github.com/promptconduit/cli/internal/git"
+
+// DiffEnrichment is the "diff" slug, attached to turn-end events (Stop,
+// SessionEnd): the working tree's change stats vs HEAD (staged + unstaged),
+// so reports can tie a session's cost to its output — "this $1.61 session
+// changed +120/−40 across 3 files". Counts only, never file names or content.
+type DiffEnrichment struct {
+	FilesChanged int `json:"files_changed"`
+	Insertions   int `json:"insertions"`
+	Deletions    int `json:"deletions"`
+}
+
+type diffEnricher struct{}
+
+func init() { Register(diffEnricher{}) }
+
+func (diffEnricher) Slug() string { return "diff" }
+
+func (diffEnricher) Applies(ctx *Context) bool {
+	if ctx.Cwd == "" {
+		return false
+	}
+	return ctx.HookEvent == "Stop" || ctx.HookEvent == "SessionEnd"
+}
+
+func (diffEnricher) Enrich(ctx *Context) (any, error) {
+	files, insertions, deletions, ok := git.DiffShortstat(ctx.Cwd)
+	if !ok {
+		return nil, nil // not a git repo — omit the slug; zeros mean "clean tree"
+	}
+	return DiffEnrichment{
+		FilesChanged: files,
+		Insertions:   insertions,
+		Deletions:    deletions,
+	}, nil
+}

--- a/internal/enrich/enrich_test.go
+++ b/internal/enrich/enrich_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -212,5 +213,165 @@ func TestVCS_NormalizeRemote(t *testing.T) {
 		if slug != tc.wantSlug || url != tc.wantURL {
 			t.Errorf("normalizeRemote(%q) = %q,%q want %q,%q", tc.in, slug, url, tc.wantSlug, tc.wantURL)
 		}
+	}
+}
+
+func TestSubagentEnricher_StartStopJoin(t *testing.T) {
+	SetStateDirForTest(t.TempDir())
+	t.Cleanup(func() { SetStateDirForTest("") })
+
+	// Fake subagent transcript with two priced requests.
+	transcript := filepath.Join(t.TempDir(), "agent.jsonl")
+	lines := `{"type":"assistant","requestId":"ar-1","timestamp":"2026-07-03T10:00:00Z","message":{"model":"claude-opus-4-8","usage":{"input_tokens":100,"output_tokens":50,"cache_read_input_tokens":1000,"cache_creation_input_tokens":0}}}
+{"type":"assistant","requestId":"ar-2","timestamp":"2026-07-03T10:00:05Z","message":{"model":"claude-haiku-4-5","usage":{"input_tokens":10,"output_tokens":5,"cache_read_input_tokens":0,"cache_creation_input_tokens":0}}}
+`
+	if err := os.WriteFile(transcript, []byte(lines), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	e := subagentEnricher{}
+
+	startCtx := &Context{
+		Tool: "claude-code", HookEvent: "SubagentStart", SessionID: "sub-sess",
+		RawEvent: map[string]interface{}{"agent_id": "a1", "agent_type": "Explore"},
+	}
+	if !e.Applies(startCtx) {
+		t.Fatal("must apply to SubagentStart")
+	}
+	payload, err := e.Enrich(startCtx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	start := payload.(*SubagentEnrichment)
+	if start.Phase != "start" || start.AgentType != "Explore" || start.Concurrent != 1 {
+		t.Errorf("start = %+v", start)
+	}
+
+	// A second concurrent agent bumps parallelism.
+	payload, _ = e.Enrich(&Context{
+		Tool: "claude-code", HookEvent: "SubagentStart", SessionID: "sub-sess",
+		RawEvent: map[string]interface{}{"agent_id": "a2", "agent_type": "Plan"},
+	})
+	if payload.(*SubagentEnrichment).Concurrent != 2 {
+		t.Errorf("second start concurrent = %d, want 2", payload.(*SubagentEnrichment).Concurrent)
+	}
+
+	// Stop: real payloads carry an EMPTY agent_type — the state join recovers it.
+	payload, err = e.Enrich(&Context{
+		Tool: "claude-code", HookEvent: "SubagentStop", SessionID: "sub-sess",
+		RawEvent: map[string]interface{}{"agent_id": "a1", "agent_type": "", "agent_transcript_path": transcript},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	stop := payload.(*SubagentEnrichment)
+	if stop.Phase != "stop" || stop.AgentType != "Explore" {
+		t.Errorf("stop join failed: %+v", stop)
+	}
+	if stop.DurationMs < 0 {
+		t.Errorf("duration = %d", stop.DurationMs)
+	}
+	if stop.Requests != 2 || stop.Tokens == nil || stop.Tokens.Input != 110 {
+		t.Errorf("transcript sum wrong: requests=%d tokens=%+v", stop.Requests, stop.Tokens)
+	}
+	if stop.USD == nil || stop.USD.Total <= 0 {
+		t.Errorf("usd = %+v, want > 0 for priced models", stop.USD)
+	}
+	if stop.Model != "claude-opus-4-8" {
+		t.Errorf("model = %q, want the costliest", stop.Model)
+	}
+
+	// State entry consumed: a repeated Stop degrades gracefully (no join).
+	payload, _ = e.Enrich(&Context{
+		Tool: "claude-code", HookEvent: "SubagentStop", SessionID: "sub-sess",
+		RawEvent: map[string]interface{}{"agent_id": "a1", "agent_type": ""},
+	})
+	if payload.(*SubagentEnrichment).AgentType != "" {
+		t.Error("state entry should have been consumed by the first Stop")
+	}
+}
+
+func TestToolsEnricher_Shapes(t *testing.T) {
+	e := toolsEnricher{}
+
+	// Single PostToolUse.
+	payload, err := e.Enrich(&Context{
+		Tool: "claude-code", HookEvent: "PostToolUse",
+		RawEvent: map[string]interface{}{
+			"tool_name": "Bash", "duration_ms": float64(1500),
+			"tool_input":    map[string]interface{}{"command": "SECRET must not leak"},
+			"tool_response": map[string]interface{}{"stdout": "ok"},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	single := payload.(*ToolsEnrichment)
+	if single.Total != 1 || single.Failed != 0 || single.Calls[0].Name != "Bash" || single.Calls[0].DurationMs != 1500 {
+		t.Errorf("single = %+v", single)
+	}
+
+	// Privacy: serialized slug must not contain tool inputs.
+	data, _ := json.Marshal(single)
+	if strings.Contains(string(data), "SECRET") {
+		t.Fatalf("tool_input leaked into tools slug: %s", data)
+	}
+
+	// Failure event.
+	payload, _ = e.Enrich(&Context{
+		Tool: "claude-code", HookEvent: "PostToolUseFailure",
+		RawEvent: map[string]interface{}{"tool_name": "Bash", "tool_response": nil},
+	})
+	if fail := payload.(*ToolsEnrichment); fail.Failed != 1 || fail.Calls[0].OK {
+		t.Errorf("failure = %+v", fail)
+	}
+
+	// Batch with MCP, Skill, and a subagent call (+ one is_error response).
+	payload, _ = e.Enrich(&Context{
+		Tool: "claude-code", HookEvent: "PostToolBatch",
+		RawEvent: map[string]interface{}{
+			"tool_calls": []interface{}{
+				map[string]interface{}{"tool_name": "mcp__stripe__create_customer", "tool_response": map[string]interface{}{}},
+				map[string]interface{}{"tool_name": "Skill", "tool_input": map[string]interface{}{"skill": "schedule"}},
+				map[string]interface{}{"tool_name": "Agent", "tool_response": map[string]interface{}{"agentType": "Explore", "totalDurationMs": float64(41000)}},
+				map[string]interface{}{"tool_name": "Read", "tool_response": map[string]interface{}{"is_error": true}},
+			},
+		},
+	})
+	batch := payload.(*ToolsEnrichment)
+	if batch.Total != 4 || batch.Failed != 1 {
+		t.Fatalf("batch = %+v", batch)
+	}
+	if batch.Calls[0].MCPServer != "stripe" {
+		t.Errorf("mcp_server = %q", batch.Calls[0].MCPServer)
+	}
+	if batch.Calls[1].Skill != "schedule" {
+		t.Errorf("skill = %q", batch.Calls[1].Skill)
+	}
+	if batch.Calls[2].AgentType != "Explore" || batch.Calls[2].DurationMs != 41000 {
+		t.Errorf("agent call = %+v", batch.Calls[2])
+	}
+	if batch.Calls[3].OK {
+		t.Error("is_error response must mark the call failed")
+	}
+}
+
+func TestOSVersionParsers(t *testing.T) {
+	plist := []byte(`<dict><key>ProductName</key><string>macOS</string>
+<key>ProductVersion</key>
+<string>26.1</string></dict>`)
+	if got := osVersionFromPlist(plist); got != "26.1" {
+		t.Errorf("plist version = %q", got)
+	}
+	if got := osVersionFromPlist([]byte("<dict></dict>")); got != "" {
+		t.Errorf("missing key should yield empty, got %q", got)
+	}
+
+	osRelease := []byte("NAME=\"Ubuntu\"\nPRETTY_NAME=\"Ubuntu 24.04.1 LTS\"\nVERSION_ID=\"24.04\"\n")
+	if got := osVersionFromOSRelease(osRelease); got != "Ubuntu 24.04.1 LTS" {
+		t.Errorf("os-release = %q", got)
+	}
+	if got := osVersionFromOSRelease([]byte("VERSION_ID=\"12\"\n")); got != "12" {
+		t.Errorf("version_id fallback = %q", got)
 	}
 }

--- a/internal/enrich/env.go
+++ b/internal/enrich/env.go
@@ -2,15 +2,20 @@ package enrich
 
 import (
 	"os"
+	"regexp"
 	"runtime"
+	"strings"
 )
 
 // EnvEnrichment is the "env" slug: where the event was produced.
 type EnvEnrichment struct {
 	Host string `json:"host,omitempty"` // machine hostname (best-effort)
 	OS   string `json:"os,omitempty"`   // runtime.GOOS
-	Arch string `json:"arch,omitempty"` // runtime.GOARCH
-	Cwd  string `json:"cwd,omitempty"`  // tool-reported working directory
+	// OSVersion is the human OS release (e.g. "26.1" on macOS, the
+	// PRETTY_NAME on Linux). Best-effort file read; omitted when unknown.
+	OSVersion string `json:"os_version,omitempty"`
+	Arch      string `json:"arch,omitempty"` // runtime.GOARCH
+	Cwd       string `json:"cwd,omitempty"`  // tool-reported working directory
 }
 
 type envEnricher struct{}
@@ -23,9 +28,62 @@ func (envEnricher) Applies(ctx *Context) bool { return true }
 func (envEnricher) Enrich(ctx *Context) (any, error) {
 	host, _ := os.Hostname()
 	return EnvEnrichment{
-		Host: host,
-		OS:   runtime.GOOS,
-		Arch: runtime.GOARCH,
-		Cwd:  ctx.Cwd,
+		Host:      host,
+		OS:        runtime.GOOS,
+		OSVersion: osVersion(),
+		Arch:      runtime.GOARCH,
+		Cwd:       ctx.Cwd,
 	}, nil
+}
+
+// osVersion reads the OS release from the platform's version file — a plain
+// file read on the hook's hot path, no subprocess. Returns "" when unknown.
+func osVersion() string {
+	switch runtime.GOOS {
+	case "darwin":
+		data, err := os.ReadFile("/System/Library/CoreServices/SystemVersion.plist")
+		if err != nil {
+			return ""
+		}
+		return osVersionFromPlist(data)
+	case "linux":
+		data, err := os.ReadFile("/etc/os-release")
+		if err != nil {
+			return ""
+		}
+		return osVersionFromOSRelease(data)
+	}
+	return ""
+}
+
+var productVersionRE = regexp.MustCompile(`<key>ProductVersion</key>\s*<string>([^<]+)</string>`)
+
+// osVersionFromPlist pulls ProductVersion out of macOS's SystemVersion.plist.
+func osVersionFromPlist(data []byte) string {
+	if m := productVersionRE.FindSubmatch(data); m != nil {
+		return string(m[1])
+	}
+	return ""
+}
+
+// osVersionFromOSRelease prefers PRETTY_NAME ("Ubuntu 24.04.1 LTS"), falling
+// back to VERSION_ID, from /etc/os-release.
+func osVersionFromOSRelease(data []byte) string {
+	var versionID string
+	for _, line := range strings.Split(string(data), "\n") {
+		key, value, found := strings.Cut(strings.TrimSpace(line), "=")
+		if !found {
+			continue
+		}
+		value = strings.Trim(value, `"`)
+		switch key {
+		case "PRETTY_NAME":
+			if value != "" {
+				return value
+			}
+		case "VERSION_ID":
+			versionID = value
+		}
+	}
+	return versionID
 }

--- a/internal/enrich/state.go
+++ b/internal/enrich/state.go
@@ -12,13 +12,22 @@ import (
 )
 
 // sessionState is the tiny per-session scratchpad some enrichers need across
-// hook fires: the running prompt count and how far into the transcript the
-// cost enricher has already priced. One JSON file per session under
+// hook fires: the running prompt count, how far into the transcript the cost
+// enricher has already priced, and the currently-open subagents (so
+// SubagentStop can recover the type and duration that only SubagentStart
+// carries). One JSON file per session under
 // ~/.config/promptconduit/enrich/sessions/, GC'd by mtime like the
 // correlation store.
 type sessionState struct {
-	PromptCount      int   `json:"prompt_count,omitempty"`
-	TranscriptOffset int64 `json:"transcript_offset,omitempty"`
+	PromptCount      int                     `json:"prompt_count,omitempty"`
+	TranscriptOffset int64                   `json:"transcript_offset,omitempty"`
+	Subagents        map[string]subagentInfo `json:"subagents,omitempty"`
+}
+
+// subagentInfo is what SubagentStart records for the matching SubagentStop.
+type subagentInfo struct {
+	Type      string `json:"type,omitempty"`
+	StartedAt string `json:"started_at"`
 }
 
 const (

--- a/internal/enrich/subagent.go
+++ b/internal/enrich/subagent.go
@@ -1,0 +1,167 @@
+package enrich
+
+import (
+	"bufio"
+	"os"
+	"time"
+
+	"github.com/promptconduit/cli/internal/cost"
+)
+
+// SubagentEnrichment is the "subagent" slug, attached to SubagentStart and
+// SubagentStop events. Identity and parallelism come from the hook payloads;
+// type and duration require joining Stop back to Start (SubagentStop's own
+// agent_type field arrives empty), which the per-session state provides; and
+// tokens/USD come from pricing the subagent's own transcript at Stop with the
+// same engine the cost slug uses. Numbers and identifiers only — no content.
+type SubagentEnrichment struct {
+	AgentID   string `json:"agent_id"`
+	AgentType string `json:"agent_type,omitempty"`
+	// Phase is "start" or "stop".
+	Phase string `json:"phase"`
+	// Concurrent (start only): open subagents in this session including this
+	// one — the parallelism signal.
+	Concurrent int `json:"concurrent,omitempty"`
+	// DurationMs (stop only): wall time since the matching SubagentStart.
+	DurationMs int64 `json:"duration_ms,omitempty"`
+	// Requests/Model/Tokens/USD (stop only): summed from the subagent's own
+	// transcript. Model is the costliest one observed.
+	Requests int          `json:"requests,omitempty"`
+	Model    string       `json:"model,omitempty"`
+	Tokens   *cost.Tokens `json:"tokens,omitempty"`
+	USD      *cost.Cost   `json:"usd,omitempty"`
+}
+
+type subagentEnricher struct{}
+
+func init() { Register(subagentEnricher{}) }
+
+func (subagentEnricher) Slug() string { return "subagent" }
+
+func (subagentEnricher) Applies(ctx *Context) bool {
+	if ctx.Tool != "claude-code" {
+		return false
+	}
+	return ctx.HookEvent == "SubagentStart" || ctx.HookEvent == "SubagentStop"
+}
+
+func (subagentEnricher) Enrich(ctx *Context) (any, error) {
+	agentID, _ := ctx.RawEvent["agent_id"].(string)
+	if agentID == "" {
+		return nil, nil
+	}
+	if ctx.HookEvent == "SubagentStart" {
+		return subagentStart(ctx, agentID), nil
+	}
+	return subagentStop(ctx, agentID), nil
+}
+
+func subagentStart(ctx *Context, agentID string) *SubagentEnrichment {
+	agentType, _ := ctx.RawEvent["agent_type"].(string)
+
+	concurrent := 1
+	if ctx.SessionID != "" {
+		st := loadState(ctx.SessionID)
+		if st.Subagents == nil {
+			st.Subagents = map[string]subagentInfo{}
+		}
+		st.Subagents[agentID] = subagentInfo{
+			Type:      agentType,
+			StartedAt: time.Now().UTC().Format(time.RFC3339),
+		}
+		concurrent = len(st.Subagents)
+		saveState(ctx.SessionID, st)
+	}
+
+	return &SubagentEnrichment{
+		AgentID:    agentID,
+		AgentType:  agentType,
+		Phase:      "start",
+		Concurrent: concurrent,
+	}
+}
+
+func subagentStop(ctx *Context, agentID string) *SubagentEnrichment {
+	out := &SubagentEnrichment{AgentID: agentID, Phase: "stop"}
+
+	// SubagentStop's own agent_type is empty in real traffic; recover type and
+	// start time from the state SubagentStart recorded. A missing entry (e.g. a
+	// lost write race between parallel hook processes) degrades gracefully to
+	// whatever the raw payload carries.
+	out.AgentType, _ = ctx.RawEvent["agent_type"].(string)
+	if ctx.SessionID != "" {
+		st := loadState(ctx.SessionID)
+		if info, ok := st.Subagents[agentID]; ok {
+			if info.Type != "" {
+				out.AgentType = info.Type
+			}
+			if started, err := time.Parse(time.RFC3339, info.StartedAt); err == nil {
+				out.DurationMs = time.Since(started).Milliseconds()
+			}
+			delete(st.Subagents, agentID)
+			saveState(ctx.SessionID, st)
+		}
+	}
+
+	// Price the subagent's own transcript (bounded: per-agent transcripts are
+	// small). Best-effort — a missing file or pricing table just omits the
+	// token/USD fields.
+	if path, _ := ctx.RawEvent["agent_transcript_path"].(string); path != "" {
+		sumAgentTranscript(path, out)
+	}
+	return out
+}
+
+// sumAgentTranscript folds every priced request in the subagent transcript
+// into the enrichment: request count, token and dollar totals, and the
+// costliest model.
+func sumAgentTranscript(path string, out *SubagentEnrichment) {
+	table, err := cost.LoadPriceTable()
+	if err != nil {
+		return
+	}
+	f, err := os.Open(path)
+	if err != nil {
+		return
+	}
+	defer func() { _ = f.Close() }()
+
+	var tokens cost.Tokens
+	var usd cost.Cost
+	usd.Currency = cost.Currency
+	modelCost := map[string]float64{}
+	seen := map[string]bool{}
+
+	scanner := bufio.NewScanner(f)
+	scanner.Buffer(make([]byte, 0, 1024*1024), 32*1024*1024)
+	for scanner.Scan() {
+		ev, dedupKey, ok := cost.ParseTranscriptLine(scanner.Bytes(), table, "")
+		if !ok || seen[dedupKey] {
+			continue
+		}
+		seen[dedupKey] = true
+		out.Requests++
+		tokens.Input += ev.Tokens.Input
+		tokens.Output += ev.Tokens.Output
+		tokens.CacheRead += ev.Tokens.CacheRead
+		tokens.CacheWrite += ev.Tokens.CacheWrite
+		usd.Input += ev.Cost.Input
+		usd.Output += ev.Cost.Output
+		usd.CacheRead += ev.Cost.CacheRead
+		usd.CacheWrite += ev.Cost.CacheWrite
+		usd.Total += ev.Cost.Total
+		modelCost[ev.Model] += ev.Cost.Total
+	}
+	if out.Requests == 0 {
+		return
+	}
+	best, bestCost := "", -1.0
+	for m, c := range modelCost {
+		if c > bestCost {
+			best, bestCost = m, c
+		}
+	}
+	out.Model = best
+	out.Tokens = &tokens
+	out.USD = &usd
+}

--- a/internal/enrich/tools.go
+++ b/internal/enrich/tools.go
@@ -1,0 +1,130 @@
+package enrich
+
+import (
+	"regexp"
+	"strings"
+)
+
+// ToolsEnrichment is the "tools" slug, attached to tool-result events
+// (PostToolUse, PostToolUseFailure, PostToolBatch). It normalizes Claude
+// Code's single-call and batched shapes into one flat list so readers stop
+// re-deriving tool metrics from tool-specific raw payloads.
+//
+// Privacy invariant (load-bearing — this ships in a public repo): calls carry
+// NAMES and NUMBERS only, never tool_input contents. The one exception is the
+// invoked SKILL.md name, matching the existing coaching extraction.
+type ToolsEnrichment struct {
+	Total  int        `json:"total"`
+	Failed int        `json:"failed"`
+	Calls  []ToolCall `json:"calls"`
+}
+
+// ToolCall is one normalized tool invocation.
+type ToolCall struct {
+	Name string `json:"name"`
+	OK   bool   `json:"ok"`
+	// DurationMs from the single-call top-level field, or the Agent/Task
+	// tool_response's totalDurationMs.
+	DurationMs int64 `json:"duration_ms,omitempty"`
+	// MCPServer is the <server> of an mcp__<server>__<tool> name.
+	MCPServer string `json:"mcp_server,omitempty"`
+	// Skill is the invoked SKILL.md name when Name == "Skill".
+	Skill string `json:"skill,omitempty"`
+	// AgentType for Agent/Task subagent-spawning calls (tool_response.agentType).
+	AgentType string `json:"agent_type,omitempty"`
+}
+
+var mcpNameRE = regexp.MustCompile(`^mcp__(.+?)__`)
+
+type toolsEnricher struct{}
+
+func init() { Register(toolsEnricher{}) }
+
+func (toolsEnricher) Slug() string { return "tools" }
+
+func (toolsEnricher) Applies(ctx *Context) bool {
+	if ctx.Tool != "claude-code" {
+		return false
+	}
+	switch ctx.HookEvent {
+	case "PostToolUse", "PostToolUseFailure", "PostToolBatch":
+		return true
+	}
+	return false
+}
+
+func (toolsEnricher) Enrich(ctx *Context) (any, error) {
+	failed := ctx.HookEvent == "PostToolUseFailure"
+
+	var calls []ToolCall
+	if ctx.HookEvent == "PostToolBatch" {
+		raw, _ := ctx.RawEvent["tool_calls"].([]interface{})
+		for _, c := range raw {
+			if m, ok := c.(map[string]interface{}); ok {
+				if call, ok := normalizeCall(m, false); ok {
+					calls = append(calls, call)
+				}
+			}
+		}
+	} else if call, ok := normalizeCall(ctx.RawEvent, failed); ok {
+		calls = append(calls, call)
+	}
+	if len(calls) == 0 {
+		return nil, nil
+	}
+
+	out := &ToolsEnrichment{Total: len(calls), Calls: calls}
+	for _, c := range calls {
+		if !c.OK {
+			out.Failed++
+		}
+	}
+	return out, nil
+}
+
+// normalizeCall maps one raw call (a PostToolBatch element, or the event's own
+// top-level fields for the single-call shapes) into a ToolCall.
+func normalizeCall(m map[string]interface{}, failed bool) (ToolCall, bool) {
+	name, _ := m["tool_name"].(string)
+	if name == "" {
+		return ToolCall{}, false
+	}
+	resp, _ := m["tool_response"].(map[string]interface{})
+
+	call := ToolCall{
+		Name: name,
+		OK:   !failed && !responseIsError(resp),
+	}
+	if d, ok := m["duration_ms"].(float64); ok {
+		call.DurationMs = int64(d)
+	}
+	if s := mcpNameRE.FindStringSubmatch(name); s != nil {
+		call.MCPServer = s[1]
+	}
+	input, _ := m["tool_input"].(map[string]interface{})
+	if name == "Skill" {
+		if skill, ok := input["skill"].(string); ok && strings.TrimSpace(skill) != "" {
+			call.Skill = skill
+		}
+	}
+	if name == "Agent" || name == "Task" {
+		if at, ok := resp["agentType"].(string); ok {
+			call.AgentType = at
+		} else if at, ok := input["subagent_type"].(string); ok {
+			call.AgentType = at
+		}
+		if d, ok := resp["totalDurationMs"].(float64); ok && call.DurationMs == 0 {
+			call.DurationMs = int64(d)
+		}
+	}
+	return call, true
+}
+
+// responseIsError mirrors the shared rule (extension coaching + platform
+// ingest): a tool_response with is_error / isError / interrupted true failed.
+func responseIsError(resp map[string]interface{}) bool {
+	if resp == nil {
+		return false
+	}
+	return resp["is_error"] == true || resp["isError"] == true || resp["interrupted"] == true
+}

--- a/internal/git/context.go
+++ b/internal/git/context.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"os/exec"
 	"path/filepath"
+	"regexp"
 	"strconv"
 	"strings"
 	"time"
@@ -188,6 +189,35 @@ func DefaultBranch(workingDir string) string {
 		return strings.TrimPrefix(ref, prefix)
 	}
 	return ""
+}
+
+// diffShortstatRE parses `git diff --shortstat` output, whose insertion and
+// deletion clauses are each optional:
+//
+//	" 3 files changed, 120 insertions(+), 40 deletions(-)"
+var diffShortstatRE = regexp.MustCompile(`(\d+) files? changed(?:, (\d+) insertions?\(\+\))?(?:, (\d+) deletions?\(-\))?`)
+
+// DiffShortstat returns the working-tree change counts vs HEAD (staged +
+// unstaged). ok is false when workingDir isn't a git repo or git failed; a
+// clean tree returns (0, 0, 0, true).
+func DiffShortstat(workingDir string) (files, insertions, deletions int, ok bool) {
+	// Distinguish "clean tree" (empty output, success) from "not a repo"
+	// (command failure, also empty via runGitCmd) with an explicit repo check.
+	if runGitCmd(workingDir, "rev-parse", "--git-dir") == "" {
+		return 0, 0, 0, false
+	}
+	out := runGitCmd(workingDir, "diff", "HEAD", "--shortstat")
+	if out == "" {
+		return 0, 0, 0, true // clean tree (or unborn HEAD — treat as no changes)
+	}
+	m := diffShortstatRE.FindStringSubmatch(out)
+	if m == nil {
+		return 0, 0, 0, false
+	}
+	files, _ = strconv.Atoi(m[1])
+	insertions, _ = strconv.Atoi(m[2])
+	deletions, _ = strconv.Atoi(m[3])
+	return files, insertions, deletions, true
 }
 
 // GetRepoName extracts repository name from path or git remote

--- a/internal/git/diff_test.go
+++ b/internal/git/diff_test.go
@@ -1,0 +1,51 @@
+package git
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+)
+
+func TestDiffShortstat(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+	dir := t.TempDir()
+	run := func(args ...string) {
+		cmd := exec.Command("git", args...)
+		cmd.Dir = dir
+		cmd.Env = append(os.Environ(),
+			"GIT_AUTHOR_NAME=t", "GIT_AUTHOR_EMAIL=t@t", "GIT_COMMITTER_NAME=t", "GIT_COMMITTER_EMAIL=t@t")
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v\n%s", args, err, out)
+		}
+	}
+	run("init", "-q")
+	file := filepath.Join(dir, "a.txt")
+	if err := os.WriteFile(file, []byte("one\ntwo\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	run("add", ".")
+	run("commit", "-q", "-m", "init")
+
+	// Clean tree.
+	files, ins, del, ok := DiffShortstat(dir)
+	if !ok || files != 0 || ins != 0 || del != 0 {
+		t.Fatalf("clean tree = %d/%d/%d ok=%v, want zeros/true", files, ins, del, ok)
+	}
+
+	// Modify: one line changed becomes 1 insertion + 1 deletion, plus one added line.
+	if err := os.WriteFile(file, []byte("one\nTWO\nthree\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	files, ins, del, ok = DiffShortstat(dir)
+	if !ok || files != 1 || ins != 2 || del != 1 {
+		t.Fatalf("dirty tree = %d/%d/%d ok=%v, want 1/2/1/true", files, ins, del, ok)
+	}
+
+	// Not a repo.
+	if _, _, _, notRepoOK := DiffShortstat(t.TempDir()); notRepoOK {
+		t.Fatal("non-repo must return ok=false")
+	}
+}


### PR DESCRIPTION
## Summary

Round-2 enrichment slugs, following the `internal/enrich` registry pattern from #100. Closes #101. All additive — readers ignore unknown slugs, no coordinated release required.

- **`subagent`** (SubagentStart/Stop): Start records agent type + start time in per-session state (real SubagentStop payloads carry an EMPTY `agent_type`, so the join is required) and reports `concurrent` parallelism; Stop joins for type + `duration_ms` and prices the subagent's own transcript (`agent_transcript_path` + the existing cost engine) into per-agent `requests`/`tokens`/`usd` + costliest `model` — "Explore ran 2s, 21.7k tokens, $0.024"
- **`tools`** (PostToolUse/Failure/Batch): one normalized call list — `{name, ok, duration_ms, mcp_server?, skill?, agent_type?}` + total/failed. Names and numbers only, never tool inputs (privacy test included)
- **`diff`** (Stop/SessionEnd): `git diff HEAD --shortstat` → `{files_changed, insertions, deletions}` via new `git.DiffShortstat`; ties session cost to output
- **`env.os_version`**: macOS `SystemVersion.plist` / linux `/etc/os-release`, plain file reads

Deferred siblings tracked in #103 (editor), #104 (context); consumers in editor-extension#53; platform types mirror in a paired platform PR.

## Test plan
- `go test ./...` green (new subagent/tools/os-version/DiffShortstat tests incl. state-join, dedup, privacy-leak assertions)
- Live-verified in a sandboxed HOME: Start→Stop join recovered type + duration and priced the agent transcript; batch tools normalized with mcp_server/skill/failed; diff matched the real working tree; os_version 26.3

🤖 Generated with [Claude Code](https://claude.com/claude-code)