### PR TITLE
feat: configurable time-based retention for local hook history

### DIFF
--- a/cmd/config.go
+++ b/cmd/config.go
@@ -49,6 +49,11 @@ var configShowCmd = &cobra.Command{
 			eventLog = "disabled"
 		}
 		cmd.Printf("Event log:   %s\n", eventLog)
+		if cfg.RetentionDays() == 0 {
+			cmd.Printf("Retention:   keep forever\n")
+		} else {
+			cmd.Printf("Retention:   %d days of local hook history\n", cfg.RetentionDays())
+		}
 		// Effective mode: Free / local-only (nothing sent) vs cloud sync. This
 		// reflects ShouldSend, so "no API key" also reads as local-only.
 		mode := "cloud sync"
@@ -80,12 +85,13 @@ var configShowCmd = &cobra.Command{
 }
 
 var (
-	setAPIKey            string
-	setAPIURL            string
-	setDebug             bool
-	setDisableAutoUpdate bool
-	setDisableEventLog   bool
-	setLocalOnly         bool
+	setAPIKey                string
+	setAPIURL                string
+	setDebug                 bool
+	setDisableAutoUpdate     bool
+	setDisableEventLog       bool
+	setLocalOnly             bool
+	setEventLogRetentionDays int
 )
 
 var configSetCmd = &cobra.Command{
@@ -116,7 +122,13 @@ Examples:
   promptconduit config set --local-only=true
 
   # Re-enable cloud sync (events sent when an API key is set)
-  promptconduit config set --local-only=false`,
+  promptconduit config set --local-only=false
+
+  # Keep 90 days of local hook history (default is 30)
+  promptconduit config set --event-log-retention-days=90
+
+  # Never prune local hook history
+  promptconduit config set --event-log-retention-days=-1`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		fc, err := client.LoadFileConfig()
 		if err != nil {
@@ -153,9 +165,13 @@ Examples:
 			fc.LocalOnly = setLocalOnly
 			changed = true
 		}
+		if cmd.Flags().Changed("event-log-retention-days") {
+			fc.EventLogRetentionDays = setEventLogRetentionDays
+			changed = true
+		}
 
 		if !changed {
-			return fmt.Errorf("no values provided. Use --api-key, --api-url, --debug, --disable-auto-update, --disable-event-log, or --local-only")
+			return fmt.Errorf("no values provided. Use --api-key, --api-url, --debug, --disable-auto-update, --disable-event-log, --local-only, or --event-log-retention-days")
 		}
 
 		if err := client.SaveFileConfig(fc); err != nil {
@@ -191,6 +207,13 @@ Examples:
 				cmd.Printf("  Mode:        local-only (Free) — events captured locally, nothing sent\n")
 			} else {
 				cmd.Printf("  Mode:        cloud sync — events sent when an API key is set\n")
+			}
+		}
+		if cmd.Flags().Changed("event-log-retention-days") {
+			if fc.EventLogRetentionDays < 0 {
+				cmd.Printf("  Retention:   keep forever (local hook history never pruned)\n")
+			} else {
+				cmd.Printf("  Retention:   %d days of local hook history\n", (&client.Config{EventLogRetentionDays: fc.EventLogRetentionDays}).RetentionDays())
 			}
 		}
 
@@ -415,6 +438,7 @@ func init() {
 	configSetCmd.Flags().BoolVar(&setDisableAutoUpdate, "disable-auto-update", false, "Disable the background self-upgrade check")
 	configSetCmd.Flags().BoolVar(&setDisableEventLog, "disable-event-log", false, "Disable the local event log written to ~/.promptconduit/")
 	configSetCmd.Flags().BoolVar(&setLocalOnly, "local-only", false, "Free / local-only mode: capture events locally, never send to the cloud")
+	configSetCmd.Flags().IntVar(&setEventLogRetentionDays, "event-log-retention-days", 0, "Days of local hook history to keep (default 30; -1 = keep forever)")
 
 	// Environment subcommands
 	configEnvCmd.AddCommand(configEnvListCmd)

--- a/cmd/events.go
+++ b/cmd/events.go
@@ -34,8 +34,9 @@ sent to the platform.
 
 This reads ~/.promptconduit/events.jsonl — one v2 envelope per line, written at
 capture time for every event, in cloud AND Free/local-only mode (secrets
-scrubbed; the file rotates to events.jsonl.1 at 50MB). Send outcomes are in
-'promptconduit status'; raw HTTP diagnostics in 'promptconduit watch'.
+scrubbed; history is kept for the configured retention window, default 30 days —
+see 'promptconduit prune'). Send outcomes are in 'promptconduit status'; raw
+HTTP diagnostics in 'promptconduit watch'.
 
 By default each event is shown as a one-line summary:
 

