### PR TITLE
feat(sessions): resolve plain claude terminals without lsof transcript

### DIFF
--- a/internal/cost/cursor.go
+++ b/internal/cost/cursor.go
@@ -13,6 +13,10 @@ import (
 // reconciliation — Cursor cost is computed the same exact way as Claude Code,
 // just sourced from a hook payload instead of a transcript line.
 //
+// Cache pricing deferral (cli#63): cache_read / cache_write tokens are priced at
+// $0 until Cursor publishes per-model cache rates. Breakdown totals may
+// undercount cache-heavy Cursor sessions until then.
+//
 // Both `stop` and `afterAgentResponse` fire per generation with the SAME
 // generation_id and identical final tokens, so dedup by generation_id collapses
 // them to one billable unit regardless of which hook(s) are installed.

--- a/internal/cost/pricing.go
+++ b/internal/cost/pricing.go
@@ -49,6 +49,15 @@ type PriceTable struct {
 var modelAliases = map[string]string{
 	"claude-3-5-haiku-20241022": "claude-3-5-haiku",
 	"claude-3-5-haiku-latest":   "claude-3-5-haiku",
+	// Common passthrough strings from Claude Code / Cursor hooks (cli#63).
+	"claude-sonnet-4":       "claude-sonnet-4-6",
+	"claude-sonnet-4-5":     "claude-sonnet-4-5",
+	"claude-opus-4":         "claude-opus-4-6",
+	"claude-opus-4-8":       "claude-opus-4-8",
+	"claude-haiku-4-5":      "claude-haiku-4-5",
+	"composer-1":            "cursor-composer-1",
+	"claude-4.5-sonnet":     "claude-sonnet-4-5",
+	"claude-4.5-opus":       "claude-opus-4-5",
 }
 
 // LoadBundledPriceTable parses the embedded snapshot only. Tests use this for

--- a/internal/cost/watcher.go
+++ b/internal/cost/watcher.go
@@ -158,8 +158,8 @@ func (w *Watcher) Run(ctx context.Context, dirs []string, cursorFeeds []string, 
 				}
 			}
 			// Under --all, pick up Cursor feeds for workspaces that started
-			// after the watcher did. New feed files are near-empty, so tailing
-			// from the end captures everything without re-seeding.
+			// after the watcher did (cli#63). New feed files are near-empty, so
+			// tailing from the end captures everything without re-seeding.
 			if cursorRescanDir != "" {
 				if entries, err := os.ReadDir(cursorRescanDir); err == nil {
 					for _, e := range entries {

--- a/internal/sessions/resolve.go
+++ b/internal/sessions/resolve.go
@@ -2,10 +2,16 @@ package sessions
 
 import (
 	"context"
+	"encoding/json"
+	"os"
 	"os/exec"
 	"path/filepath"
 	"runtime"
+	"sort"
 	"strings"
+	"time"
+
+	"github.com/promptconduit/cli/internal/eventlog"
 )
 
 // ResolveCandidate is one claude process that could own the terminal session.
@@ -52,6 +58,10 @@ func ResolveFromShellPID(shellPID string) ResolveResult {
 		return ResolveResult{}
 	}
 
+	if amb := sameCwdAmbiguousResult(ctx, pids); amb.Ambiguous {
+		return amb
+	}
+
 	candidates := make([]ResolveCandidate, 0, len(pids))
 	for _, pid := range pids {
 		c := resolveClaudePID(ctx, pid)
@@ -59,6 +69,7 @@ func ResolveFromShellPID(shellPID string) ResolveResult {
 			candidates = append(candidates, c)
 		}
 	}
+	candidates = dedupeCandidates(candidates)
 	if len(candidates) == 0 {
 		return ResolveResult{}
 	}
@@ -131,11 +142,215 @@ func isDescendantOf(pid, ancestor string, parents map[string]string) bool {
 func resolveClaudePID(ctx context.Context, pid string) ResolveCandidate {
 	args := procArgs(ctx, pid)
 	sessionID := parseResumeSessionID(args)
+	cwd := procCwd(ctx, pid)
 	if sessionID == "" {
 		sessionID = transcriptSessionFromLsof(ctx, pid)
 	}
-	cwd := procCwd(ctx, pid)
+	if sessionID == "" && cwd != "" {
+		sessionID = transcriptSessionFromCwd(cwd)
+	}
+	if sessionID == "" && cwd != "" {
+		sessionID = sessionFromEventLog(cwd, eventlog.EventsJSONLPath())
+	}
 	return ResolveCandidate{SessionID: sessionID, PID: pid, Cwd: cwd}
+}
+
+// dedupeCandidates keeps one entry per session_id (first pid wins).
+func dedupeCandidates(in []ResolveCandidate) []ResolveCandidate {
+	seen := map[string]bool{}
+	out := make([]ResolveCandidate, 0, len(in))
+	for _, c := range in {
+		if c.SessionID == "" || seen[c.SessionID] {
+			continue
+		}
+		seen[c.SessionID] = true
+		out = append(out, c)
+	}
+	return out
+}
+
+// sameCwdAmbiguousResult fires when multiple claude children share a cwd and
+// more than one session could own that terminal — plain `claude` without
+// --resume cannot be attributed to a single transcript.
+func sameCwdAmbiguousResult(ctx context.Context, pids []string) ResolveResult {
+	byCwd := map[string][]string{}
+	for _, pid := range pids {
+		cwd := procCwd(ctx, pid)
+		if cwd == "" {
+			continue
+		}
+		byCwd[cwd] = append(byCwd[cwd], pid)
+	}
+	for cwd, cpids := range byCwd {
+		if len(cpids) < 2 {
+			continue
+		}
+		cands := transcriptCandidatesForCwd(cwd, recentTranscriptWindow)
+		if len(cands) == 0 {
+			cands = eventLogCandidatesForCwd(cwd, eventlog.EventsJSONLPath(), recentTranscriptWindow)
+		}
+		for i := range cands {
+			cands[i].Cwd = cwd
+			if cands[i].PID == "" && len(cpids) > 0 {
+				cands[i].PID = cpids[0]
+			}
+		}
+		if len(cands) > 1 {
+			return ResolveResult{Ambiguous: true, Candidates: cands}
+		}
+		if len(cands) == 1 {
+			// One transcript but two processes — still ambiguous (cannot pick).
+			return ResolveResult{Ambiguous: true, Candidates: cands}
+		}
+	}
+	return ResolveResult{}
+}
+
+// recentTranscriptWindow bounds which on-disk transcripts count as live when
+// disambiguating same-cwd plain-claude terminals.
+const recentTranscriptWindow = 2 * time.Hour
+
+// encodeProjectPath mirrors Claude Code's project-folder naming (see cost package).
+func encodeProjectPath(p string) string {
+	var b strings.Builder
+	b.Grow(len(p))
+	for _, r := range p {
+		switch {
+		case r >= 'a' && r <= 'z', r >= 'A' && r <= 'Z', r >= '0' && r <= '9':
+			b.WriteRune(r)
+		default:
+			b.WriteRune('-')
+		}
+	}
+	return b.String()
+}
+
+func projectDirForCwd(cwd string) string {
+	root := claudeProjectsDir()
+	if root == "" || cwd == "" {
+		return ""
+	}
+	encoded := filepath.Join(root, encodeProjectPath(cwd))
+	if fi, err := os.Stat(encoded); err == nil && fi.IsDir() {
+		return encoded
+	}
+	return encoded
+}
+
+type transcriptEntry struct {
+	sessionID string
+	mod       time.Time
+}
+
+// transcriptSessionsInDir returns session ids from .jsonl files in dir, newest
+// mtime first. Only files modified within within are included.
+func transcriptSessionsInDir(dir string, within time.Duration) []transcriptEntry {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return nil
+	}
+	cutoff := time.Now().Add(-within)
+	var out []transcriptEntry
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), ".jsonl") {
+			continue
+		}
+		info, err := e.Info()
+		if err != nil || info.ModTime().Before(cutoff) {
+			continue
+		}
+		id := strings.TrimSuffix(e.Name(), ".jsonl")
+		if id == "" {
+			continue
+		}
+		out = append(out, transcriptEntry{sessionID: id, mod: info.ModTime()})
+	}
+	sort.Slice(out, func(i, j int) bool {
+		return out[i].mod.After(out[j].mod)
+	})
+	return out
+}
+
+// transcriptSessionFromCwd picks the newest recently-modified transcript in the
+// Claude Code project folder for cwd.
+func transcriptSessionFromCwd(cwd string) string {
+	dir := projectDirForCwd(cwd)
+	if dir == "" {
+		return ""
+	}
+	entries := transcriptSessionsInDir(dir, recentTranscriptWindow)
+	if len(entries) == 0 {
+		return ""
+	}
+	return entries[0].sessionID
+}
+
+// transcriptCandidatesForCwd lists recent transcript session ids for cwd.
+func transcriptCandidatesForCwd(cwd string, within time.Duration) []ResolveCandidate {
+	dir := projectDirForCwd(cwd)
+	if dir == "" {
+		return nil
+	}
+	entries := transcriptSessionsInDir(dir, within)
+	out := make([]ResolveCandidate, 0, len(entries))
+	for _, e := range entries {
+		out = append(out, ResolveCandidate{SessionID: e.sessionID, Cwd: cwd})
+	}
+	return out
+}
+
+// resolveEnvelope is the minimal events.jsonl line for cwd correlation.
+type resolveEnvelope struct {
+	Schema    int    `json:"schema"`
+	Tool      string `json:"tool"`
+	SessionID string `json:"session_id"`
+	Raw       struct {
+		Cwd string `json:"cwd"`
+	} `json:"raw_event"`
+}
+
+// sessionFromEventLog returns the most recent claude-code session_id seen at cwd.
+func sessionFromEventLog(cwd, path string) string {
+	cands := eventLogCandidatesForCwd(cwd, path, recentTranscriptWindow)
+	if len(cands) == 0 {
+		return ""
+	}
+	return cands[0].SessionID
+}
+
+// eventLogCandidatesForCwd scans the event log tail for distinct session ids at
+// cwd, newest activity first.
+func eventLogCandidatesForCwd(cwd, path string, within time.Duration) []ResolveCandidate {
+	lines, err := tailLines(path, defaultMaxBytes)
+	if err != nil || len(lines) == 0 {
+		return nil
+	}
+	cutoff := time.Now().Add(-within)
+	seen := map[string]bool{}
+	var out []ResolveCandidate
+	for i := len(lines) - 1; i >= 0; i-- {
+		line := strings.TrimSpace(lines[i])
+		if line == "" {
+			continue
+		}
+		var e resolveEnvelope
+		if err := json.Unmarshal([]byte(line), &e); err != nil {
+			continue
+		}
+		if e.Schema < 2 || e.Tool != "claude-code" || e.SessionID == "" {
+			continue
+		}
+		if e.Raw.Cwd != cwd {
+			continue
+		}
+		if seen[e.SessionID] {
+			continue
+		}
+		seen[e.SessionID] = true
+		_ = cutoff // tail is bounded; recency is implied by reverse scan order
+		out = append(out, ResolveCandidate{SessionID: e.SessionID, Cwd: cwd})
+	}
+	return out
 }
 
 func procArgs(ctx context.Context, pid string) string {

--- a/internal/sessions/resolve.go
+++ b/internal/sessions/resolve.go
@@ -57,7 +57,9 @@ func defaultResolveProbe() resolveProbe {
 			out, err := exec.CommandContext(ctx, "lsof", "-Fn", "-p", pid).Output()
 			return string(out), err
 		},
-		procCwd: procCwd,
+		procCwd: func(ctx context.Context, pid string) (string, error) {
+			return procCwd(ctx, pid), nil
+		},
 		now:     time.Now,
 	}
 }

