### PR TITLE
feat: Epic 5 — sessions resolve for focus-aware cost

### DIFF
--- a/cmd/sessions.go
+++ b/cmd/sessions.go
@@ -17,6 +17,8 @@ var (
 	sessionsJSON      bool
 	sessionsAll       bool // include sessions that are still running
 	sessionsUnderPath string
+	sessionsResolvePID string
+	sessionsResolveJSON bool
 )
 
 var sessionsCmd = &cobra.Command{
@@ -153,10 +155,34 @@ func shortID(id string) string {
 	return id
 }
 
+var sessionsResolveCmd = &cobra.Command{
+	Use:   "resolve",
+	Short: "Resolve a terminal shell PID to a Claude Code session",
+	Long: `Map a VS Code / Cursor terminal shell PID to the Claude Code session
+running inside it. Used by the editor extension to follow terminal focus.
+
+Resolution order per claude child process: --resume in argv, else an open
+transcript file (lsof). When several claude processes exist under the shell
+(sub-agents), --json returns ambiguous: true with a candidates list.`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if sessionsResolvePID == "" {
+			return fmt.Errorf("--pid is required")
+		}
+		result := sessions.ResolveFromShellPID(sessionsResolvePID)
+		enc := json.NewEncoder(cmd.OutOrStdout())
+		enc.SetIndent("", "  ")
+		return enc.Encode(result)
+	},
+}
+
 func init() {
 	sessionsCmd.Flags().DurationVar(&sessionsSince, "since", 12*time.Hour, "only sessions active within this window")
 	sessionsCmd.Flags().BoolVar(&sessionsJSON, "json", false, "emit machine-readable JSON")
 	sessionsCmd.Flags().BoolVar(&sessionsAll, "all", false, "include sessions that are still running")
 	sessionsCmd.Flags().StringVar(&sessionsUnderPath, "under", "", "only sessions whose directory is under this path")
+	sessionsResolveCmd.Flags().StringVar(&sessionsResolvePID, "pid", "", "shell process id from the focused terminal")
+	sessionsResolveCmd.Flags().BoolVar(&sessionsResolveJSON, "json", false, "emit machine-readable JSON (always JSON; flag for CLI consistency)")
+	_ = sessionsResolveCmd.MarkFlagRequired("pid")
+	sessionsCmd.AddCommand(sessionsResolveCmd)
 	rootCmd.AddCommand(sessionsCmd)
 }

