### PR TITLE
feat: promptconduit login and init onboarding commands

### DIFF
--- a/cmd/init.go
+++ b/cmd/init.go
@@ -48,6 +48,11 @@ func runInit(cmd *cobra.Command, args []string) error {
 	// Step 1: Choose mode (unless flags preset it)
 	if !initLocalOnly && !initYes && outbound.IsTerminal(os.Stdin) && initAPIKey == "" {
 		cloudMode, initLocalOnly = promptInitMode(cmd)
+	} else if !initLocalOnly && !outbound.IsTerminal(os.Stdin) && initAPIKey == "" {
+		cfg := client.LoadConfig()
+		if !cfg.IsConfigured() {
+			return fmt.Errorf("non-interactive mode: pass --local-only, --api-key, or run in a terminal to sign in")
+		}
 	}
 
 	if initLocalOnly {
@@ -74,6 +79,9 @@ func runInit(cmd *cobra.Command, args []string) error {
 		} else {
 			cfg := client.LoadConfig()
 			if !cfg.IsConfigured() {
+				if !outbound.IsTerminal(os.Stdin) {
+					return fmt.Errorf("non-interactive mode: pass --api-key or run promptconduit login in a terminal first")
+				}
 				_, _ = fmt.Fprintln(out, "No API key found — starting login...")
 				_, _ = fmt.Fprintln(out)
 				if _, err := performLogin(cmd, "", true); err != nil {

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -1,0 +1,288 @@
+package cmd
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/promptconduit/cli/internal/client"
+	"github.com/promptconduit/cli/internal/outbound"
+	"github.com/spf13/cobra"
+)
+
+var initCmd = &cobra.Command{
+	Use:   "init",
+	Short: "Interactive setup wizard",
+	Long: `Guided setup for PromptConduit: choose cloud sync or local-only mode,
+authenticate (if needed), detect installed AI tools, and install hooks.
+
+Run with no flags for an interactive wizard, or use --yes to accept defaults.`,
+	RunE: runInit,
+}
+
+var (
+	initLocalOnly bool
+	initAPIKey    string
+	initYes       bool
+	initTools     string
+)
+
+func init() {
+	initCmd.Flags().BoolVar(&initLocalOnly, "local-only", false, "Local-only mode — no account or cloud sync")
+	initCmd.Flags().StringVar(&initAPIKey, "api-key", "", "Set API key directly (skips login)")
+	initCmd.Flags().BoolVar(&initYes, "yes", false, "Non-interactive: install all detected tools")
+	initCmd.Flags().StringVar(&initTools, "tools", "", "Comma-separated tools to install (skips picker)")
+}
+
+func runInit(cmd *cobra.Command, args []string) error {
+	out := cmd.OutOrStdout()
+
+	_, _ = fmt.Fprintf(out, "PromptConduit CLI v%s\n", Version)
+	_, _ = fmt.Fprintln(out, "================================")
+	_, _ = fmt.Fprintln(out)
+
+	cloudMode := !initLocalOnly
+
+	// Step 1: Choose mode (unless flags preset it)
+	if !initLocalOnly && !initYes && outbound.IsTerminal(os.Stdin) && initAPIKey == "" {
+		cloudMode, initLocalOnly = promptInitMode(cmd)
+	}
+
+	if initLocalOnly {
+		cloudMode = false
+		if err := persistLocalOnly(true); err != nil {
+			_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "warning: could not save local-only setting: %v\n", err)
+		}
+		_, _ = fmt.Fprintln(out, "Mode: Free (local-only) — events captured locally, nothing sent to the cloud")
+	} else {
+		if err := persistLocalOnly(false); err != nil {
+			_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "warning: could not update local-only setting: %v\n", err)
+		}
+		_, _ = fmt.Fprintln(out, "Mode: Cloud sync — events sent to the PromptConduit platform")
+	}
+	_, _ = fmt.Fprintln(out)
+
+	// Step 2: API key / login for cloud mode
+	if cloudMode {
+		if initAPIKey != "" {
+			if err := client.SaveAPIKey(initAPIKey); err != nil {
+				return fmt.Errorf("failed to save API key: %w", err)
+			}
+			_, _ = fmt.Fprintf(out, "API key configured: %s\n\n", client.MaskAPIKey(initAPIKey))
+		} else {
+			cfg := client.LoadConfig()
+			if !cfg.IsConfigured() {
+				_, _ = fmt.Fprintln(out, "No API key found — starting login...")
+				_, _ = fmt.Fprintln(out)
+				if _, err := performLogin(cmd, "", true); err != nil {
+					return err
+				}
+				_, _ = fmt.Fprintln(out)
+			} else {
+				_, _ = fmt.Fprintf(out, "API key already configured: %s\n\n", client.MaskAPIKey(cfg.APIKey))
+			}
+		}
+	}
+
+	// Step 3: Detect and select tools
+	detected := detectInstalledTools()
+	var tools []string
+	var err error
+
+	if initTools != "" {
+		tools, err = parseToolSelection(initTools)
+		if err != nil {
+			return err
+		}
+	} else if initYes {
+		if len(detected) > 0 {
+			tools = detected
+		} else {
+			tools = toolNames()
+		}
+		_, _ = fmt.Fprintf(out, "Installing tools: %s\n\n", strings.Join(tools, ", "))
+	} else if len(args) > 0 {
+		tools, err = resolveInstallTools(cmd, args)
+		if err != nil {
+			return err
+		}
+	} else {
+		tools, err = selectToolsForInit(cmd, detected)
+		if err != nil {
+			return err
+		}
+	}
+
+	if len(tools) == 0 {
+		_, _ = fmt.Fprintln(out, "No tools selected — skipping hook installation.")
+	} else {
+		exePath, err := os.Executable()
+		if err != nil {
+			return fmt.Errorf("failed to get executable path: %w", err)
+		}
+		exePath, err = stableExecutablePath(exePath)
+		if err != nil {
+			return fmt.Errorf("failed to resolve executable path: %w", err)
+		}
+
+		_, _ = fmt.Fprintln(out, "Installing hooks...")
+		for i, tool := range tools {
+			if i > 0 {
+				_, _ = fmt.Fprintln(out)
+			}
+			if err := installTool(tool, exePath); err != nil {
+				return fmt.Errorf("install %s: %w", tool, err)
+			}
+		}
+		_, _ = fmt.Fprintln(out)
+	}
+
+	// Step 4: Test connectivity (cloud mode with API key)
+	cfg := client.LoadConfig()
+	if cfg.ShouldSend() {
+		_, _ = fmt.Fprintln(out, "Testing API connectivity...")
+		apiClient := client.NewClient(cfg, Version)
+		response := apiClient.TestConnection()
+		if response.Success {
+			_, _ = fmt.Fprintln(out, "✓ API connection verified")
+		} else {
+			_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "⚠ API test failed: %s\n", response.Error)
+		}
+		_, _ = fmt.Fprintln(out)
+	}
+
+	// Step 5: Summary
+	printInitSummary(cmd, tools, cloudMode)
+	return nil
+}
+
+func promptInitMode(cmd *cobra.Command) (cloudMode bool, localOnly bool) {
+	out := cmd.OutOrStdout()
+	_, _ = fmt.Fprintln(out, "How would you like to use PromptConduit?")
+	_, _ = fmt.Fprintln(out, "  1) Cloud sync — sign in and send events to the platform")
+	_, _ = fmt.Fprintln(out, "  2) Local-only — capture events locally, no account needed")
+	_, _ = fmt.Fprint(out, "Choose [1/2] (default 1): ")
+
+	line, err := bufio.NewReader(cmd.InOrStdin()).ReadString('\n')
+	if err != nil && strings.TrimSpace(line) == "" {
+		return true, false
+	}
+	choice := strings.TrimSpace(line)
+	if choice == "2" {
+		return false, true
+	}
+	return true, false
+}
+
+// selectToolsForInit shows the tool picker with detected tools pre-selected.
+func selectToolsForInit(cmd *cobra.Command, detected []string) ([]string, error) {
+	if !outbound.IsTerminal(os.Stdin) {
+		if len(detected) > 0 {
+			return detected, nil
+		}
+		return nil, fmt.Errorf("run in a terminal to pick tools, or pass --tools or --yes")
+	}
+
+	out := cmd.OutOrStdout()
+	_, _ = fmt.Fprintln(out, "Which AI tools should PromptConduit set up?")
+	for i, t := range installableTools {
+		marker := " "
+		for _, d := range detected {
+			if d == t.name {
+				marker = "*"
+				break
+			}
+		}
+		_, _ = fmt.Fprintf(out, "  %s %d) %s\n", marker, i+1, t.label)
+	}
+	if len(detected) > 0 {
+		_, _ = fmt.Fprintf(out, "\n  * = detected on this machine (%s)\n", strings.Join(detected, ", "))
+	}
+	defaultHint := "all"
+	if len(detected) > 0 {
+		defaultHint = strings.Join(detected, ",")
+	}
+	_, _ = fmt.Fprintf(out, "Enter numbers (e.g. 1,2), names, or 'all' [%s]: ", defaultHint)
+
+	line, err := bufio.NewReader(cmd.InOrStdin()).ReadString('\n')
+	if err != nil && strings.TrimSpace(line) == "" {
+		if len(detected) > 0 {
+			return detected, nil
+		}
+		return toolNames(), nil
+	}
+	if strings.TrimSpace(line) == "" {
+		if len(detected) > 0 {
+			return detected, nil
+		}
+		return toolNames(), nil
+	}
+	return parseToolSelection(line)
+}
+
+// detectInstalledTools checks common config paths for installed AI tools.
+func detectInstalledTools() []string {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return nil
+	}
+
+	checks := []struct {
+		tool  string
+		paths []string
+	}{
+		{"cursor", []string{".cursor/hooks.json", ".cursor"}},
+		{"claude-code", []string{".claude/settings.json", ".claude"}},
+		{"gemini-cli", []string{".gemini/settings.json"}},
+		{"codex", []string{".codex/hooks.json"}},
+		{"copilot", []string{".copilot/hooks"}},
+	}
+
+	var detected []string
+	seen := map[string]bool{}
+	for _, c := range checks {
+		for _, rel := range c.paths {
+			p := filepath.Join(home, rel)
+			if _, err := os.Stat(p); err == nil {
+				if !seen[c.tool] {
+					seen[c.tool] = true
+					detected = append(detected, c.tool)
+				}
+				break
+			}
+		}
+	}
+	return detected
+}
+
+func printInitSummary(cmd *cobra.Command, tools []string, cloudMode bool) {
+	out := cmd.OutOrStdout()
+	_, _ = fmt.Fprintln(out, "Setup complete!")
+	_, _ = fmt.Fprintln(out, "================")
+	if cloudMode {
+		_, _ = fmt.Fprintln(out, "  Mode:   Cloud sync")
+		cfg := client.LoadConfig()
+		if cfg.IsConfigured() {
+			_, _ = fmt.Fprintf(out, "  API:    %s (%s)\n", cfg.APIURL, client.MaskAPIKey(cfg.APIKey))
+		}
+	} else {
+		_, _ = fmt.Fprintln(out, "  Mode:   Local-only (Free)")
+	}
+	if len(tools) > 0 {
+		_, _ = fmt.Fprintf(out, "  Tools:  %s\n", strings.Join(tools, ", "))
+	} else {
+		_, _ = fmt.Fprintln(out, "  Tools:  (none installed)")
+	}
+	_, _ = fmt.Fprintln(out)
+	_, _ = fmt.Fprintln(out, "Next steps:")
+	if len(tools) > 0 {
+		_, _ = fmt.Fprintln(out, "  • Restart your AI tools to activate hooks")
+	}
+	_, _ = fmt.Fprintln(out, "  • Run `promptconduit status` to verify installation")
+	if cloudMode {
+		_, _ = fmt.Fprintln(out, "  • Run `promptconduit test` to verify API connectivity")
+	}
+	_, _ = fmt.Fprintln(out)
+}

