### PR TITLE
feat(enrich): turn, permission slugs + prompt.is_interrupt

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,7 +53,7 @@ to what's POSTed to `/v1/events/raw` and stored in the platform bucket.
   "cli_version": "…",
   "raw_event": { /* native hook payload, untouched */ },
   "enrichments": { "env": {…}, "trace": {…}, "vcs": {…}, "prompt": {…}, "cost": {…},
-                   "tools": {…}, "diff": {…}, "subagent": {…} }
+                   "tools": {…}, "diff": {…}, "subagent": {…}, "turn": {…}, "permission": {…} }
 }
 ```
 
@@ -63,7 +63,10 @@ git repos) · `prompt` (count/shape, UserPromptSubmit) · `cost` (priced
 requests, Stop / cursor stop) · `tools` (normalized tool-call list,
 PostToolUse/Failure/Batch) · `diff` (working-tree shortstat vs HEAD,
 Stop/SessionEnd) · `subagent` (Start/Stop join with duration + per-agent
-tokens/USD from the agent transcript, SubagentStart/Stop).
+tokens/USD from the agent transcript, SubagentStart/Stop) · `turn`
+(prompt→Stop wall-clock, Stop/StopFailure) · `permission`
+(requested/denied + tool name, PermissionRequest/Denied). `prompt` also
+carries `is_interrupt` (turn-open rule computed at the source).
 
 **Adding an enrichment** = one new file in `internal/enrich/` implementing
 `Enricher` (Slug/Applies/Enrich) plus `Register()` in its `init()`. Rules:

--- a/internal/enrich/enrich_test.go
+++ b/internal/enrich/enrich_test.go
@@ -375,3 +375,102 @@ func TestOSVersionParsers(t *testing.T) {
 		t.Errorf("version_id fallback = %q", got)
 	}
 }
+
+func TestTurnAndInterrupt_Lifecycle(t *testing.T) {
+	SetStateDirForTest(t.TempDir())
+	t.Cleanup(func() { SetStateDirForTest("") })
+
+	sess := "turn-sess"
+	pe := promptEnricher{}
+	te := turnEnricher{}
+	promptCtx := func() *Context {
+		return &Context{
+			Tool: "claude-code", HookEvent: "UserPromptSubmit", SessionID: sess,
+			RawEvent: map[string]interface{}{"prompt": "do the thing"},
+		}
+	}
+	stopCtx := func() *Context {
+		return &Context{
+			Tool: "claude-code", HookEvent: "Stop", SessionID: sess, PromptID: "p-9",
+			RawEvent: map[string]interface{}{},
+		}
+	}
+
+	// Prompt 1 opens a turn: not an interrupt.
+	payload, err := pe.Enrich(promptCtx())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if payload.(PromptEnrichment).IsInterrupt {
+		t.Error("first prompt must not be an interrupt")
+	}
+
+	// Prompt 2 before any Stop: interrupt.
+	payload, _ = pe.Enrich(promptCtx())
+	if !payload.(PromptEnrichment).IsInterrupt {
+		t.Error("prompt during an open turn must be an interrupt")
+	}
+
+	// Stop closes the turn and reports its duration + prompt id.
+	if !te.Applies(stopCtx()) {
+		t.Fatal("turn enricher must apply to Stop")
+	}
+	payload, err = te.Enrich(stopCtx())
+	if err != nil {
+		t.Fatal(err)
+	}
+	turn := payload.(TurnEnrichment)
+	if turn.DurationMs < 0 || turn.PromptID != "p-9" {
+		t.Errorf("turn = %+v", turn)
+	}
+
+	// Turn consumed: a second Stop emits nothing…
+	payload, _ = te.Enrich(stopCtx())
+	if payload != nil {
+		t.Errorf("closed turn should not re-emit, got %+v", payload)
+	}
+	// …and the next prompt is clean again.
+	payload, _ = pe.Enrich(promptCtx())
+	if payload.(PromptEnrichment).IsInterrupt {
+		t.Error("prompt after Stop must not be an interrupt")
+	}
+}
+
+func TestPermissionEnricher(t *testing.T) {
+	e := permissionEnricher{}
+
+	payload, err := e.Enrich(&Context{
+		Tool: "claude-code", HookEvent: "PermissionRequest",
+		RawEvent: map[string]interface{}{
+			"tool_name":  "Bash",
+			"tool_input": map[string]interface{}{"command": "SECRET"},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	req := payload.(PermissionEnrichment)
+	if req.Decision != "requested" || req.ToolName != "Bash" {
+		t.Errorf("request = %+v", req)
+	}
+	data, _ := json.Marshal(req)
+	if strings.Contains(string(data), "SECRET") {
+		t.Fatalf("tool_input leaked into permission slug: %s", data)
+	}
+
+	payload, _ = e.Enrich(&Context{
+		Tool: "claude-code", HookEvent: "PermissionDenied",
+		RawEvent: map[string]interface{}{
+			"tool_name": "mcp__stripe__create_customer",
+			"reason":    "policy says no",
+		},
+	})
+	den := payload.(PermissionEnrichment)
+	if den.Decision != "denied" || den.MCPServer != "stripe" {
+		t.Errorf("denied = %+v", den)
+	}
+	data, _ = json.Marshal(den)
+	if strings.Contains(string(data), "policy says no") {
+		t.Fatalf("denial reason leaked into permission slug: %s", data)
+	}
+}

--- a/internal/enrich/permission.go
+++ b/internal/enrich/permission.go
@@ -1,0 +1,40 @@
+package enrich
+
+// PermissionEnrichment is the "permission" slug, attached to
+// PermissionRequest / PermissionDenied events: the permission-friction
+// signal. A high request rate is the "add allowlist rules" coaching insight;
+// denials mark policy blocks. Tool names only — the payload's tool_input and
+// denial reason can carry content and are deliberately excluded.
+type PermissionEnrichment struct {
+	// Decision is "requested" (PermissionRequest) or "denied" (PermissionDenied).
+	Decision string `json:"decision"`
+	ToolName string `json:"tool_name,omitempty"`
+	// MCPServer is the <server> of an mcp__<server>__<tool> tool name.
+	MCPServer string `json:"mcp_server,omitempty"`
+}
+
+type permissionEnricher struct{}
+
+func init() { Register(permissionEnricher{}) }
+
+func (permissionEnricher) Slug() string { return "permission" }
+
+func (permissionEnricher) Applies(ctx *Context) bool {
+	if ctx.Tool != "claude-code" {
+		return false
+	}
+	return ctx.HookEvent == "PermissionRequest" || ctx.HookEvent == "PermissionDenied"
+}
+
+func (permissionEnricher) Enrich(ctx *Context) (any, error) {
+	decision := "requested"
+	if ctx.HookEvent == "PermissionDenied" {
+		decision = "denied"
+	}
+	out := PermissionEnrichment{Decision: decision}
+	out.ToolName, _ = ctx.RawEvent["tool_name"].(string)
+	if m := mcpNameRE.FindStringSubmatch(out.ToolName); m != nil {
+		out.MCPServer = m[1]
+	}
+	return out, nil
+}

--- a/internal/enrich/prompt.go
+++ b/internal/enrich/prompt.go
@@ -1,6 +1,9 @@
 package enrich
 
-import "strings"
+import (
+	"strings"
+	"time"
+)
 
 // PromptEnrichment is the "prompt" slug, attached to prompt-submission events:
 // shape metrics about the prompt, never its content.
@@ -12,6 +15,10 @@ type PromptEnrichment struct {
 	Words int `json:"words"`
 	// HasAttachments is true when the message carried attachments.
 	HasAttachments bool `json:"has_attachments,omitempty"`
+	// IsInterrupt is true when this prompt arrived while the previous turn was
+	// still open (no Stop yet) — the same turn-open rule the platform and the
+	// extension coaching apply, computed once at the source.
+	IsInterrupt bool `json:"is_interrupt,omitempty"`
 }
 
 type promptEnricher struct{}
@@ -28,10 +35,15 @@ func (promptEnricher) Enrich(ctx *Context) (any, error) {
 	prompt, _ := ctx.RawEvent["prompt"].(string)
 
 	count := 1
+	isInterrupt := false
 	if ctx.SessionID != "" {
 		st := loadState(ctx.SessionID)
 		st.PromptCount++
 		count = st.PromptCount
+		// A still-open turn (no Stop since the last prompt) means this prompt
+		// interrupted it. Read before opening the new turn.
+		isInterrupt = st.TurnStartedAt != ""
+		st.TurnStartedAt = time.Now().UTC().Format(time.RFC3339)
 		saveState(ctx.SessionID, st)
 	}
 
@@ -45,5 +57,6 @@ func (promptEnricher) Enrich(ctx *Context) (any, error) {
 		Chars:          len([]rune(prompt)),
 		Words:          len(strings.Fields(prompt)),
 		HasAttachments: hasAttachments,
+		IsInterrupt:    isInterrupt,
 	}, nil
 }

--- a/internal/enrich/state.go
+++ b/internal/enrich/state.go
@@ -22,6 +22,10 @@ type sessionState struct {
 	PromptCount      int                     `json:"prompt_count,omitempty"`
 	TranscriptOffset int64                   `json:"transcript_offset,omitempty"`
 	Subagents        map[string]subagentInfo `json:"subagents,omitempty"`
+	// TurnStartedAt is the RFC3339 time of the last UserPromptSubmit; non-empty
+	// means a turn is OPEN (no Stop yet). The prompt enricher sets it (and reads
+	// it first for is_interrupt); the turn enricher consumes it at Stop.
+	TurnStartedAt string `json:"turn_started_at,omitempty"`
 }
 
 // subagentInfo is what SubagentStart records for the matching SubagentStop.

--- a/internal/enrich/turn.go
+++ b/internal/enrich/turn.go
@@ -1,0 +1,52 @@
+package enrich
+
+import "time"
+
+// TurnEnrichment is the "turn" slug, attached to turn-close events (Stop,
+// StopFailure): how long the turn took, wall-clock, from the prompt that
+// opened it. Combined with the cost and diff slugs on the same event this
+// completes the headline metric — "this turn took 4m, cost $0.31, changed
+// +120/−40".
+//
+// The turn clock starts at UserPromptSubmit (recorded by the prompt enricher
+// in the per-session state). An interrupting prompt restarts the clock, so an
+// interrupted turn's duration measures from its LAST prompt.
+type TurnEnrichment struct {
+	DurationMs int64 `json:"duration_ms"`
+	// PromptID of the prompt that closed with this Stop (from the envelope).
+	PromptID string `json:"prompt_id,omitempty"`
+}
+
+type turnEnricher struct{}
+
+func init() { Register(turnEnricher{}) }
+
+func (turnEnricher) Slug() string { return "turn" }
+
+func (turnEnricher) Applies(ctx *Context) bool {
+	if ctx.Tool != "claude-code" || ctx.SessionID == "" {
+		return false
+	}
+	return ctx.HookEvent == "Stop" || ctx.HookEvent == "StopFailure"
+}
+
+func (turnEnricher) Enrich(ctx *Context) (any, error) {
+	st := loadState(ctx.SessionID)
+	if st.TurnStartedAt == "" {
+		return nil, nil // no open turn (e.g. Stop after a fresh install)
+	}
+	started, err := time.Parse(time.RFC3339, st.TurnStartedAt)
+
+	// Close the turn regardless — a corrupt timestamp must not leave the turn
+	// permanently open (which would mark every future prompt an interrupt).
+	st.TurnStartedAt = ""
+	saveState(ctx.SessionID, st)
+
+	if err != nil {
+		return nil, nil
+	}
+	return TurnEnrichment{
+		DurationMs: time.Since(started).Milliseconds(),
+		PromptID:   ctx.PromptID,
+	}, nil
+}


### PR DESCRIPTION
## Summary

Round-3 enrichment slugs (follows #105; same `internal/enrich` registry pattern, all additive):

- **`turn`** (Stop/StopFailure): prompt→Stop wall-clock — `{duration_ms, prompt_id}`. The clock starts at UserPromptSubmit via the shared per-session state; an interrupting prompt restarts it. With `cost` + `diff` on the same event this completes the headline metric: *time, dollars, output*.
- **`prompt.is_interrupt`**: the turn-open interruption rule computed once at the source (prompt arrives before the previous turn's Stop). Platform ingest (D1 lookback) and extension coaching (local state machine) currently each re-derive this; they can now trust the flag.
- **`permission`** (PermissionRequest/PermissionDenied): friction signal — `{decision: requested|denied, tool_name, mcp_server?}`. `tool_input` and the denial `reason` are deliberately excluded (content); tests assert no leakage.

## Test plan
- `go test ./...` green (lifecycle test: prompt→interrupt→Stop→clean-again; permission privacy assertions)
- Live-verified in a sandboxed HOME: prompt 1 clean → prompt 2 `is_interrupt:true` → PermissionRequest `{requested, Bash}` with no command leaked → Stop `turn {duration_ms:1220, prompt_id:pp-2}`

🤖 Generated with [Claude Code](https://claude.com/claude-code)