### PR TITLE
fix: detect Cursor hooks before claude-code heuristic

### DIFF
--- a/cmd/hook.go
+++ b/cmd/hook.go
@@ -263,17 +263,19 @@ func detectTool(event map[string]interface{}) string {
 		return tool
 	}
 
+	// Cursor: has cursor_version field. Must precede the hook_event_name check —
+	// Cursor hooks also carry hook_event_name, so checking that first would
+	// mislabel every Cursor event as claude-code.
+	if _, ok := event["cursor_version"]; ok {
+		return "cursor"
+	}
+
 	// Claude Code: has hook_event_name or hook_event field
 	if _, ok := event["hook_event_name"]; ok {
 		return "claude-code"
 	}
 	if _, ok := event["hook_event"]; ok {
 		return "claude-code"
-	}
-
-	// Cursor: has cursor_version field
-	if _, ok := event["cursor_version"]; ok {
-		return "cursor"
 	}
 
 	// Gemini: has gemini_session field

--- a/cmd/hook_detect_test.go
+++ b/cmd/hook_detect_test.go
@@ -1,0 +1,47 @@
+package cmd
+
+import "testing"
+
+func TestDetectTool(t *testing.T) {
+	tests := []struct {
+		name  string
+		event map[string]interface{}
+		want  string
+	}{
+		{
+			name:  "claude code",
+			event: map[string]interface{}{"hook_event_name": "PostToolUse", "session_id": "abc"},
+			want:  "claude-code",
+		},
+		{
+			name: "cursor with hook_event_name",
+			event: map[string]interface{}{
+				"hook_event_name":  "postToolUse",
+				"cursor_version":   "1.0",
+				"conversation_id":  "conv-1",
+				"generation_id":    "gen-1",
+				"model":            "composer-2.5",
+				"workspace_roots":  []interface{}{"/tmp/proj"},
+			},
+			want: "cursor",
+		},
+		{
+			name:  "gemini",
+			event: map[string]interface{}{"gemini_session": "sess", "event": "foo"},
+			want:  "gemini-cli",
+		},
+		{
+			name:  "unknown generic event",
+			event: map[string]interface{}{"event": "something"},
+			want:  "unknown",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := detectTool(tt.event); got != tt.want {
+				t.Errorf("detectTool() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
Cursor hook payloads include both `cursor_version` and `hook_event_name`. Because `detectTool` checked `hook_event_name` first, every Cursor session was written to `events.jsonl` with `tool: "claude-code"`, showing the wrong badge in Stream and Cost Breakdown.

This PR reorders detection so `cursor_version` wins, with a regression test.

Closes #113

## Changes

### Hook detection
- Check `cursor_version` before `hook_event_name` in `detectTool`
- Add `TestDetectTool` covering Cursor payloads that carry both fields

## Architecture

```mermaid
flowchart LR
    payload[Hook JSON] --> detect{detectTool}
    detect -->|cursor_version| cursor[cursor]
    detect -->|hook_event_name only| claude[claude-code]
    cursor --> log[events.jsonl]
    claude --> log
```

## Testing
- `go test ./cmd/ -run TestDetectTool -v` — PASS
- `go test ./cmd/ -count=1` — PASS

## Agent Review Context
- **change-type**: fix
- **risk-level**: low
- **key-files**: cmd/hook.go, cmd/hook_detect_test.go
- **testing-confidence**: high

## Changelog
Platform PR pending: 0.13.1 entry in `releases.ts`

## Checklist
- [x] Tests pass
- [x] No breaking changes
- [x] Code follows project conventions

Made with [Cursor](https://cursor.com)