--- a/internal/sessions/resolve.go
+++ b/internal/sessions/resolve.go
@@ -1,0 +1,196 @@
+package sessions
+
+import (
+	"context"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+)
+
+// ResolveCandidate is one claude process that could own the terminal session.
+type ResolveCandidate struct {
+	SessionID string `json:"session_id"`
+	PID       string `json:"pid,omitempty"`
+	Cwd       string `json:"cwd,omitempty"`
+}
+
+// ResolveResult maps a terminal shell pid to a Claude Code session when possible.
+// When several claude children exist under the shell, Ambiguous is true and
+// Candidates carries each option for the caller to disambiguate.
+type ResolveResult struct {
+	SessionID  string             `json:"session_id,omitempty"`
+	Tool       string             `json:"tool,omitempty"`
+	Cwd        string             `json:"cwd,omitempty"`
+	Ambiguous  bool               `json:"ambiguous,omitempty"`
+	Candidates []ResolveCandidate `json:"candidates,omitempty"`
+}
+
+// ResolveFromShellPID finds claude processes descended from shellPID and resolves
+// each to a session id (--resume in argv, else an open transcript via lsof).
+// macOS/Linux only; returns an empty result on other platforms or when nothing
+// matches.
+func ResolveFromShellPID(shellPID string) ResolveResult {
+	if runtime.GOOS != "darwin" && runtime.GOOS != "linux" {
+		return ResolveResult{}
+	}
+	shellPID = strings.TrimSpace(shellPID)
+	if shellPID == "" {
+		return ResolveResult{}
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), liveProbeTimeout)
+	defer cancel()
+
+	psOut, err := exec.CommandContext(ctx, "ps", "-axo", "pid=,ppid=,comm=").Output()
+	if err != nil {
+		return ResolveResult{}
+	}
+	parents, comms := parseProcessTree(string(psOut))
+	pids := claudeDescendants(shellPID, parents, comms)
+	if len(pids) == 0 {
+		return ResolveResult{}
+	}
+
+	candidates := make([]ResolveCandidate, 0, len(pids))
+	for _, pid := range pids {
+		c := resolveClaudePID(ctx, pid)
+		if c.SessionID != "" {
+			candidates = append(candidates, c)
+		}
+	}
+	if len(candidates) == 0 {
+		return ResolveResult{}
+	}
+	if len(candidates) == 1 {
+		c := candidates[0]
+		return ResolveResult{
+			SessionID: c.SessionID,
+			Tool:      "claude-code",
+			Cwd:       c.Cwd,
+		}
+	}
+	return ResolveResult{
+		Ambiguous:  true,
+		Candidates: candidates,
+	}
+}
+
+// parseProcessTree reads `ps -axo pid=,ppid=,comm=` into parent and comm maps.
+func parseProcessTree(psOutput string) (parents map[string]string, comms map[string]string) {
+	parents = map[string]string{}
+	comms = map[string]string{}
+	for _, line := range strings.Split(psOutput, "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		pid, rest, ok := strings.Cut(line, " ")
+		if !ok {
+			continue
+		}
+		ppid, comm, ok := strings.Cut(strings.TrimSpace(rest), " ")
+		if !ok {
+			continue
+		}
+		pid = strings.TrimSpace(pid)
+		ppid = strings.TrimSpace(ppid)
+		comms[pid] = strings.TrimSpace(comm)
+		parents[pid] = ppid
+	}
+	return parents, comms
+}
+
+// claudeDescendants returns claude pids whose parent chain includes shellPID.
+func claudeDescendants(shellPID string, parents, comms map[string]string) []string {
+	var pids []string
+	for pid, comm := range comms {
+		if filepath.Base(comm) != "claude" {
+			continue
+		}
+		if isDescendantOf(pid, shellPID, parents) {
+			pids = append(pids, pid)
+		}
+	}
+	return pids
+}
+
+func isDescendantOf(pid, ancestor string, parents map[string]string) bool {
+	for {
+		ppid, ok := parents[pid]
+		if !ok || ppid == "" || ppid == "0" || ppid == "1" {
+			return false
+		}
+		if ppid == ancestor {
+			return true
+		}
+		pid = ppid
+	}
+}
+
+func resolveClaudePID(ctx context.Context, pid string) ResolveCandidate {
+	args := procArgs(ctx, pid)
+	sessionID := parseResumeSessionID(args)
+	if sessionID == "" {
+		sessionID = transcriptSessionFromLsof(ctx, pid)
+	}
+	cwd := procCwd(ctx, pid)
+	return ResolveCandidate{SessionID: sessionID, PID: pid, Cwd: cwd}
+}
+
+func procArgs(ctx context.Context, pid string) string {
+	out, err := exec.CommandContext(ctx, "ps", "-p", pid, "-o", "args=").Output()
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(out))
+}
+
+// parseResumeSessionID extracts the session id from a claude argv string.
+func parseResumeSessionID(args string) string {
+	fields := strings.Fields(args)
+	for i, f := range fields {
+		if f == "--resume" && i+1 < len(fields) {
+			return fields[i+1]
+		}
+	}
+	return ""
+}
+
+// transcriptSessionFromLsof finds an open Claude Code transcript for pid and
+// returns the session id from its filename (<session-id>.jsonl).
+func transcriptSessionFromLsof(ctx context.Context, pid string) string {
+	out, err := exec.CommandContext(ctx, "lsof", "-Fn", "-p", pid).Output()
+	if err != nil {
+		return ""
+	}
+	return parseTranscriptSessionID(string(out))
+}
+
+// parseTranscriptSessionID scans lsof -Fn output for a .jsonl path under
+// ~/.claude/projects and returns the session id from the basename.
+func parseTranscriptSessionID(lsofOutput string) string {
+	projects := claudeProjectsDir()
+	if projects == "" {
+		return ""
+	}
+	projects = filepath.Clean(projects)
+	for _, line := range strings.Split(lsofOutput, "\n") {
+		if !strings.HasPrefix(line, "n") {
+			continue
+		}
+		p := strings.TrimSpace(line[1:])
+		if !strings.HasSuffix(p, ".jsonl") {
+			continue
+		}
+		if !strings.Contains(p, projects) {
+			continue
+		}
+		base := filepath.Base(p)
+		id := strings.TrimSuffix(base, ".jsonl")
+		if id != "" {
+			return id
+		}
+	}
+	return ""
+}