--- a/cmd/hook.go
+++ b/cmd/hook.go
@@ -61,6 +61,12 @@ func processHookEvent() error {
 	logger.SetDebug(cfg.Debug)
 	eventlog.SetEnabled(cfg.EventLogEnabled())
 
+	// Opportunistically enforce local hook-history retention. Runs after the
+	// event is captured (deferred); cheap on the hot path — a couple of stats
+	// unless the log has grown past its size ceiling, in which case expired
+	// records (older than the retention window) are trimmed oldest-first.
+	defer eventlog.MaybePrune(cfg.RetentionDays())
+
 	logger.Debug("Hook started")
 
 	// Read raw input from stdin

--- a/cmd/prune.go
+++ b/cmd/prune.go
@@ -1,0 +1,66 @@
+package cmd
+
+import (
+	"github.com/promptconduit/cli/internal/client"
+	"github.com/promptconduit/cli/internal/eventlog"
+	"github.com/spf13/cobra"
+)
+
+var pruneDryRun bool
+
+var pruneCmd = &cobra.Command{
+	Use:   "prune",
+	Short: "Trim local hook history older than the retention window",
+	Long: `Remove locally-captured events older than the configured retention window
+from ~/.promptconduit/events.jsonl (and the hook-events trace).
+
+Events within the retention window are ALWAYS kept — prune can only ever remove
+already-expired data. The window defaults to 30 days and is configurable:
+
+  promptconduit config set --event-log-retention-days=90   # keep 90 days
+  promptconduit config set --event-log-retention-days=-1   # keep forever
+
+The CLI also prunes automatically in the background once the log grows past its
+size ceiling; this command lets you reclaim space on demand.`,
+	SilenceUsage:  true,
+	SilenceErrors: true,
+	RunE:          runPrune,
+}
+
+func init() {
+	pruneCmd.Flags().BoolVar(&pruneDryRun, "dry-run", false, "Report what would be removed without changing any files")
+}
+
+func runPrune(cmd *cobra.Command, args []string) error {
+	cfg := client.LoadConfig()
+	days := cfg.RetentionDays()
+
+	if days == 0 {
+		cmd.Println("Retention: keep forever — local hook history is never pruned.")
+		cmd.Println("Set a window with: promptconduit config set --event-log-retention-days=30")
+		return nil
+	}
+
+	stats := eventlog.Stats(days)
+	cmd.Printf("Retention window: %d days\n", days)
+	cmd.Printf("Event log:        %s (%s)\n", eventlog.EventsJSONLPath(), humanBytes(int(stats.EventsBytes)))
+	cmd.Printf("Events:           %d total, %d older than %d days\n", stats.EventsTotal, stats.EventsExpired, days)
+	if stats.HookTotal > 0 {
+		cmd.Printf("Hook-events:      %d total, %d older than %d days\n", stats.HookTotal, stats.HookExpired, days)
+	}
+
+	expired := stats.EventsExpired + stats.HookExpired
+	if expired == 0 {
+		cmd.Println("\nNothing to prune — all local history is within the retention window.")
+		return nil
+	}
+
+	if pruneDryRun {
+		cmd.Printf("\nDry run: would remove %d expired record(s). Re-run without --dry-run to apply.\n", expired)
+		return nil
+	}
+
+	removed := eventlog.PruneExpired(days)
+	cmd.Printf("\nPruned %d expired record(s) older than %d days.\n", removed, days)
+	return nil
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -61,6 +61,7 @@ func init() {
 	rootCmd.AddCommand(logsCmd)
 	rootCmd.AddCommand(eventsCmd)
 	rootCmd.AddCommand(costCmd)
+	rootCmd.AddCommand(pruneCmd)
 }
 
 var versionCmd = &cobra.Command{

--- a/internal/client/config.go
+++ b/internal/client/config.go
@@ -10,17 +10,21 @@ import (
 const (
 	DefaultAPIURL      = "https://api.promptconduit.dev"
 	DefaultTimeoutSecs = 30
-	EnvAPIKey          = "PROMPTCONDUIT_API_KEY"
-	EnvAPIURL          = "PROMPTCONDUIT_API_URL"
-	EnvDebug           = "PROMPTCONDUIT_DEBUG"
-	EnvTimeout         = "PROMPTCONDUIT_TIMEOUT"
-	EnvTool            = "PROMPTCONDUIT_TOOL"
-	EnvAutoUpdate      = "PROMPTCONDUIT_AUTO_UPDATE" // "0"/"false" disables background self-upgrade
-	EnvEventLog        = "PROMPTCONDUIT_EVENT_LOG"   // "0"/"false" disables the local ~/.promptconduit event log
-	EnvLocalOnly       = "PROMPTCONDUIT_LOCAL_ONLY"  // "1"/"true" forces Free / local-only mode (never send to the cloud)
-	EnvXDGConfigHome   = "XDG_CONFIG_HOME"
-	ConfigDirName      = "promptconduit" // ~/.config/promptconduit/
-	ConfigFileName     = "config.json"
+	// DefaultEventLogRetentionDays is the floor for local hook history: every
+	// event captured in the last N days is kept. Used when retention is unset.
+	DefaultEventLogRetentionDays = 30
+	EnvAPIKey                    = "PROMPTCONDUIT_API_KEY"
+	EnvAPIURL                    = "PROMPTCONDUIT_API_URL"
+	EnvDebug                     = "PROMPTCONDUIT_DEBUG"
+	EnvTimeout                   = "PROMPTCONDUIT_TIMEOUT"
+	EnvTool                      = "PROMPTCONDUIT_TOOL"
+	EnvAutoUpdate                = "PROMPTCONDUIT_AUTO_UPDATE"              // "0"/"false" disables background self-upgrade
+	EnvEventLog                  = "PROMPTCONDUIT_EVENT_LOG"                // "0"/"false" disables the local ~/.promptconduit event log
+	EnvEventLogRetentionDays     = "PROMPTCONDUIT_EVENT_LOG_RETENTION_DAYS" // days of local hook history to keep; -1 keeps forever
+	EnvLocalOnly                 = "PROMPTCONDUIT_LOCAL_ONLY"               // "1"/"true" forces Free / local-only mode (never send to the cloud)
+	EnvXDGConfigHome             = "XDG_CONFIG_HOME"
+	ConfigDirName                = "promptconduit" // ~/.config/promptconduit/
+	ConfigFileName               = "config.json"
 )
 
 // Config holds the client configuration
@@ -40,6 +44,11 @@ type Config struct {
 	// but NEVER sent to the cloud, regardless of whether an API key is set.
 	// Zero value (false) leaves cloud sync enabled (when an API key exists).
 	LocalOnly bool `json:"local_only,omitempty"`
+	// EventLogRetentionDays is how many days of local hook history
+	// (~/.promptconduit/events.jsonl) to keep. Zero/unset means the default
+	// (DefaultEventLogRetentionDays); a negative value keeps history forever
+	// (never prune). Resolve via RetentionDays(), not this field directly.
+	EventLogRetentionDays int `json:"event_log_retention_days,omitempty"`
 }
 
 // FileConfig represents the config file structure with environment support
@@ -51,13 +60,14 @@ type FileConfig struct {
 	Environments map[string]*Config `json:"environments,omitempty"`
 
 	// Legacy flat config (for backwards compatibility)
-	APIKey            string `json:"api_key,omitempty"`
-	APIURL            string `json:"api_url,omitempty"`
-	Debug             bool   `json:"debug,omitempty"`
-	Timeout           int    `json:"timeout_seconds,omitempty"`
-	DisableAutoUpdate bool   `json:"disable_auto_update,omitempty"`
-	DisableEventLog   bool   `json:"disable_event_log,omitempty"`
-	LocalOnly         bool   `json:"local_only,omitempty"`
+	APIKey                string `json:"api_key,omitempty"`
+	APIURL                string `json:"api_url,omitempty"`
+	Debug                 bool   `json:"debug,omitempty"`
+	Timeout               int    `json:"timeout_seconds,omitempty"`
+	DisableAutoUpdate     bool   `json:"disable_auto_update,omitempty"`
+	DisableEventLog       bool   `json:"disable_event_log,omitempty"`
+	LocalOnly             bool   `json:"local_only,omitempty"`
+	EventLogRetentionDays int    `json:"event_log_retention_days,omitempty"`
 }
 
 // EventLogEnabled reports whether the local ~/.promptconduit event log should
@@ -65,6 +75,21 @@ type FileConfig struct {
 // config (disable_event_log) or PROMPTCONDUIT_EVENT_LOG=0.
 func (c *Config) EventLogEnabled() bool {
 	return !c.DisableEventLog
+}
+
+// RetentionDays resolves the effective local hook-history retention window in
+// days. Returns 0 to mean "keep forever" (no pruning): an unset field falls
+// back to DefaultEventLogRetentionDays, and a negative field is the explicit
+// keep-forever opt-out. Any positive value is used as-is.
+func (c *Config) RetentionDays() int {
+	switch {
+	case c.EventLogRetentionDays < 0:
+		return 0 // keep forever
+	case c.EventLogRetentionDays == 0:
+		return DefaultEventLogRetentionDays
+	default:
+		return c.EventLogRetentionDays
+	}
 }
 
 // IsConfigured returns true if the API key is set
@@ -172,20 +197,25 @@ func (fc *FileConfig) GetCurrentConfig() *Config {
 			merged.DisableAutoUpdate = merged.DisableAutoUpdate || fc.DisableAutoUpdate
 			merged.DisableEventLog = merged.DisableEventLog || fc.DisableEventLog
 			merged.LocalOnly = merged.LocalOnly || fc.LocalOnly
+			// Retention is a global default too: use it when the env didn't set one.
+			if merged.EventLogRetentionDays == 0 {
+				merged.EventLogRetentionDays = fc.EventLogRetentionDays
+			}
 			return &merged
 		}
 	}
 
 	// Fall back to legacy flat config
-	if fc.APIKey != "" || fc.APIURL != "" || fc.DisableAutoUpdate || fc.DisableEventLog || fc.LocalOnly {
+	if fc.APIKey != "" || fc.APIURL != "" || fc.DisableAutoUpdate || fc.DisableEventLog || fc.LocalOnly || fc.EventLogRetentionDays != 0 {
 		return &Config{
-			APIKey:            fc.APIKey,
-			APIURL:            fc.APIURL,
-			Debug:             fc.Debug,
-			TimeoutSeconds:    fc.Timeout,
-			DisableAutoUpdate: fc.DisableAutoUpdate,
-			DisableEventLog:   fc.DisableEventLog,
-			LocalOnly:         fc.LocalOnly,
+			APIKey:                fc.APIKey,
+			APIURL:                fc.APIURL,
+			Debug:                 fc.Debug,
+			TimeoutSeconds:        fc.Timeout,
+			DisableAutoUpdate:     fc.DisableAutoUpdate,
+			DisableEventLog:       fc.DisableEventLog,
+			LocalOnly:             fc.LocalOnly,
+			EventLogRetentionDays: fc.EventLogRetentionDays,
 		}
 	}
 
@@ -226,6 +256,9 @@ func LoadConfig() *Config {
 			if fileCfg.LocalOnly {
 				cfg.LocalOnly = true
 			}
+			if fileCfg.EventLogRetentionDays != 0 {
+				cfg.EventLogRetentionDays = fileCfg.EventLogRetentionDays
+			}
 		}
 	}
 
@@ -245,6 +278,14 @@ func LoadConfig() *Config {
 	// anything else (or unset) leaves whatever the file config decided.
 	if v := os.Getenv(EnvLocalOnly); v == "1" || v == "true" || v == "yes" {
 		cfg.LocalOnly = true
+	}
+
+	// PROMPTCONDUIT_EVENT_LOG_RETENTION_DAYS overrides the local hook-history
+	// window (in days); -1 keeps forever. Anything unparseable is ignored.
+	if v := os.Getenv(EnvEventLogRetentionDays); v != "" {
+		if n, err := strconv.Atoi(v); err == nil {
+			cfg.EventLogRetentionDays = n
+		}
 	}
 
 	// Apply defaults

--- a/internal/eventlog/capture.go
+++ b/internal/eventlog/capture.go
@@ -30,7 +30,10 @@ func RecordCapture(payload []byte) {
 	}
 
 	migrateOnce.Do(migrateV1Files)
-	appendLine(EventsJSONLPath(), line, EventsRotateAt)
+	// rotateAt=0: no blind size rotation. Disk is bounded by time-based
+	// retention pruning instead (see prune.go / MaybePrune), which never drops
+	// records inside the retention window.
+	appendLine(EventsJSONLPath(), line, 0)
 }
 
 var migrateOnce sync.Once
@@ -74,7 +77,7 @@ func headIsV1(path string) bool {
 
 // CountCaptured returns the number of events currently in events.jsonl and
 // false if the file doesn't exist yet. Best-effort; reads the whole file, whose
-// size is bounded by rotation (EventsRotateAt).
+// size is bounded by retention pruning (EventsCeiling, see prune.go).
 func CountCaptured() (int, bool) {
 	data, err := os.ReadFile(EventsJSONLPath())
 	if err != nil {

--- a/internal/eventlog/eventlog.go
+++ b/internal/eventlog/eventlog.go
@@ -39,10 +39,11 @@ import (
 	"time"
 )
 
-// EventsRotateAt is the size threshold at which events.jsonl is rotated to
-// events.jsonl.1. Records themselves are never truncated (full fidelity);
-// total disk is bounded by rotation instead. One backup is kept.
-const EventsRotateAt int64 = 50 * 1024 * 1024 // 50 MB
+// events.jsonl is NOT size-rotated: its disk footprint is governed by
+// time-based retention (see prune.go — every record within the retention
+// window is kept, older ones trimmed only past EventsCeiling). Blind size
+// rotation is avoided here precisely because it would discard a whole backup at
+// once, dropping recent data and breaking the "keep at least N days" guarantee.
 
 // ErrorsRotateAt is the (smaller) rotation threshold for the human-readable
 // errors.log — sized like internal/logger so a tail/cat finishes instantly.

--- a/internal/eventlog/prune.go
+++ b/internal/eventlog/prune.go
@@ -1,0 +1,321 @@
+package eventlog
+
+import (
+	"bufio"
+	"crypto/rand"
+	"encoding/binary"
+	"encoding/json"
+	"io"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+// Local hook-history retention.
+//
+// Policy: TIME FLOOR + SIZE CEILING. Every record captured within the
+// retention window (the floor) is kept — this is the "keep all hook history for
+// at least N days" guarantee. Records older than the window are pruned only when
+// a file grows past a generous size CEILING, and then oldest-first among the
+// already-expired records. Data inside the window is never dropped, even if the
+// file exceeds the ceiling. Retention of 0 (or negative) means keep forever.
+//
+// The prune is a full-file atomic rewrite (temp + rename), so it never leaves a
+// half-written log. It runs opportunistically (see MaybePrune) and preserves any
+// lines appended concurrently while it works.
+
+// EventsCeiling is the soft size ceiling for events.jsonl. The retention window
+// always wins: records inside it are kept even past this. Older records are
+// trimmed oldest-first only once the file grows beyond it.
+const EventsCeiling int64 = 500 * 1024 * 1024 // 500 MB
+
+// hookEventsCeiling bounds the lightweight ~/.promptconduit/hook-events status
+// trace (consumed by the macOS menu-bar app), which otherwise grows unbounded.
+const hookEventsCeiling int64 = 20 * 1024 * 1024 // 20 MB
+
+// pruneProbabilityDenominator: MaybePrune runs a full pass ~1/N invocations
+// (plus always when a file is already over its ceiling). Mirrors the
+// correlation store's opportunistic GC so retention costs nothing per event.
+const pruneProbabilityDenominator = 100
+
+// HookEventsPath is the lightweight status trace written by the hook command
+// (~/.promptconduit/hook-events).
+func HookEventsPath() string { return filepath.Join(Dir(), "hook-events") }
+
+// MaybePrune opportunistically enforces retention on the local event files.
+// retentionDays is the effective window; 0 or negative means keep forever (a
+// no-op). It runs a full pass ~1/pruneProbabilityDenominator invocations, but
+// always when a file already exceeds its ceiling, so disk can't run away on an
+// unlucky roll. Best-effort and safe to call on the hook hot path.
+func MaybePrune(retentionDays int) {
+	if retentionDays <= 0 {
+		return
+	}
+	forced := fileOverCeiling(EventsJSONLPath(), EventsCeiling) ||
+		fileOverCeiling(HookEventsPath(), hookEventsCeiling)
+	if !forced && !pruneDiceHit() {
+		return
+	}
+	Prune(retentionDays)
+}
+
+// Prune runs one retention pass over events.jsonl and the hook-events trace.
+// Returns the total number of records removed. Best-effort: a failure on one
+// file never affects the other or the caller.
+func Prune(retentionDays int) int {
+	if retentionDays <= 0 {
+		return 0
+	}
+	cutoff := nowUTC().Add(-time.Duration(retentionDays) * 24 * time.Hour)
+
+	writeMu.Lock()
+	defer writeMu.Unlock()
+
+	removed := pruneFile(EventsJSONLPath(), EventsCeiling, cutoff, envelopeCapturedAt)
+	removed += pruneFile(HookEventsPath(), hookEventsCeiling, cutoff, hookEventTimestamp)
+	return removed
+}
+
+// PruneExpired trims EVERY record older than the retention window right now,
+// from events.jsonl and the hook-events trace, ignoring the size ceiling. It is
+// the explicit "reclaim space" action behind `promptconduit prune`. Records
+// inside the window are always kept (the floor), so it can only ever remove
+// already-expired data. Returns the number of records removed.
+func PruneExpired(retentionDays int) int {
+	if retentionDays <= 0 {
+		return 0
+	}
+	cutoff := nowUTC().Add(-time.Duration(retentionDays) * 24 * time.Hour)
+
+	writeMu.Lock()
+	defer writeMu.Unlock()
+
+	// ceiling 0 forces the trim loop to drop every expired record.
+	removed := pruneFile(EventsJSONLPath(), 0, cutoff, envelopeCapturedAt)
+	removed += pruneFile(HookEventsPath(), 0, cutoff, hookEventTimestamp)
+	return removed
+}
+
+// RetentionStats summarizes local hook history against a retention window.
+type RetentionStats struct {
+	RetentionDays int   // effective window; 0 means keep forever
+	EventsTotal   int   // records in events.jsonl
+	EventsExpired int   // events.jsonl records older than the window
+	EventsBytes   int64 // size of events.jsonl on disk
+	HookTotal     int   // records in the hook-events trace
+	HookExpired   int   // hook-events records older than the window
+}
+
+// Stats reports, read-only, how much local history exists and how much of it is
+// older than the retention window. Used by `promptconduit prune --dry-run`.
+func Stats(retentionDays int) RetentionStats {
+	s := RetentionStats{RetentionDays: retentionDays}
+	if info, err := os.Stat(EventsJSONLPath()); err == nil {
+		s.EventsBytes = info.Size()
+	}
+	if retentionDays <= 0 {
+		// Keep forever: nothing is ever expired; still report totals.
+		s.EventsTotal, _ = countExpired(EventsJSONLPath(), time.Time{}, envelopeCapturedAt)
+		s.HookTotal, _ = countExpired(HookEventsPath(), time.Time{}, hookEventTimestamp)
+		return s
+	}
+	cutoff := nowUTC().Add(-time.Duration(retentionDays) * 24 * time.Hour)
+	s.EventsTotal, s.EventsExpired = countExpired(EventsJSONLPath(), cutoff, envelopeCapturedAt)
+	s.HookTotal, s.HookExpired = countExpired(HookEventsPath(), cutoff, hookEventTimestamp)
+	return s
+}
+
+// countExpired reads path and returns (total records, records older than
+// cutoff). A zero cutoff counts nothing as expired. Best-effort: an unreadable
+// file reports zeros.
+func countExpired(path string, cutoff time.Time, tsOf timestampFn) (total, expired int) {
+	f, err := os.Open(path)
+	if err != nil {
+		return 0, 0
+	}
+	defer func() { _ = f.Close() }()
+	sc := bufio.NewScanner(f)
+	sc.Buffer(make([]byte, 0, 64*1024), 8*1024*1024)
+	for sc.Scan() {
+		if len(sc.Bytes()) == 0 {
+			continue
+		}
+		total++
+		if cutoff.IsZero() {
+			continue
+		}
+		if t, ok := tsOf(sc.Bytes()); ok && t.Before(cutoff) {
+			expired++
+		}
+	}
+	return total, expired
+}
+
+func pruneDiceHit() bool {
+	var b [4]byte
+	if _, err := rand.Read(b[:]); err != nil {
+		return false
+	}
+	return binary.BigEndian.Uint32(b[:])%pruneProbabilityDenominator == 0
+}
+
+func fileOverCeiling(path string, ceiling int64) bool {
+	info, err := os.Stat(path)
+	if err != nil {
+		return false
+	}
+	return info.Size() > ceiling
+}
+
+// timestampFn extracts a record's time from a JSONL line. ok=false when the line
+// has no parseable timestamp — such records are treated as "young" (kept), so a
+// malformed or foreign line is never silently discarded.
+type timestampFn func(line []byte) (t time.Time, ok bool)
+
+func envelopeCapturedAt(line []byte) (time.Time, bool) {
+	var rec struct {
+		CapturedAt string `json:"captured_at"`
+	}
+	if json.Unmarshal(line, &rec) != nil || rec.CapturedAt == "" {
+		return time.Time{}, false
+	}
+	t, err := time.Parse(time.RFC3339, rec.CapturedAt)
+	if err != nil {
+		return time.Time{}, false
+	}
+	return t, true
+}
+
+func hookEventTimestamp(line []byte) (time.Time, bool) {
+	var rec struct {
+		Timestamp string `json:"timestamp"`
+	}
+	if json.Unmarshal(line, &rec) != nil || rec.Timestamp == "" {
+		return time.Time{}, false
+	}
+	t, err := time.Parse(time.RFC3339, rec.Timestamp)
+	if err != nil {
+		return time.Time{}, false
+	}
+	return t, true
+}
+
+// pruneFile rewrites path keeping (a) every record younger than cutoff and (b)
+// as many older records as fit under ceiling, oldest dropped first. When nothing
+// needs dropping it returns without touching the file. Any lines appended by
+// another writer while the rewrite is in flight are carried over, so a
+// concurrent capture is never lost. Called with writeMu held; returns the number
+// of records removed.
+func pruneFile(path string, ceiling int64, cutoff time.Time, tsOf timestampFn) int {
+	info, err := os.Stat(path)
+	if err != nil {
+		return 0
+	}
+	// Fast path: under the ceiling → keep everything (the floor is already
+	// satisfied, and we only ever trim expired records to honour the ceiling).
+	// No read, no rewrite.
+	if info.Size() <= ceiling {
+		return 0
+	}
+	return pruneFileFrom(path, ceiling, cutoff, tsOf, info.Size())
+}
+
+// pruneFileFrom is pruneFile's core with an explicit startSize (the byte length
+// to treat as the file's committed content). Only the first startSize bytes are
+// scanned; anything appended past it by a concurrent writer is copied over
+// verbatim, so an in-flight capture is never lost. Split out for testability.
+func pruneFileFrom(path string, ceiling int64, cutoff time.Time, tsOf timestampFn, startSize int64) int {
+	f, err := os.Open(path)
+	if err != nil {
+		return 0
+	}
+	// Read exactly the bytes present when we started, so appends that arrive
+	// during the scan land strictly after startSize and are copied verbatim
+	// below rather than double-counted here. events.jsonl lines always end in
+	// '\n', so startSize is a clean line boundary.
+	type record struct {
+		data  []byte
+		young bool
+		size  int64
+	}
+	var records []record
+	var total int64
+	sc := bufio.NewScanner(io.LimitReader(f, startSize))
+	sc.Buffer(make([]byte, 0, 64*1024), 8*1024*1024)
+	for sc.Scan() {
+		b := append([]byte(nil), sc.Bytes()...)
+		t, ok := tsOf(b)
+		young := !ok || !t.Before(cutoff) // unknown-ts lines are kept
+		size := int64(len(b)) + 1         // +1 for the newline
+		records = append(records, record{data: b, young: young, size: size})
+		total += size
+	}
+	scanErr := sc.Err()
+	_ = f.Close()
+	if scanErr != nil {
+		return 0 // never rewrite from a partial read
+	}
+
+	// Drop oldest EXPIRED records first until under the ceiling. Young records
+	// are never candidates, so the retention window is always preserved — even
+	// if the window alone exceeds the ceiling (the floor wins).
+	keep := make([]bool, len(records))
+	for i := range records {
+		keep[i] = true
+	}
+	removed := 0
+	for i := 0; i < len(records) && total > ceiling; i++ {
+		if !records[i].young {
+			keep[i] = false
+			total -= records[i].size
+			removed++
+		}
+	}
+	if removed == 0 {
+		return 0 // everything over the ceiling is still within the window — keep it
+	}
+
+	tmp, err := os.CreateTemp(filepath.Dir(path), ".prune-*")
+	if err != nil {
+		return 0
+	}
+	tmpName := tmp.Name()
+	w := bufio.NewWriter(tmp)
+	for i, rec := range records {
+		if !keep[i] {
+			continue
+		}
+		_, _ = w.Write(rec.data)
+		_, _ = w.Write([]byte{'\n'})
+	}
+	// Carry over any bytes appended after startSize by a concurrent writer, so no
+	// in-flight capture is dropped by the rewrite.
+	if src, err := os.Open(path); err == nil {
+		if _, err := src.Seek(startSize, io.SeekStart); err == nil {
+			_, _ = io.Copy(w, src)
+		}
+		_ = src.Close()
+	}
+	if err := w.Flush(); err != nil {
+		cleanupTemp(tmp, tmpName)
+		return 0
+	}
+	if err := tmp.Sync(); err != nil {
+		cleanupTemp(tmp, tmpName)
+		return 0
+	}
+	if err := tmp.Close(); err != nil {
+		_ = os.Remove(tmpName)
+		return 0
+	}
+	if err := os.Rename(tmpName, path); err != nil {
+		_ = os.Remove(tmpName)
+		return 0
+	}
+	return removed
+}
+
+func cleanupTemp(f *os.File, name string) {
+	_ = f.Close()
+	_ = os.Remove(name)
+}

--- a/internal/eventlog/prune_test.go
+++ b/internal/eventlog/prune_test.go
@@ -1,0 +1,275 @@
+package eventlog
+
+import (
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+	"time"
+)
+
+// fixedNow pins nowUTC for a test so retention cutoffs are deterministic.
+func fixedNow(t *testing.T, at time.Time) {
+	t.Helper()
+	prev := nowUTC
+	nowUTC = func() time.Time { return at }
+	t.Cleanup(func() { nowUTC = prev })
+}
+
+// writeEvents writes envelope-shaped lines (captured_at) to events.jsonl.
+func writeEvents(t *testing.T, tss ...string) {
+	t.Helper()
+	var b strings.Builder
+	for i, ts := range tss {
+		fmt.Fprintf(&b, `{"schema":2,"event_id":"e%d","captured_at":"%s"}`+"\n", i, ts)
+	}
+	if err := os.WriteFile(EventsJSONLPath(), []byte(b.String()), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func readEventLines(t *testing.T) []string {
+	t.Helper()
+	data, err := os.ReadFile(EventsJSONLPath())
+	if err != nil {
+		t.Fatal(err)
+	}
+	trimmed := strings.TrimRight(string(data), "\n")
+	if trimmed == "" {
+		return nil
+	}
+	return strings.Split(trimmed, "\n")
+}
+
+func iso(daysAgo int, base time.Time) string {
+	return base.Add(-time.Duration(daysAgo) * 24 * time.Hour).Format(time.RFC3339)
+}
+
+func TestPruneExpiredRemovesOldKeepsYoung(t *testing.T) {
+	withTempDir(t)
+	now := time.Date(2026, 7, 6, 12, 0, 0, 0, time.UTC)
+	fixedNow(t, now)
+
+	// 3 within a 30-day window, 2 older than it.
+	writeEvents(t, iso(1, now), iso(10, now), iso(29, now), iso(31, now), iso(90, now))
+
+	removed := PruneExpired(30)
+	if removed != 2 {
+		t.Fatalf("expected 2 expired records removed, got %d", removed)
+	}
+	lines := readEventLines(t)
+	if len(lines) != 3 {
+		t.Fatalf("expected 3 retained lines, got %d: %v", len(lines), lines)
+	}
+	// The two oldest (e3=31d, e4=90d) must be gone; e0/e1/e2 kept in order.
+	for i, want := range []string{"e0", "e1", "e2"} {
+		if !strings.Contains(lines[i], `"`+want+`"`) {
+			t.Errorf("line %d = %q, expected to contain %q", i, lines[i], want)
+		}
+	}
+}
+
+func TestPruneUnderCeilingKeepsEverything(t *testing.T) {
+	withTempDir(t)
+	now := time.Date(2026, 7, 6, 12, 0, 0, 0, time.UTC)
+	fixedNow(t, now)
+
+	// Even records older than the window survive the automatic ceiling policy
+	// while the file is under the ceiling: the floor is a minimum, not a cap.
+	writeEvents(t, iso(1, now), iso(100, now), iso(400, now))
+
+	removed := Prune(30) // ceiling policy (EventsCeiling = 500MB, far above this)
+	if removed != 0 {
+		t.Fatalf("expected nothing pruned under the ceiling, got %d removed", removed)
+	}
+	if got := len(readEventLines(t)); got != 3 {
+		t.Fatalf("expected all 3 lines retained, got %d", got)
+	}
+}
+
+func TestPruneCeilingTrimsOldestExpiredFirst(t *testing.T) {
+	withTempDir(t)
+	now := time.Date(2026, 7, 6, 12, 0, 0, 0, time.UTC)
+	fixedNow(t, now)
+
+	// Chronological order, as a real append-only log accumulates (oldest first):
+	// three expired (60d, 50d, 40d) then two young (2d, 1d). Padded bodies let us
+	// set a small ceiling and force trimming.
+	pad := strings.Repeat("x", 100)
+	tss := []string{iso(60, now), iso(50, now), iso(40, now), iso(2, now), iso(1, now)}
+	var b strings.Builder
+	for i, ts := range tss {
+		fmt.Fprintf(&b, `{"event_id":"e%d","captured_at":"%s","pad":"%s"}`+"\n", i, ts, pad)
+	}
+	if err := os.WriteFile(EventsJSONLPath(), []byte(b.String()), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	info, _ := os.Stat(EventsJSONLPath())
+	// Ceiling that leaves room for ~4 of the 5 lines: forces dropping 1 (the
+	// oldest = e0 at 60d), but never the young ones.
+	ceiling := info.Size() - 120
+	cutoff := now.Add(-30 * 24 * time.Hour)
+
+	removed := pruneFile(EventsJSONLPath(), ceiling, cutoff, envelopeCapturedAt)
+	if removed != 1 {
+		t.Fatalf("expected exactly 1 record trimmed to meet the ceiling, got %d", removed)
+	}
+	lines := readEventLines(t)
+	if len(lines) != 4 {
+		t.Fatalf("expected 4 lines after trim, got %d", len(lines))
+	}
+	// e0 (60d, oldest) dropped first; e3/e4 (young) and e1/e2 (next-oldest
+	// expired) kept.
+	if strings.Contains(strings.Join(lines, "\n"), `"e0"`) {
+		t.Errorf("oldest expired record e0 should have been trimmed first")
+	}
+	for _, mustKeep := range []string{"e3", "e4"} {
+		if !strings.Contains(strings.Join(lines, "\n"), `"`+mustKeep+`"`) {
+			t.Errorf("young record %s must never be trimmed", mustKeep)
+		}
+	}
+}
+
+func TestPruneNeverDropsYoungEvenOverCeiling(t *testing.T) {
+	withTempDir(t)
+	now := time.Date(2026, 7, 6, 12, 0, 0, 0, time.UTC)
+	fixedNow(t, now)
+
+	// All records are within the window; even a tiny ceiling can't drop them.
+	pad := strings.Repeat("y", 100)
+	var b strings.Builder
+	for i := 0; i < 4; i++ {
+		fmt.Fprintf(&b, `{"event_id":"y%d","captured_at":"%s","pad":"%s"}`+"\n", i, iso(i, now), pad)
+	}
+	if err := os.WriteFile(EventsJSONLPath(), []byte(b.String()), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	cutoff := now.Add(-30 * 24 * time.Hour)
+
+	removed := pruneFile(EventsJSONLPath(), 1 /* absurdly small ceiling */, cutoff, envelopeCapturedAt)
+	if removed != 0 {
+		t.Fatalf("young records must survive any ceiling; got %d removed", removed)
+	}
+	if got := len(readEventLines(t)); got != 4 {
+		t.Fatalf("expected all 4 young lines retained, got %d", got)
+	}
+}
+
+func TestPruneKeepsUnparseableTimestampLines(t *testing.T) {
+	withTempDir(t)
+	now := time.Date(2026, 7, 6, 12, 0, 0, 0, time.UTC)
+	fixedNow(t, now)
+
+	// A line with no captured_at must be treated as young (kept), never dropped.
+	lines := []string{
+		`{"event_id":"old","captured_at":"` + iso(90, now) + `"}`,
+		`{"event_id":"noTs"}`,
+		`{"event_id":"young","captured_at":"` + iso(1, now) + `"}`,
+	}
+	if err := os.WriteFile(EventsJSONLPath(), []byte(strings.Join(lines, "\n")+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	removed := PruneExpired(30)
+	if removed != 1 {
+		t.Fatalf("expected only the 90-day record removed, got %d", removed)
+	}
+	joined := strings.Join(readEventLines(t), "\n")
+	if !strings.Contains(joined, `"noTs"`) {
+		t.Errorf("record with no timestamp must be preserved, not dropped")
+	}
+	if strings.Contains(joined, `"old"`) {
+		t.Errorf("90-day-old record should have been removed")
+	}
+}
+
+func TestPruneKeepForeverIsNoOp(t *testing.T) {
+	withTempDir(t)
+	now := time.Date(2026, 7, 6, 12, 0, 0, 0, time.UTC)
+	fixedNow(t, now)
+	writeEvents(t, iso(1, now), iso(1000, now))
+
+	if removed := Prune(0); removed != 0 {
+		t.Fatalf("retention 0 must never prune, got %d", removed)
+	}
+	if removed := PruneExpired(0); removed != 0 {
+		t.Fatalf("retention 0 must never prune, got %d", removed)
+	}
+	if removed := Prune(-1); removed != 0 {
+		t.Fatalf("negative retention must never prune, got %d", removed)
+	}
+	if got := len(readEventLines(t)); got != 2 {
+		t.Fatalf("expected both lines retained, got %d", got)
+	}
+}
+
+func TestStatsCountsExpired(t *testing.T) {
+	withTempDir(t)
+	now := time.Date(2026, 7, 6, 12, 0, 0, 0, time.UTC)
+	fixedNow(t, now)
+	writeEvents(t, iso(1, now), iso(5, now), iso(40, now), iso(90, now))
+
+	s := Stats(30)
+	if s.EventsTotal != 4 {
+		t.Errorf("EventsTotal = %d, want 4", s.EventsTotal)
+	}
+	if s.EventsExpired != 2 {
+		t.Errorf("EventsExpired = %d, want 2", s.EventsExpired)
+	}
+	if s.EventsBytes == 0 {
+		t.Errorf("EventsBytes should be non-zero")
+	}
+
+	// Keep-forever: nothing is expired, but totals still report.
+	sf := Stats(0)
+	if sf.EventsExpired != 0 || sf.EventsTotal != 4 {
+		t.Errorf("keep-forever stats = %+v, want total 4 / expired 0", sf)
+	}
+}
+
+func TestPrunePreservesConcurrentAppendTail(t *testing.T) {
+	withTempDir(t)
+	now := time.Date(2026, 7, 6, 12, 0, 0, 0, time.UTC)
+	fixedNow(t, now)
+
+	// Write expired + young records with padding so we can force a ceiling trim.
+	pad := strings.Repeat("z", 100)
+	tss := []string{iso(60, now), iso(50, now), iso(1, now)}
+	var b strings.Builder
+	for i, ts := range tss {
+		fmt.Fprintf(&b, `{"event_id":"e%d","captured_at":"%s","pad":"%s"}`+"\n", i, ts, pad)
+	}
+	if err := os.WriteFile(EventsJSONLPath(), []byte(b.String()), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	info, _ := os.Stat(EventsJSONLPath())
+	startSize := info.Size()
+
+	// Simulate a concurrent append landing after we captured startSize by
+	// appending a new line, then invoking pruneFile with the stat it would have
+	// taken. We approximate by appending before the call but relying on pruneFile
+	// re-statting: the tail-copy must carry the appended line over.
+	appended := fmt.Sprintf(`{"event_id":"late","captured_at":"%s"}`+"\n", iso(0, now))
+	f, err := os.OpenFile(EventsJSONLPath(), os.O_APPEND|os.O_WRONLY, 0o644)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, _ = f.WriteString(appended)
+	_ = f.Close()
+
+	// Ceiling forces trimming the oldest expired (e0). startSize-based scan means
+	// the "late" line (appended after startSize) is carried via the tail copy.
+	ceiling := startSize - 120
+	cutoff := now.Add(-30 * 24 * time.Hour)
+	removed := pruneFileFrom(EventsJSONLPath(), ceiling, cutoff, envelopeCapturedAt, startSize)
+	if removed != 1 {
+		t.Fatalf("expected 1 expired trimmed, got %d", removed)
+	}
+	joined := strings.Join(readEventLines(t), "\n")
+	if !strings.Contains(joined, `"late"`) {
+		t.Errorf("concurrently-appended line must be preserved, got:\n%s", joined)
+	}
+	if strings.Contains(joined, `"e0"`) {
+		t.Errorf("oldest expired e0 should have been trimmed")
+	}
+}


### PR DESCRIPTION
## Summary
Local hook history (`~/.promptconduit/events.jsonl`) was bounded only by a blind 50MB size rotation that silently discarded a whole backup at once — with no guarantee of how many days were kept. This adds real, configurable **time-based retention**.

## Policy: time floor + size ceiling
- Every event captured within the retention window (**default 30 days**) is **always kept** — the floor.
- Records older than the window are trimmed **oldest-first only** once the log grows past a generous **500MB ceiling**.
- Data inside the window is never dropped, even past the ceiling.

## Changes
- **Config**: `event_log_retention_days` (default 30, `-1` = keep forever) via `config set --event-log-retention-days`, shown in `config show`, and `PROMPTCONDUIT_EVENT_LOG_RETENTION_DAYS`.
- **Prune** (`internal/eventlog/prune.go`): atomic rewrite (temp + rename), preserves lines appended concurrently mid-prune, treats unparseable-timestamp lines as "keep".
- **`promptconduit prune`** command with `--dry-run`; opportunistic prune on the hook hot path (cheap — a couple of stats unless over the ceiling).
- Retires the 50MB blind rotation for events.jsonl; also bounds the previously-unbounded `hook-events` trace.

## Testing
- New `internal/eventlog/prune_test.go`: age boundary, ceiling oldest-first trim, young-never-dropped, unparseable-ts safety, keep-forever, concurrent-append preservation, stats.
- Verified end-to-end against a throwaway home dir: `config set` 90/-1, then `prune --dry-run` → `prune` removed expired records, kept recent ones, idempotent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)