--- a/cmd/init_test.go
+++ b/cmd/init_test.go
@@ -1,0 +1,44 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestDetectInstalledTools(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	// Create cursor marker
+	if err := os.MkdirAll(filepath.Join(home, ".cursor"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// Create claude marker
+	if err := os.Mkdir(filepath.Join(home, ".claude"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	got := detectInstalledTools()
+	if len(got) != 2 {
+		t.Fatalf("expected 2 detected tools, got %v", got)
+	}
+
+	seen := map[string]bool{}
+	for _, tool := range got {
+		seen[tool] = true
+	}
+	if !seen["cursor"] || !seen["claude-code"] {
+		t.Fatalf("expected cursor and claude-code, got %v", got)
+	}
+}
+
+func TestDetectInstalledTools_Empty(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	got := detectInstalledTools()
+	if len(got) != 0 {
+		t.Fatalf("expected no tools, got %v", got)
+	}
+}

--- a/cmd/login.go
+++ b/cmd/login.go
@@ -1,0 +1,107 @@
+package cmd
+
+import (
+	"fmt"
+	"os/exec"
+	"runtime"
+	"time"
+
+	"github.com/promptconduit/cli/internal/client"
+	"github.com/spf13/cobra"
+)
+
+var loginCmd = &cobra.Command{
+	Use:   "login",
+	Short: "Sign in to PromptConduit via browser",
+	Long: `Authenticate with your PromptConduit account using a browser-based device flow.
+
+Opens your browser to sign in and approve CLI access. On success, your API key
+is saved to ~/.config/promptconduit/config.json.
+
+Use --no-browser to print the verification URL instead of opening it automatically.`,
+	RunE: runLogin,
+}
+
+var (
+	loginNoBrowser bool
+	loginAPIURL    string
+)
+
+func init() {
+	loginCmd.Flags().BoolVar(&loginNoBrowser, "no-browser", false, "Don't open browser automatically")
+	loginCmd.Flags().StringVar(&loginAPIURL, "api-url", "", "Override API URL (default: from config or https://api.promptconduit.dev)")
+}
+
+func runLogin(cmd *cobra.Command, args []string) error {
+	apiKey, err := performLogin(cmd, loginAPIURL, !loginNoBrowser)
+	if err != nil {
+		return err
+	}
+
+	_, _ = fmt.Fprintf(cmd.OutOrStdout(), "\n✓ Logged in successfully\n")
+	_, _ = fmt.Fprintf(cmd.OutOrStdout(), "  API Key: %s\n", client.MaskAPIKey(apiKey))
+	_, _ = fmt.Fprintln(cmd.OutOrStdout(), "  Config:  ", client.ConfigPath())
+	return nil
+}
+
+// performLogin runs the device authorization flow and saves the API key.
+func performLogin(cmd *cobra.Command, apiURLOverride string, openBrowser bool) (string, error) {
+	apiURL := apiURLOverride
+	if apiURL == "" {
+		cfg := client.LoadConfig()
+		apiURL = cfg.APIURL
+	}
+
+	out := cmd.OutOrStdout()
+	_, _ = fmt.Fprintln(out, "Requesting device code...")
+
+	deviceResp, err := client.RequestDeviceCode(apiURL, Version)
+	if err != nil {
+		return "", fmt.Errorf("failed to start login: %w", err)
+	}
+
+	verificationURL := deviceResp.VerificationURI
+	if verificationURL == "" {
+		verificationURL = deviceResp.VerificationURIComplete
+	}
+
+	_, _ = fmt.Fprintf(out, "\nTo sign in, visit:\n  %s\n\n", verificationURL)
+	_, _ = fmt.Fprintf(out, "And enter code: %s\n\n", deviceResp.UserCode)
+
+	if openBrowser {
+		if err := openBrowserURL(verificationURL); err != nil {
+			_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Could not open browser: %v\n", err)
+			_, _ = fmt.Fprintln(cmd.ErrOrStderr(), "Open the URL above manually.")
+		}
+	}
+
+	_, _ = fmt.Fprintln(out, "Waiting for authorization...")
+	timeout := time.Duration(deviceResp.ExpiresIn) * time.Second
+	if timeout <= 0 {
+		timeout = 15 * time.Minute
+	}
+
+	apiKey, err := client.PollDeviceToken(apiURL, Version, deviceResp.DeviceCode, timeout)
+	if err != nil {
+		return "", err
+	}
+
+	if err := client.SaveAPIKey(apiKey); err != nil {
+		return "", fmt.Errorf("failed to save API key: %w", err)
+	}
+
+	return apiKey, nil
+}
+
+func openBrowserURL(url string) error {
+	var c *exec.Cmd
+	switch runtime.GOOS {
+	case "darwin":
+		c = exec.Command("open", url)
+	case "windows":
+		c = exec.Command("cmd", "/c", "start", url)
+	default:
+		c = exec.Command("xdg-open", url)
+	}
+	return c.Start()
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -30,11 +30,13 @@ Supported tools:
   - Claude Code
   - Cursor
   - Gemini CLI
+  - Codex
+  - GitHub Copilot
 
 Get started:
-  1. Set your API key: promptconduit config set --api-key="your-key"
-  2. Install hooks: promptconduit install claude-code
-  3. Use your AI assistant as normal - events are captured automatically`,
+  1. Install: curl -fsSL https://promptconduit.dev/install | bash
+  2. Sign in:  promptconduit login
+  3. Set up:   promptconduit init`,
 	PersistentPreRun: func(cmd *cobra.Command, args []string) {
 		maybeBackgroundUpdateCheck(cmd)
 	},
@@ -47,6 +49,8 @@ func Execute() error {
 func init() {
 	rootCmd.AddCommand(installCmd)
 	rootCmd.AddCommand(uninstallCmd)
+	rootCmd.AddCommand(loginCmd)
+	rootCmd.AddCommand(initCmd)
 	rootCmd.AddCommand(statusCmd)
 	rootCmd.AddCommand(testCmd)
 	rootCmd.AddCommand(hookCmd)

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -55,6 +55,8 @@ func runStatus(cmd *cobra.Command, args []string) error {
 	checkClaudeCodeInstallation()
 	checkCursorInstallation()
 	checkGeminiInstallation()
+	checkCodexInstallation()
+	checkCopilotInstallation()
 
 	return nil
 }
@@ -206,6 +208,77 @@ func checkGeminiInstallation() {
 		fmt.Printf("  Gemini CLI:  Installed (%d hooks)\n", count)
 	} else {
 		fmt.Println("  Gemini CLI:  Not installed")
+	}
+}
+
+func checkCodexInstallation() {
+	homeDir, _ := os.UserHomeDir()
+	settingsPath := filepath.Join(homeDir, ".codex", "hooks.json")
+
+	data, err := os.ReadFile(settingsPath)
+	if err != nil {
+		fmt.Println("  Codex:       Not installed (no hooks file)")
+		return
+	}
+
+	var settings map[string]interface{}
+	if err := json.Unmarshal(data, &settings); err != nil {
+		fmt.Println("  Codex:       Error reading hooks")
+		return
+	}
+
+	hooks, ok := settings["hooks"].(map[string]interface{})
+	if !ok {
+		fmt.Println("  Codex:       Not installed (no hooks)")
+		return
+	}
+
+	count := 0
+	for _, hookConfig := range hooks {
+		if containsPromptConduitString(hookConfig) {
+			count++
+		}
+	}
+
+	if count > 0 {
+		fmt.Printf("  Codex:       Installed (%d hooks)\n", count)
+	} else {
+		fmt.Println("  Codex:       Not installed")
+	}
+}
+
+func checkCopilotInstallation() {
+	homeDir, _ := os.UserHomeDir()
+	hooksDir := filepath.Join(homeDir, ".copilot", "hooks")
+
+	entries, err := os.ReadDir(hooksDir)
+	if err != nil {
+		fmt.Println("  Copilot:     Not installed (no hooks directory)")
+		return
+	}
+
+	count := 0
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		data, err := os.ReadFile(filepath.Join(hooksDir, entry.Name()))
+		if err != nil {
+			continue
+		}
+		var hook map[string]interface{}
+		if err := json.Unmarshal(data, &hook); err != nil {
+			continue
+		}
+		if containsPromptConduitString(hook) {
+			count++
+		}
+	}
+
+	if count > 0 {
+		fmt.Printf("  Copilot:     Installed (%d hooks)\n", count)
+	} else {
+		fmt.Println("  Copilot:     Not installed")
 	}
 }
 

--- a/internal/client/device_auth.go
+++ b/internal/client/device_auth.go
@@ -1,0 +1,173 @@
+package client
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+)
+
+// DeviceCodeResponse is returned by POST /v1/auth/device/code.
+type DeviceCodeResponse struct {
+	DeviceCode              string `json:"device_code"`
+	UserCode                string `json:"user_code"`
+	VerificationURI         string `json:"verification_uri"`
+	VerificationURIComplete string `json:"verification_uri_complete"`
+	ExpiresIn               int    `json:"expires_in"`
+	Interval                int    `json:"interval"`
+}
+
+// DeviceTokenResponse is returned on successful device authorization.
+type DeviceTokenResponse struct {
+	APIKey    string `json:"api_key"`
+	TokenType string `json:"token_type"`
+}
+
+// DeviceTokenError is an OAuth-style polling error.
+type DeviceTokenError struct {
+	Error            string `json:"error"`
+	ErrorDescription string `json:"error_description"`
+	Interval         int    `json:"interval,omitempty"`
+}
+
+// RequestDeviceCode starts the RFC 8628 device authorization flow.
+func RequestDeviceCode(apiURL, version string) (*DeviceCodeResponse, error) {
+	body, err := postJSON(apiURL+"/v1/auth/device/code", map[string]string{
+		"client_id": "cli",
+	}, version, "")
+	if err != nil {
+		return nil, err
+	}
+
+	var resp DeviceCodeResponse
+	if err := json.Unmarshal(body, &resp); err != nil {
+		return nil, fmt.Errorf("invalid device code response: %w", err)
+	}
+	if resp.DeviceCode == "" || resp.UserCode == "" {
+		return nil, fmt.Errorf("incomplete device code response")
+	}
+	return &resp, nil
+}
+
+// PollDeviceToken polls POST /v1/auth/device/token until authorized or timeout.
+func PollDeviceToken(apiURL, version, deviceCode string, timeout time.Duration) (string, error) {
+	deadline := time.Now().Add(timeout)
+	interval := 5 * time.Second
+
+	for time.Now().Before(deadline) {
+		body, status, err := postJSONWithStatus(apiURL+"/v1/auth/device/token", map[string]string{
+			"device_code": deviceCode,
+			"grant_type":  "urn:ietf:params:oauth:grant-type:device_code",
+		}, version, "")
+		if err != nil {
+			return "", err
+		}
+
+		// OAuth-style pending/slow_down responses use HTTP 400
+		if status == 400 {
+			var tokenErr DeviceTokenError
+			if err := json.Unmarshal(body, &tokenErr); err == nil && tokenErr.Error != "" {
+				switch tokenErr.Error {
+				case "authorization_pending":
+					if tokenErr.Interval > 0 {
+						interval = time.Duration(tokenErr.Interval) * time.Second
+					}
+					time.Sleep(interval)
+					continue
+				case "slow_down":
+					if tokenErr.Interval > 0 {
+						interval = time.Duration(tokenErr.Interval) * time.Second
+					} else {
+						interval += 5 * time.Second
+					}
+					time.Sleep(interval)
+					continue
+				case "expired_token":
+					return "", fmt.Errorf("device code expired — run `promptconduit login` again")
+				case "access_denied":
+					return "", fmt.Errorf("authorization denied")
+				default:
+					return "", fmt.Errorf("authorization failed: %s", tokenErr.ErrorDescription)
+				}
+			}
+			return "", fmt.Errorf("HTTP %d: %s", status, string(body))
+		}
+
+		if status < 200 || status >= 300 {
+			return "", fmt.Errorf("HTTP %d: %s", status, string(body))
+		}
+
+		var tokenResp DeviceTokenResponse
+		if err := json.Unmarshal(body, &tokenResp); err != nil {
+			return "", fmt.Errorf("invalid token response: %w", err)
+		}
+		if tokenResp.APIKey != "" {
+			return tokenResp.APIKey, nil
+		}
+
+		time.Sleep(interval)
+	}
+
+	return "", fmt.Errorf("authorization timed out — complete sign-in in your browser and run `promptconduit login` again")
+}
+
+func postJSON(url string, payload interface{}, version, bearerToken string) ([]byte, error) {
+	body, status, err := postJSONWithStatus(url, payload, version, bearerToken)
+	if err != nil {
+		return nil, err
+	}
+	if status < 200 || status >= 300 {
+		return body, fmt.Errorf("HTTP %d: %s", status, string(body))
+	}
+	return body, nil
+}
+
+func postJSONWithStatus(url string, payload interface{}, version, bearerToken string) ([]byte, int, error) {
+	jsonData, err := json.Marshal(payload)
+	if err != nil {
+		return nil, 0, fmt.Errorf("failed to marshal request: %w", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(jsonData))
+	if err != nil {
+		return nil, 0, fmt.Errorf("failed to create request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("User-Agent", fmt.Sprintf("PromptConduit-CLI/%s", version))
+	if bearerToken != "" {
+		req.Header.Set("Authorization", "Bearer "+bearerToken)
+	}
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, 0, fmt.Errorf("request failed: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, resp.StatusCode, fmt.Errorf("failed to read response: %w", err)
+	}
+
+	return body, resp.StatusCode, nil
+}
+
+// SaveAPIKey persists the API key to config and disables local-only mode.
+func SaveAPIKey(apiKey string) error {
+	fc, err := LoadFileConfig()
+	if err != nil {
+		return err
+	}
+	if fc == nil {
+		fc = &FileConfig{}
+	}
+	fc.APIKey = apiKey
+	fc.LocalOnly = false
+	return SaveFileConfig(fc)
+}

--- a/internal/client/device_auth.go
+++ b/internal/client/device_auth.go
@@ -158,7 +158,8 @@ func postJSONWithStatus(url string, payload interface{}, version, bearerToken st
 	return body, resp.StatusCode, nil
 }
 
-// SaveAPIKey persists the API key to config and disables local-only mode.
+// SaveAPIKey persists the API key to the active config (environment-aware) and
+// disables local-only mode.
 func SaveAPIKey(apiKey string) error {
 	fc, err := LoadFileConfig()
 	if err != nil {
@@ -167,7 +168,21 @@ func SaveAPIKey(apiKey string) error {
 	if fc == nil {
 		fc = &FileConfig{}
 	}
-	fc.APIKey = apiKey
+
+	if fc.CurrentEnv != "" {
+		if fc.Environments == nil {
+			fc.Environments = make(map[string]*Config)
+		}
+		cfg := fc.Environments[fc.CurrentEnv]
+		if cfg == nil {
+			cfg = &Config{}
+			fc.Environments[fc.CurrentEnv] = cfg
+		}
+		cfg.APIKey = apiKey
+		cfg.LocalOnly = false
+	} else {
+		fc.APIKey = apiKey
+	}
 	fc.LocalOnly = false
 	return SaveFileConfig(fc)
 }

--- a/internal/client/device_auth_test.go
+++ b/internal/client/device_auth_test.go
@@ -69,6 +69,30 @@ func TestPollDeviceToken_Success(t *testing.T) {
 	}
 }
 
+func TestSaveAPIKey_EnvironmentAware(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", dir)
+
+	fc := &FileConfig{
+		CurrentEnv: "prod",
+		Environments: map[string]*Config{
+			"prod": {APIURL: "https://api.example.com"},
+		},
+	}
+	if err := SaveFileConfig(fc); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := SaveAPIKey("sk_env_key"); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := LoadConfig()
+	if cfg.APIKey != "sk_env_key" {
+		t.Fatalf("api_key = %q", cfg.APIKey)
+	}
+}
+
 func TestSaveAPIKey(t *testing.T) {
 	dir := t.TempDir()
 	t.Setenv("XDG_CONFIG_HOME", dir)

--- a/internal/client/device_auth_test.go
+++ b/internal/client/device_auth_test.go
@@ -1,0 +1,87 @@
+package client
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+func TestRequestDeviceCode(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/auth/device/code" {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"device_code":              "dev-code-123",
+			"user_code":                "ABCD-EFGH",
+			"verification_uri":         "https://app.example.com/device?code=ABCD-EFGH",
+			"verification_uri_complete": "https://app.example.com/device?code=ABCD-EFGH",
+			"expires_in":               900,
+			"interval":                 5,
+		})
+	}))
+	defer srv.Close()
+
+	resp, err := RequestDeviceCode(srv.URL, "test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.DeviceCode != "dev-code-123" {
+		t.Fatalf("device_code = %q", resp.DeviceCode)
+	}
+	if resp.UserCode != "ABCD-EFGH" {
+		t.Fatalf("user_code = %q", resp.UserCode)
+	}
+}
+
+func TestPollDeviceToken_Success(t *testing.T) {
+	polls := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		polls++
+		w.Header().Set("Content-Type", "application/json")
+		if polls < 2 {
+			w.WriteHeader(http.StatusBadRequest)
+			_ = json.NewEncoder(w).Encode(map[string]string{
+				"error":             "authorization_pending",
+				"error_description": "Authorization pending",
+			})
+			return
+		}
+		_ = json.NewEncoder(w).Encode(map[string]string{
+			"api_key":    "sk_testkey123",
+			"token_type": "Bearer",
+		})
+	}))
+	defer srv.Close()
+
+	key, err := PollDeviceToken(srv.URL, "test", "dev-code", 10*time.Second)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if key != "sk_testkey123" {
+		t.Fatalf("api_key = %q", key)
+	}
+	if polls < 2 {
+		t.Fatalf("expected at least 2 polls, got %d", polls)
+	}
+}
+
+func TestSaveAPIKey(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", dir)
+
+	if err := SaveAPIKey("sk_test_save_key"); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := LoadConfig()
+	if cfg.APIKey != "sk_test_save_key" {
+		t.Fatalf("api_key = %q", cfg.APIKey)
+	}
+	if cfg.LocalOnly {
+		t.Fatal("expected local_only to be false after login")
+	}
+}

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -149,6 +149,28 @@ configure_api_key() {
     fi
 }
 
+# Run the init wizard after install when in an interactive terminal
+run_init_wizard() {
+    local api_key="$1"
+
+    if [ ! -t 0 ] || [ ! -t 1 ]; then
+        return
+    fi
+
+    if ! command -v promptconduit &> /dev/null; then
+        return
+    fi
+
+    info "Starting setup wizard..."
+    echo ""
+
+    if [ -n "$api_key" ]; then
+        promptconduit init --yes
+    else
+        promptconduit init
+    fi
+}
+
 main() {
     local api_key="${1:-}"
     local version="${PROMPTCONDUIT_VERSION:-}"
@@ -183,13 +205,24 @@ main() {
     # Configure API key if provided
     configure_api_key "$api_key"
 
+    # Run init wizard if interactive terminal and CLI is available
+    run_init_wizard "$api_key"
+
     echo ""
     info "Installation complete!"
     echo ""
-    echo "  Next steps:"
-    echo "    1. Set your API key: promptconduit config set --api-key=\"your-key\""
-    echo "    2. Install hooks:    promptconduit install claude-code"
-    echo "    3. Check status:     promptconduit status"
+
+    if [ -n "$api_key" ]; then
+        echo "  Next steps:"
+        echo "    1. Restart your AI tools to activate hooks"
+        echo "    2. Check status:     promptconduit status"
+        echo "    3. Test connection:  promptconduit test"
+    else
+        echo "  Next steps:"
+        echo "    1. Run setup wizard: promptconduit init"
+        echo "       (or local-only:  promptconduit init --local-only)"
+        echo "    2. Check status:     promptconduit status"
+    fi
     echo ""
 }
 


### PR DESCRIPTION
## Summary
Adds `promptconduit login` (OAuth device flow) and `promptconduit init` (interactive setup wizard) to replace manual API key copy-paste and per-tool install commands. Updates the install script to chain into init and extends status checks for Codex and Copilot.

Closes #117

Requires companion platform PR for device auth API endpoints.

## Changes

### Login
- `cmd/login.go` — device flow with browser open, polling, key save
- `internal/client/device_auth.go` — HTTP client for device endpoints

### Init wizard
- `cmd/init.go` — mode selection, login, tool auto-detect, hook install, test
- Flags: `--local-only`, `--tools`, `--yes`, `--api-key`

### Polish
- `cmd/status.go` — Codex and Copilot installation checks
- `scripts/install.sh` — runs `promptconduit init` post-install
- `cmd/root.go` — updated help text for login + init flow

## Architecture

```mermaid
flowchart LR
    A[install] --> B[init]
    B --> C{API key?}
    C -->|No| D[login]
    C -->|Yes| E[detect tools]
    D --> E
    E --> F[install hooks]
    F --> G[test]
```

## Testing
- `make test` — all packages pass
- Manual device login flow verified against local API

## Agent Review Context
- **change-type**: feature
- **risk-level**: medium
- **key-files**: cmd/login.go, cmd/init.go, internal/client/device_auth.go
- **testing-confidence**: high

## Checklist
- [x] Tests pass
- [x] No breaking changes
- [x] Code follows project conventions

Made with [Cursor](https://cursor.com)