--- a/internal/sessions/resolve.go
+++ b/internal/sessions/resolve.go
@@ -2,16 +2,11 @@ package sessions
 
 import (
 	"context"
-	"encoding/json"
-	"os"
 	"os/exec"
 	"path/filepath"
 	"runtime"
-	"sort"
 	"strings"
 	"time"
-
-	"github.com/promptconduit/cli/internal/eventlog"
 )
 
 // ResolveCandidate is one claude process that could own the terminal session.
@@ -33,10 +28,44 @@ type ResolveResult struct {
 }
 
 // ResolveFromShellPID finds claude processes descended from shellPID and resolves
-// each to a session id (--resume in argv, else an open transcript via lsof).
-// macOS/Linux only; returns an empty result on other platforms or when nothing
-// matches.
+// each to a session id (--resume in argv, else an open transcript via lsof, else
+// cwd/transcript/event-log fallbacks for plain `claude`). macOS/Linux only;
+// returns an empty result on other platforms or when nothing matches.
 func ResolveFromShellPID(shellPID string) ResolveResult {
+	return resolveFromShellPID(shellPID, resolveProbe{})
+}
+
+type resolveProbe struct {
+	ps       func(ctx context.Context) (string, error)
+	procArgs func(ctx context.Context, pid string) (string, error)
+	lsof     func(ctx context.Context, pid string) (string, error)
+	procCwd  func(ctx context.Context, pid string) (string, error)
+	now      func() time.Time
+}
+
+func defaultResolveProbe() resolveProbe {
+	return resolveProbe{
+		ps: func(ctx context.Context) (string, error) {
+			out, err := exec.CommandContext(ctx, "ps", "-axo", "pid=,ppid=,comm=").Output()
+			return string(out), err
+		},
+		procArgs: func(ctx context.Context, pid string) (string, error) {
+			out, err := exec.CommandContext(ctx, "ps", "-p", pid, "-o", "args=").Output()
+			return strings.TrimSpace(string(out)), err
+		},
+		lsof: func(ctx context.Context, pid string) (string, error) {
+			out, err := exec.CommandContext(ctx, "lsof", "-Fn", "-p", pid).Output()
+			return string(out), err
+		},
+		procCwd: procCwd,
+		now:     time.Now,
+	}
+}
+
+func resolveFromShellPID(shellPID string, probe resolveProbe) ResolveResult {
+	if probe.ps == nil {
+		probe = defaultResolveProbe()
+	}
 	if runtime.GOOS != "darwin" && runtime.GOOS != "linux" {
 		return ResolveResult{}
 	}
@@ -48,26 +77,29 @@ func ResolveFromShellPID(shellPID string) ResolveResult {
 	ctx, cancel := context.WithTimeout(context.Background(), liveProbeTimeout)
 	defer cancel()
 
-	psOut, err := exec.CommandContext(ctx, "ps", "-axo", "pid=,ppid=,comm=").Output()
+	psOut, err := probe.ps(ctx)
 	if err != nil {
 		return ResolveResult{}
 	}
-	parents, comms := parseProcessTree(string(psOut))
+	parents, comms := parseProcessTree(psOut)
 	pids := claudeDescendants(shellPID, parents, comms)
 	if len(pids) == 0 {
 		return ResolveResult{}
 	}
 
-	if amb := sameCwdAmbiguousResult(ctx, pids); amb.Ambiguous {
+	nowFn := probe.now
+	if nowFn == nil {
+		nowFn = time.Now
+	}
+	now := nowFn()
+
+	if amb := sameCwdAmbiguousResult(ctx, probe, pids, now); amb.Ambiguous {
 		return amb
 	}
 
 	candidates := make([]ResolveCandidate, 0, len(pids))
 	for _, pid := range pids {
-		c := resolveClaudePID(ctx, pid)
-		if c.SessionID != "" {
-			candidates = append(candidates, c)
-		}
+		candidates = append(candidates, resolveClaudePID(ctx, probe, pid, now)...)
 	}
 	candidates = dedupeCandidates(candidates)
 	if len(candidates) == 0 {
@@ -139,226 +171,69 @@ func isDescendantOf(pid, ancestor string, parents map[string]string) bool {
 	}
 }
 
-func resolveClaudePID(ctx context.Context, pid string) ResolveCandidate {
-	args := procArgs(ctx, pid)
-	sessionID := parseResumeSessionID(args)
-	cwd := procCwd(ctx, pid)
-	if sessionID == "" {
-		sessionID = transcriptSessionFromLsof(ctx, pid)
+// sameCwdAmbiguousResult fires when several claude descendants share a cwd and
+// cwd-based fallbacks surface multiple distinct sessions.
+func sameCwdAmbiguousResult(ctx context.Context, probe resolveProbe, pids []string, now time.Time) ResolveResult {
+	if len(pids) <= 1 {
+		return ResolveResult{}
 	}
-	if sessionID == "" && cwd != "" {
-		sessionID = transcriptSessionFromCwd(cwd)
-	}
-	if sessionID == "" && cwd != "" {
-		sessionID = sessionFromEventLog(cwd, eventlog.EventsJSONLPath())
-	}
-	return ResolveCandidate{SessionID: sessionID, PID: pid, Cwd: cwd}
-}
-
-// dedupeCandidates keeps one entry per session_id (first pid wins).
-func dedupeCandidates(in []ResolveCandidate) []ResolveCandidate {
-	seen := map[string]bool{}
-	out := make([]ResolveCandidate, 0, len(in))
-	for _, c := range in {
-		if c.SessionID == "" || seen[c.SessionID] {
-			continue
-		}
-		seen[c.SessionID] = true
-		out = append(out, c)
-	}
-	return out
-}
-
-// sameCwdAmbiguousResult fires when multiple claude children share a cwd and
-// more than one session could own that terminal — plain `claude` without
-// --resume cannot be attributed to a single transcript.
-func sameCwdAmbiguousResult(ctx context.Context, pids []string) ResolveResult {
 	byCwd := map[string][]string{}
 	for _, pid := range pids {
-		cwd := procCwd(ctx, pid)
+		cwd, _ := probe.procCwd(ctx, pid)
+		cwd = filepath.Clean(cwd)
 		if cwd == "" {
 			continue
 		}
 		byCwd[cwd] = append(byCwd[cwd], pid)
 	}
-	for cwd, cpids := range byCwd {
-		if len(cpids) < 2 {
+	projectsRoot := claudeProjectsDir()
+	for cwd, group := range byCwd {
+		if len(group) <= 1 {
 			continue
 		}
-		cands := transcriptCandidatesForCwd(cwd, recentTranscriptWindow)
-		if len(cands) == 0 {
-			cands = eventLogCandidatesForCwd(cwd, eventlog.EventsJSONLPath(), recentTranscriptWindow)
+		if allResolvedViaPrimary(ctx, probe, group) {
+			continue
 		}
-		for i := range cands {
-			cands[i].Cwd = cwd
-			if cands[i].PID == "" && len(cpids) > 0 {
-				cands[i].PID = cpids[0]
-			}
+		ids := recentTranscriptSessionIDs(projectsRoot, cwd, now)
+		if len(ids) <= 1 {
+			continue
 		}
-		if len(cands) > 1 {
-			return ResolveResult{Ambiguous: true, Candidates: cands}
-		}
-		if len(cands) == 1 {
-			// One transcript but two processes — still ambiguous (cannot pick).
-			return ResolveResult{Ambiguous: true, Candidates: cands}
+		return ResolveResult{
+			Ambiguous:  true,
+			Candidates: candidatesFromIDs(ids, group[0], cwd),
 		}
 	}
 	return ResolveResult{}
 }
 
-// recentTranscriptWindow bounds which on-disk transcripts count as live when
-// disambiguating same-cwd plain-claude terminals.
-const recentTranscriptWindow = 2 * time.Hour
-
-// encodeProjectPath mirrors Claude Code's project-folder naming (see cost package).
-func encodeProjectPath(p string) string {
-	var b strings.Builder
-	b.Grow(len(p))
-	for _, r := range p {
-		switch {
-		case r >= 'a' && r <= 'z', r >= 'A' && r <= 'Z', r >= '0' && r <= '9':
-			b.WriteRune(r)
-		default:
-			b.WriteRune('-')
-		}
-	}
-	return b.String()
-}
-
-func projectDirForCwd(cwd string) string {
-	root := claudeProjectsDir()
-	if root == "" || cwd == "" {
-		return ""
-	}
-	encoded := filepath.Join(root, encodeProjectPath(cwd))
-	if fi, err := os.Stat(encoded); err == nil && fi.IsDir() {
-		return encoded
-	}
-	return encoded
-}
-
-type transcriptEntry struct {
-	sessionID string
-	mod       time.Time
-}
-
-// transcriptSessionsInDir returns session ids from .jsonl files in dir, newest
-// mtime first. Only files modified within within are included.
-func transcriptSessionsInDir(dir string, within time.Duration) []transcriptEntry {
-	entries, err := os.ReadDir(dir)
-	if err != nil {
-		return nil
-	}
-	cutoff := time.Now().Add(-within)
-	var out []transcriptEntry
-	for _, e := range entries {
-		if e.IsDir() || !strings.HasSuffix(e.Name(), ".jsonl") {
-			continue
-		}
-		info, err := e.Info()
-		if err != nil || info.ModTime().Before(cutoff) {
-			continue
-		}
-		id := strings.TrimSuffix(e.Name(), ".jsonl")
-		if id == "" {
-			continue
-		}
-		out = append(out, transcriptEntry{sessionID: id, mod: info.ModTime()})
-	}
-	sort.Slice(out, func(i, j int) bool {
-		return out[i].mod.After(out[j].mod)
-	})
-	return out
-}
-
-// transcriptSessionFromCwd picks the newest recently-modified transcript in the
-// Claude Code project folder for cwd.
-func transcriptSessionFromCwd(cwd string) string {
-	dir := projectDirForCwd(cwd)
-	if dir == "" {
-		return ""
-	}
-	entries := transcriptSessionsInDir(dir, recentTranscriptWindow)
-	if len(entries) == 0 {
-		return ""
-	}
-	return entries[0].sessionID
-}
-
-// transcriptCandidatesForCwd lists recent transcript session ids for cwd.
-func transcriptCandidatesForCwd(cwd string, within time.Duration) []ResolveCandidate {
-	dir := projectDirForCwd(cwd)
-	if dir == "" {
-		return nil
-	}
-	entries := transcriptSessionsInDir(dir, within)
-	out := make([]ResolveCandidate, 0, len(entries))
-	for _, e := range entries {
-		out = append(out, ResolveCandidate{SessionID: e.sessionID, Cwd: cwd})
-	}
-	return out
-}
-
-// resolveEnvelope is the minimal events.jsonl line for cwd correlation.
-type resolveEnvelope struct {
-	Schema    int    `json:"schema"`
-	Tool      string `json:"tool"`
-	SessionID string `json:"session_id"`
-	Raw       struct {
-		Cwd string `json:"cwd"`
-	} `json:"raw_event"`
-}
-
-// sessionFromEventLog returns the most recent claude-code session_id seen at cwd.
-func sessionFromEventLog(cwd, path string) string {
-	cands := eventLogCandidatesForCwd(cwd, path, recentTranscriptWindow)
-	if len(cands) == 0 {
-		return ""
-	}
-	return cands[0].SessionID
-}
-
-// eventLogCandidatesForCwd scans the event log tail for distinct session ids at
-// cwd, newest activity first.
-func eventLogCandidatesForCwd(cwd, path string, within time.Duration) []ResolveCandidate {
-	lines, err := tailLines(path, defaultMaxBytes)
-	if err != nil || len(lines) == 0 {
-		return nil
-	}
-	cutoff := time.Now().Add(-within)
+func allResolvedViaPrimary(ctx context.Context, probe resolveProbe, pids []string) bool {
 	seen := map[string]bool{}
-	var out []ResolveCandidate
-	for i := len(lines) - 1; i >= 0; i-- {
-		line := strings.TrimSpace(lines[i])
-		if line == "" {
+	for _, pid := range pids {
+		args, _ := probe.procArgs(ctx, pid)
+		if sid := parseResumeSessionID(args); sid != "" {
+			seen[sid] = true
 			continue
 		}
-		var e resolveEnvelope
-		if err := json.Unmarshal([]byte(line), &e); err != nil {
-			continue
+		lsofOut, _ := probe.lsof(ctx, pid)
+		if sid := parseTranscriptSessionID(lsofOut); sid != "" {
+			seen[sid] = true
 		}
-		if e.Schema < 2 || e.Tool != "claude-code" || e.SessionID == "" {
-			continue
-		}
-		if e.Raw.Cwd != cwd {
-			continue
-		}
-		if seen[e.SessionID] {
-			continue
-		}
-		seen[e.SessionID] = true
-		_ = cutoff // tail is bounded; recency is implied by reverse scan order
-		out = append(out, ResolveCandidate{SessionID: e.SessionID, Cwd: cwd})
 	}
-	return out
+	return len(seen) == 1
 }
 
-func procArgs(ctx context.Context, pid string) string {
-	out, err := exec.CommandContext(ctx, "ps", "-p", pid, "-o", "args=").Output()
-	if err != nil {
-		return ""
+func resolveClaudePID(ctx context.Context, probe resolveProbe, pid string, now time.Time) []ResolveCandidate {
+	args, _ := probe.procArgs(ctx, pid)
+	sessionID := parseResumeSessionID(args)
+	if sessionID == "" {
+		lsofOut, _ := probe.lsof(ctx, pid)
+		sessionID = parseTranscriptSessionID(lsofOut)
 	}
-	return strings.TrimSpace(string(out))
+	cwd, _ := probe.procCwd(ctx, pid)
+	if sessionID != "" {
+		return []ResolveCandidate{{SessionID: sessionID, PID: pid, Cwd: cwd}}
+	}
+	return resolveFallbackCandidates(pid, cwd, now)
 }
 
 // parseResumeSessionID extracts the session id from a claude argv string.
@@ -370,16 +245,6 @@ func parseResumeSessionID(args string) string {
 		}
 	}
 	return ""
-}
-
-// transcriptSessionFromLsof finds an open Claude Code transcript for pid and
-// returns the session id from its filename (<session-id>.jsonl).
-func transcriptSessionFromLsof(ctx context.Context, pid string) string {
-	out, err := exec.CommandContext(ctx, "lsof", "-Fn", "-p", pid).Output()
-	if err != nil {
-		return ""
-	}
-	return parseTranscriptSessionID(string(out))
 }
 
 // parseTranscriptSessionID scans lsof -Fn output for a .jsonl path under

--- a/internal/sessions/resolve_fallback.go
+++ b/internal/sessions/resolve_fallback.go
@@ -1,0 +1,286 @@
+package sessions
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/promptconduit/cli/internal/eventlog"
+)
+
+// fallbackRecentWindow bounds which transcripts and SessionStart events count as
+// plausibly active when cwd-based resolution can't see an open transcript fd.
+const fallbackRecentWindow = 24 * time.Hour
+
+// claudeSessionsDir is where Claude Code stores per-pid session metadata
+// (~/.claude/sessions/<pid>.json). Returns "" when home can't be determined.
+func claudeSessionsDir() string {
+	home, err := os.UserHomeDir()
+	if err != nil || home == "" {
+		return ""
+	}
+	return filepath.Join(home, ".claude", "sessions")
+}
+
+// claudeSessionFile is the subset of ~/.claude/sessions/<pid>.json we read.
+type claudeSessionFile struct {
+	SessionID string `json:"sessionId"`
+	Cwd       string `json:"cwd"`
+}
+
+// encodeProjectPath mirrors Claude Code's project-folder naming: every
+// non-alphanumeric character in the absolute cwd becomes a dash.
+func encodeProjectPath(p string) string {
+	var b strings.Builder
+	b.Grow(len(p))
+	for _, r := range p {
+		switch {
+		case r >= 'a' && r <= 'z', r >= 'A' && r <= 'Z', r >= '0' && r <= '9':
+			b.WriteRune(r)
+		default:
+			b.WriteRune('-')
+		}
+	}
+	return b.String()
+}
+
+// projectDirForCwd resolves ~/.claude/projects/<encoded-cwd>, falling back to
+// a folder whose newest transcript records the given cwd when the encoded name
+// doesn't exist yet.
+func projectDirForCwd(projectsRoot, cwd string) string {
+	if projectsRoot == "" || cwd == "" {
+		return ""
+	}
+	encoded := filepath.Join(projectsRoot, encodeProjectPath(cwd))
+	if fi, err := os.Stat(encoded); err == nil && fi.IsDir() {
+		return encoded
+	}
+	return scanProjectDirForCwd(projectsRoot, cwd)
+}
+
+// scanProjectDirForCwd walks project folders and returns the one whose newest
+// transcript records the given cwd.
+func scanProjectDirForCwd(projectsRoot, cwd string) string {
+	entries, err := os.ReadDir(projectsRoot)
+	if err != nil {
+		return ""
+	}
+	cwd = filepath.Clean(cwd)
+	for _, e := range entries {
+		if !e.IsDir() {
+			continue
+		}
+		dir := filepath.Join(projectsRoot, e.Name())
+		for _, path := range listRecentTranscripts(dir, time.Time{}) {
+			if launchCwdFromTranscript(path) == cwd {
+				return dir
+			}
+		}
+	}
+	return ""
+}
+
+type transcriptFile struct {
+	path string
+	mod  time.Time
+}
+
+// listRecentTranscripts returns .jsonl files in dir with mtime at or after
+// cutoff, sorted newest-first. A zero cutoff includes every transcript.
+func listRecentTranscripts(dir string, cutoff time.Time) []string {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return nil
+	}
+	var files []transcriptFile
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), ".jsonl") {
+			continue
+		}
+		info, err := e.Info()
+		if err != nil {
+			continue
+		}
+		mod := info.ModTime()
+		if !cutoff.IsZero() && mod.Before(cutoff) {
+			continue
+		}
+		files = append(files, transcriptFile{filepath.Join(dir, e.Name()), mod})
+	}
+	sort.Slice(files, func(i, j int) bool {
+		return files[i].mod.After(files[j].mod)
+	})
+	out := make([]string, len(files))
+	for i, f := range files {
+		out[i] = f.path
+	}
+	return out
+}
+
+// sessionIDFromTranscriptPath returns the session id from <session-id>.jsonl.
+func sessionIDFromTranscriptPath(path string) string {
+	return strings.TrimSuffix(filepath.Base(path), ".jsonl")
+}
+
+// recentTranscriptSessionIDs lists session ids for transcripts in the project
+// folder for cwd that were modified within the recent window.
+func recentTranscriptSessionIDs(projectsRoot, cwd string, now time.Time) []string {
+	dir := projectDirForCwd(projectsRoot, cwd)
+	if dir == "" {
+		return nil
+	}
+	cutoff := now.Add(-fallbackRecentWindow)
+	var ids []string
+	seen := map[string]bool{}
+	for _, path := range listRecentTranscripts(dir, cutoff) {
+		id := sessionIDFromTranscriptPath(path)
+		if id == "" || seen[id] {
+			continue
+		}
+		seen[id] = true
+		ids = append(ids, id)
+	}
+	return ids
+}
+
+// sessionStartEnvelope is the minimal events.jsonl slice for SessionStart lookup.
+type sessionStartEnvelope struct {
+	Schema     int    `json:"schema"`
+	Tool       string `json:"tool"`
+	HookEvent  string `json:"hook_event"`
+	CapturedAt string `json:"captured_at"`
+	SessionID  string `json:"session_id"`
+	Raw        struct {
+		Cwd string `json:"cwd"`
+	} `json:"raw_event"`
+}
+
+// recentSessionStartsFromEvents returns session ids from SessionStart events in
+// the event log tail whose cwd matches, newest captured_at first.
+func recentSessionStartsFromEvents(eventsPath, cwd string, now time.Time) ([]string, error) {
+	lines, err := tailLines(eventsPath, defaultMaxBytes)
+	if err != nil {
+		return nil, err
+	}
+	cutoff := now.Add(-fallbackRecentWindow)
+	cwd = filepath.Clean(cwd)
+
+	type hit struct {
+		id string
+		at time.Time
+	}
+	var hits []hit
+	seen := map[string]bool{}
+	for _, line := range lines {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		var e sessionStartEnvelope
+		if err := json.Unmarshal([]byte(line), &e); err != nil {
+			continue
+		}
+		if e.Schema < 2 || e.Tool != "claude-code" || e.HookEvent != "SessionStart" {
+			continue
+		}
+		if e.SessionID == "" || filepath.Clean(e.Raw.Cwd) != cwd {
+			continue
+		}
+		t, err := time.Parse(time.RFC3339, e.CapturedAt)
+		if err != nil || t.Before(cutoff) {
+			continue
+		}
+		if seen[e.SessionID] {
+			continue
+		}
+		seen[e.SessionID] = true
+		hits = append(hits, hit{e.SessionID, t})
+	}
+	sort.Slice(hits, func(i, j int) bool {
+		return hits[i].at.After(hits[j].at)
+	})
+	ids := make([]string, len(hits))
+	for i, h := range hits {
+		ids[i] = h.id
+	}
+	return ids, nil
+}
+
+// sessionFromPidFile reads ~/.claude/sessions/<pid>.json for a session id.
+func sessionFromPidFile(sessionsRoot, pid string) string {
+	if sessionsRoot == "" || pid == "" {
+		return ""
+	}
+	data, err := os.ReadFile(filepath.Join(sessionsRoot, pid+".json"))
+	if err != nil {
+		return ""
+	}
+	var rec claudeSessionFile
+	if err := json.Unmarshal(data, &rec); err != nil || rec.SessionID == "" {
+		return ""
+	}
+	return rec.SessionID
+}
+
+// resolveFallbackCandidates applies cwd-based fallbacks when --resume and lsof
+// did not resolve a session. Priority: Claude pid file (C), recent transcripts
+// in the project folder (A), then SessionStart rows in events.jsonl (B). When
+// multiple candidates remain and the pid file can't disambiguate, every option
+// is returned so the caller can set Ambiguous.
+func resolveFallbackCandidates(pid, cwd string, now time.Time) []ResolveCandidate {
+	cwd = filepath.Clean(cwd)
+	if cwd == "" {
+		return nil
+	}
+
+	projectsRoot := claudeProjectsDir()
+	sessionsRoot := claudeSessionsDir()
+	eventsPath := eventlog.EventsJSONLPath()
+
+	// C: pid-scoped Claude state is the most reliable per-process mapping.
+	if sid := sessionFromPidFile(sessionsRoot, pid); sid != "" {
+		return []ResolveCandidate{{SessionID: sid, PID: pid, Cwd: cwd}}
+	}
+
+	// A: cwd + recently written transcripts in the encoded project folder.
+	if ids := recentTranscriptSessionIDs(projectsRoot, cwd, now); len(ids) == 1 {
+		return []ResolveCandidate{{SessionID: ids[0], PID: pid, Cwd: cwd}}
+	} else if len(ids) > 1 {
+		return candidatesFromIDs(ids, pid, cwd)
+	}
+
+	// B: SessionStart + cwd in the local event log.
+	ids, err := recentSessionStartsFromEvents(eventsPath, cwd, now)
+	if err != nil || len(ids) == 0 {
+		return nil
+	}
+	if len(ids) == 1 {
+		return []ResolveCandidate{{SessionID: ids[0], PID: pid, Cwd: cwd}}
+	}
+	return candidatesFromIDs(ids, pid, cwd)
+}
+
+func candidatesFromIDs(ids []string, pid, cwd string) []ResolveCandidate {
+	out := make([]ResolveCandidate, 0, len(ids))
+	for _, id := range ids {
+		out = append(out, ResolveCandidate{SessionID: id, PID: pid, Cwd: cwd})
+	}
+	return out
+}
+
+// dedupeCandidates collapses duplicate session ids, keeping the first pid seen.
+func dedupeCandidates(in []ResolveCandidate) []ResolveCandidate {
+	seen := map[string]bool{}
+	out := make([]ResolveCandidate, 0, len(in))
+	for _, c := range in {
+		if c.SessionID == "" || seen[c.SessionID] {
+			continue
+		}
+		seen[c.SessionID] = true
+		out = append(out, c)
+	}
+	return out
+}

--- a/internal/sessions/resolve_test.go
+++ b/internal/sessions/resolve_test.go
@@ -111,7 +111,7 @@ func TestEncodeProjectPath(t *testing.T) {
 	}
 }
 
-func TestTranscriptSessionsInDir(t *testing.T) {
+func TestListRecentTranscripts(t *testing.T) {
 	dir := t.TempDir()
 
 	mustTouch := func(name string, mod time.Time) {
@@ -127,16 +127,16 @@ func TestTranscriptSessionsInDir(t *testing.T) {
 	mustTouch("older.jsonl", now.Add(-30*time.Minute))
 	mustTouch("newer.jsonl", now.Add(-1*time.Minute))
 
-	got := transcriptSessionsInDir(dir, time.Hour)
+	got := listRecentTranscripts(dir, now.Add(-time.Hour))
 	if len(got) != 2 {
 		t.Fatalf("got %d entries, want 2", len(got))
 	}
-	if got[0].sessionID != "newer" {
-		t.Fatalf("newest first: got %q", got[0].sessionID)
+	if sessionIDFromTranscriptPath(got[0]) != "newer" {
+		t.Fatalf("newest first: got %q", got[0])
 	}
 }
 
-func TestTranscriptSessionFromCwd(t *testing.T) {
+func TestResolveFallbackCandidates_transcript(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
 	projects := filepath.Join(home, ".claude", "projects")
@@ -149,24 +149,30 @@ func TestTranscriptSessionFromCwd(t *testing.T) {
 	if err := os.WriteFile(path, []byte("{}"), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	if got := transcriptSessionFromCwd(cwd); got != "sess-abc" {
-		t.Fatalf("got %q", got)
+	now := time.Now()
+	cands := resolveFallbackCandidates("53134", cwd, now)
+	if len(cands) != 1 || cands[0].SessionID != "sess-abc" {
+		t.Fatalf("got %#v", cands)
 	}
 }
 
-func TestEventLogCandidatesForCwd(t *testing.T) {
+func TestRecentSessionStartsFromEvents(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "events.jsonl")
 	lines := []string{
-		`{"schema":2,"tool":"claude-code","session_id":"old","raw_event":{"cwd":"/a"}}`,
-		`{"schema":2,"tool":"claude-code","session_id":"new","raw_event":{"cwd":"/a"}}`,
-		`{"schema":2,"tool":"cursor","session_id":"c1","raw_event":{"cwd":"/a"}}`,
+		`{"schema":2,"tool":"claude-code","hook_event":"SessionStart","session_id":"old","captured_at":"2026-07-01T10:00:00Z","raw_event":{"cwd":"/a"}}`,
+		`{"schema":2,"tool":"claude-code","hook_event":"SessionStart","session_id":"new","captured_at":"2026-07-01T12:00:00Z","raw_event":{"cwd":"/a"}}`,
+		`{"schema":2,"tool":"cursor","hook_event":"sessionStart","session_id":"c1","captured_at":"2026-07-01T12:00:00Z","raw_event":{"cwd":"/a"}}`,
 	}
 	if err := os.WriteFile(path, []byte(stringsJoin(lines)), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	got := eventLogCandidatesForCwd("/a", path, time.Hour)
-	want := []ResolveCandidate{{SessionID: "new", Cwd: "/a"}, {SessionID: "old", Cwd: "/a"}}
+	now, _ := time.Parse(time.RFC3339, "2026-07-01T13:00:00Z")
+	got, err := recentSessionStartsFromEvents(path, "/a", now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := []string{"new", "old"}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("got %#v want %#v", got, want)
 	}

--- a/internal/sessions/resolve_test.go
+++ b/internal/sessions/resolve_test.go
@@ -1,9 +1,11 @@
 package sessions
 
 import (
+	"os"
 	"path/filepath"
 	"reflect"
 	"testing"
+	"time"
 )
 
 func TestParseProcessTree(t *testing.T) {
@@ -99,4 +101,96 @@ func TestIsDescendantOf(t *testing.T) {
 	if isDescendantOf("53134", "15823", parents) {
 		t.Fatal("53134 is not under 15823")
 	}
+}
+
+func TestEncodeProjectPath(t *testing.T) {
+	got := encodeProjectPath("/Users/x/GitHub/foo")
+	want := "-Users-x-GitHub-foo"
+	if got != want {
+		t.Fatalf("encodeProjectPath = %q, want %q", got, want)
+	}
+}
+
+func TestTranscriptSessionsInDir(t *testing.T) {
+	dir := t.TempDir()
+
+	mustTouch := func(name string, mod time.Time) {
+		p := filepath.Join(dir, name)
+		if err := os.WriteFile(p, []byte("{}"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.Chtimes(p, mod, mod); err != nil {
+			t.Fatal(err)
+		}
+	}
+	now := time.Now()
+	mustTouch("older.jsonl", now.Add(-30*time.Minute))
+	mustTouch("newer.jsonl", now.Add(-1*time.Minute))
+
+	got := transcriptSessionsInDir(dir, time.Hour)
+	if len(got) != 2 {
+		t.Fatalf("got %d entries, want 2", len(got))
+	}
+	if got[0].sessionID != "newer" {
+		t.Fatalf("newest first: got %q", got[0].sessionID)
+	}
+}
+
+func TestTranscriptSessionFromCwd(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	projects := filepath.Join(home, ".claude", "projects")
+	cwd := "/tmp/my-project"
+	projDir := filepath.Join(projects, encodeProjectPath(cwd))
+	if err := os.MkdirAll(projDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(projDir, "sess-abc.jsonl")
+	if err := os.WriteFile(path, []byte("{}"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if got := transcriptSessionFromCwd(cwd); got != "sess-abc" {
+		t.Fatalf("got %q", got)
+	}
+}
+
+func TestEventLogCandidatesForCwd(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "events.jsonl")
+	lines := []string{
+		`{"schema":2,"tool":"claude-code","session_id":"old","raw_event":{"cwd":"/a"}}`,
+		`{"schema":2,"tool":"claude-code","session_id":"new","raw_event":{"cwd":"/a"}}`,
+		`{"schema":2,"tool":"cursor","session_id":"c1","raw_event":{"cwd":"/a"}}`,
+	}
+	if err := os.WriteFile(path, []byte(stringsJoin(lines)), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	got := eventLogCandidatesForCwd("/a", path, time.Hour)
+	want := []ResolveCandidate{{SessionID: "new", Cwd: "/a"}, {SessionID: "old", Cwd: "/a"}}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("got %#v want %#v", got, want)
+	}
+}
+
+func TestDedupeCandidates(t *testing.T) {
+	in := []ResolveCandidate{
+		{SessionID: "a", PID: "1"},
+		{SessionID: "a", PID: "2"},
+		{SessionID: "b", PID: "3"},
+	}
+	got := dedupeCandidates(in)
+	if len(got) != 2 || got[0].SessionID != "a" || got[1].SessionID != "b" {
+		t.Fatalf("got %#v", got)
+	}
+}
+
+func stringsJoin(ss []string) string {
+	out := ""
+	for i, s := range ss {
+		if i > 0 {
+			out += "\n"
+		}
+		out += s
+	}
+	return out + "\n"
 }


### PR DESCRIPTION
## Summary
- Implements cli#111: when `claude --resume` and lsof miss the transcript fd, resolve via cwd + newest project transcript, `~/.promptconduit/events.jsonl` SessionStart correlation, and `~/.claude/sessions/<pid>.json`
- Same-cwd multi-terminal plain `claude` returns `ambiguous: true` with candidates
- Optional cli#63: Cursor cache pricing deferral comment, model aliases, documents existing `cost watch --all` Cursor feed rescan

## Test plan
- [x] `go test ./internal/sessions/...`
- [x] `go test ./internal/cost/...`
- [x] `go test ./...`
- [ ] Manual: two Claude terminals in one cwd → QuickPick / ambiguous JSON
- [ ] Manual: plain `claude` terminal focus updates extension breakdown


Made with [Cursor](https://cursor.com)