--- a/internal/sessions/resolve_test.go
+++ b/internal/sessions/resolve_test.go
@@ -1,0 +1,102 @@
+package sessions
+
+import (
+	"path/filepath"
+	"reflect"
+	"testing"
+)
+
+func TestParseProcessTree(t *testing.T) {
+	out := `
+  501 1 /sbin/launchd
+89754 35241 zsh
+53134 89754 claude
+11351 89754 claude
+35241 501 Cursor Helper
+`
+	parents, comms := parseProcessTree(out)
+	if parents["53134"] != "89754" {
+		t.Fatalf("parent 53134: got %q", parents["53134"])
+	}
+	if comms["53134"] != "claude" {
+		t.Fatalf("comm 53134: got %q", comms["53134"])
+	}
+}
+
+func TestClaudeDescendants(t *testing.T) {
+	out := `
+89754 35241 zsh
+53134 89754 claude
+11351 89754 claude
+92000 53134 claude
+15823 35241 zsh
+77777 15823 claude
+`
+	parents, comms := parseProcessTree(out)
+	got := claudeDescendants("89754", parents, comms)
+	want := []string{"53134", "11351", "92000"}
+	if !reflect.DeepEqual(sortedStrings(got), sortedStrings(want)) {
+		t.Fatalf("claudeDescendants\n got: %v\nwant: %v", got, want)
+	}
+	got2 := claudeDescendants("15823", parents, comms)
+	if !reflect.DeepEqual(got2, []string{"77777"}) {
+		t.Fatalf("other shell: got %v", got2)
+	}
+}
+
+func sortedStrings(ss []string) []string {
+	cp := append([]string(nil), ss...)
+	for i := 0; i < len(cp); i++ {
+		for j := i + 1; j < len(cp); j++ {
+			if cp[j] < cp[i] {
+				cp[i], cp[j] = cp[j], cp[i]
+			}
+		}
+	}
+	return cp
+}
+
+func TestParseResumeSessionID(t *testing.T) {
+	cases := []struct {
+		args string
+		want string
+	}{
+		{"claude --resume b7c88043-1234-5678-9abc-def012345678", "b7c88043-1234-5678-9abc-def012345678"},
+		{"claude", ""},
+		{"/usr/local/bin/claude --resume abc --add-dir /tmp/foo", "abc"},
+	}
+	for _, tc := range cases {
+		if got := parseResumeSessionID(tc.args); got != tc.want {
+			t.Fatalf("parseResumeSessionID(%q) = %q, want %q", tc.args, got, tc.want)
+		}
+	}
+}
+
+func TestParseTranscriptSessionID(t *testing.T) {
+	root := claudeProjectsDir()
+	if root == "" {
+		t.Skip("no home dir")
+	}
+	path := filepath.Join(root, "encoded-dir", "session-uuid-1234.jsonl")
+	out := "p53134\nn" + path + "\nn/dev/null\n"
+	if got := parseTranscriptSessionID(out); got != "session-uuid-1234" {
+		t.Fatalf("got %q", got)
+	}
+}
+
+func TestIsDescendantOf(t *testing.T) {
+	parents := map[string]string{
+		"53134": "89754",
+		"89754": "35241",
+		"35241": "1",
+	}
+	if !isDescendantOf("53134", "89754", parents) {
+		t.Fatal("53134 should be under 89754")
+	}
+	if isDescendantOf("89754", "89754", parents) {
+		t.Fatal("process is not its own descendant")
+	}
+	if isDescendantOf("53134", "15823", parents) {
+		t.Fatal("53134 is not under 15823")
+	}
+}


### PR DESCRIPTION
## Summary
- Add `promptconduit sessions resolve --pid` to map a VS Code/Cursor terminal shell PID to the Claude Code session running inside it (via `--resume` argv or open transcript).
- Return structured JSON including ambiguity when multiple Claude child processes exist under the same shell (sub-agents).

## Test plan
- [x] `make test` (including `internal/sessions` resolve tests)
- [ ] Manual: run `promptconduit sessions resolve --pid <shell-pid>` against a terminal with an active Claude session

## Issues
Closes promptconduit/cli#109

## Dependencies
Companion editor-extension PR (Epic #55) calls this command for focus-aware cost breakdown; merge CLI first or ship together.

Made with [Cursor](https://cursor.com)