### PR TITLE
test: v2 envelope contract guard (golden fixture)

### DIFF
--- a/internal/envelope/golden_test.go
+++ b/internal/envelope/golden_test.go
@@ -1,0 +1,118 @@
+package envelope
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// testdata/envelope.golden.json is the CANONICAL, fully-populated v2 envelope —
+// the single cross-repo contract sample. It is the source of truth mirrored
+// (byte-for-byte, additive-only) into:
+//
+//	platform/app/api/src/test/envelope.golden.json      (validated in envelope.golden.test.ts)
+//	editor-extension/src/test/envelope.golden.json      (parsed in envelope.golden.test.ts)
+//
+// When you change the envelope wire shape, update this file AND both mirrors in
+// the same coordinated change. These three tests are the guard: they fail if a
+// repo's view can no longer carry the canonical envelope, catching the drift the
+// hand-maintained mirrors would otherwise accumulate silently.
+
+// wellKnownSlugs are the enrichment slugs every reader is expected to understand.
+// Keep in sync with cli/CLAUDE.md, platform types/envelope.ts EnvelopeEnrichments,
+// and editor-extension src/envelope.ts.
+var wellKnownSlugs = []string{
+	"env", "trace", "vcs", "prompt", "cost", "tools", "diff", "subagent", "turn", "permission",
+}
+
+func loadGolden(t *testing.T) []byte {
+	t.Helper()
+	b, err := os.ReadFile(filepath.Join("testdata", "envelope.golden.json"))
+	if err != nil {
+		t.Fatalf("read golden: %v", err)
+	}
+	return b
+}
+
+// TestGoldenEnvelope_RoundTrips asserts the Go struct can faithfully carry the
+// canonical envelope: every top-level field and every well-known enrichment slug
+// survives unmarshal → struct → marshal. A renamed/removed json tag on
+// RawEventEnvelope drops the field here and fails the test.
+func TestGoldenEnvelope_RoundTrips(t *testing.T) {
+	golden := loadGolden(t)
+
+	var env RawEventEnvelope
+	if err := json.Unmarshal(golden, &env); err != nil {
+		t.Fatalf("golden is not a valid RawEventEnvelope: %v", err)
+	}
+
+	// Top-level fields must be populated (guards json tags against renames).
+	if env.Schema != SchemaVersion {
+		t.Errorf("schema = %d, want %d", env.Schema, SchemaVersion)
+	}
+	for name, got := range map[string]string{
+		"event_id":    env.EventID,
+		"session_id":  env.SessionID,
+		"prompt_id":   env.PromptID,
+		"tool":        env.Tool,
+		"hook_event":  env.HookEvent,
+		"captured_at": env.CapturedAt,
+		"cli_version": env.CliVersion,
+	} {
+		if got == "" {
+			t.Errorf("top-level field %q did not deserialize (renamed/removed json tag?)", name)
+		}
+	}
+	if len(env.RawEvent) == 0 {
+		t.Error("raw_event did not deserialize")
+	}
+	if len(env.Attachments) != 1 || env.Attachments[0].AttachmentID == "" || env.Attachments[0].Type == "" {
+		t.Errorf("attachment did not deserialize: %+v", env.Attachments)
+	}
+
+	// Every well-known slug must be present in the golden's enrichments.
+	for _, slug := range wellKnownSlugs {
+		if _, ok := env.Enrichments[slug]; !ok {
+			t.Errorf("golden missing well-known enrichment slug %q", slug)
+		}
+	}
+
+	// Re-marshal and confirm every top-level key + slug key survives.
+	out, err := env.ToJSON()
+	if err != nil {
+		t.Fatalf("re-marshal: %v", err)
+	}
+	var got map[string]json.RawMessage
+	if err := json.Unmarshal(out, &got); err != nil {
+		t.Fatal(err)
+	}
+	for _, key := range []string{"schema", "event_id", "session_id", "prompt_id", "tool", "hook_event", "captured_at", "cli_version", "raw_event", "enrichments", "attachments"} {
+		if _, ok := got[key]; !ok {
+			t.Errorf("top-level key %q missing after round-trip", key)
+		}
+	}
+	var enr map[string]json.RawMessage
+	if err := json.Unmarshal(got["enrichments"], &enr); err != nil {
+		t.Fatal(err)
+	}
+	for _, slug := range wellKnownSlugs {
+		if _, ok := enr[slug]; !ok {
+			t.Errorf("enrichment slug %q missing after round-trip", slug)
+		}
+	}
+}
+
+// TestGoldenEnvelope_SchemaGate mirrors the platform/extension "schema >= 2"
+// acceptance gate: the canonical sample must pass it.
+func TestGoldenEnvelope_SchemaGate(t *testing.T) {
+	var rec struct {
+		Schema int `json:"schema"`
+	}
+	if err := json.Unmarshal(loadGolden(t), &rec); err != nil {
+		t.Fatal(err)
+	}
+	if rec.Schema < SchemaVersion {
+		t.Errorf("golden schema %d < %d — readers would reject it", rec.Schema, SchemaVersion)
+	}
+}

--- a/internal/envelope/testdata/envelope.golden.json
+++ b/internal/envelope/testdata/envelope.golden.json
@@ -1,0 +1,133 @@
+{
+  "schema": 2,
+  "event_id": "0192f7a0-1c2d-7e3f-8a4b-5c6d7e8f9a0b",
+  "session_id": "sess-abc123",
+  "prompt_id": "prompt-xyz789",
+  "tool": "claude-code",
+  "hook_event": "Stop",
+  "captured_at": "2026-07-08T12:00:00Z",
+  "cli_version": "0.13.1",
+  "raw_event": {
+    "hook_event_name": "Stop",
+    "session_id": "sess-abc123",
+    "cwd": "/Users/dev/project"
+  },
+  "enrichments": {
+    "env": {
+      "host": "mac.local",
+      "os": "darwin",
+      "os_version": "26.3",
+      "arch": "arm64",
+      "cwd": "/Users/dev/project"
+    },
+    "trace": {
+      "trace_id": "0af7651916cd43dd8448eb211c80319c",
+      "span_id": "b7ad6b7169203331",
+      "parent_span_id": "0020000000000001"
+    },
+    "vcs": {
+      "type": "github",
+      "repo": "promptconduit/cli",
+      "repo_url": "https://github.com/promptconduit/cli",
+      "branch": "main",
+      "branch_url": "https://github.com/promptconduit/cli/tree/main",
+      "default_branch": "main",
+      "pr": {
+        "number": 42,
+        "url": "https://github.com/promptconduit/cli/pull/42",
+        "title": "fix: something",
+        "state": "open"
+      },
+      "commit": {
+        "hash": "d2065769abcdef",
+        "message": "fix: something",
+        "author": "dev"
+      },
+      "dirty": true,
+      "staged": 1,
+      "unstaged": 2,
+      "untracked": 0,
+      "ahead": 1,
+      "behind": 0,
+      "remote_url": "git@github.com:promptconduit/cli.git",
+      "repo_path": "/Users/dev/project",
+      "working_directory": "/Users/dev/project",
+      "detached_head": false,
+      "worktree": {
+        "is_worktree": true,
+        "path": "/Users/dev/promptconduit-worktrees/feat-x"
+      }
+    },
+    "prompt": {
+      "count": 1,
+      "chars": 128,
+      "words": 20,
+      "has_attachments": false,
+      "is_interrupt": false
+    },
+    "cost": {
+      "requests": [
+        {
+          "request_id": "req-1",
+          "conversation_id": "conv-1",
+          "model": "claude-opus-4-8",
+          "model_priced": true,
+          "source": "transcript",
+          "ts": "2026-07-08T12:00:00Z",
+          "tokens": { "input": 100, "output": 200, "cache_read": 50, "cache_write": 10 },
+          "usd": { "input": 0.01, "output": 0.02, "cache_read": 0.001, "cache_write": 0.0005, "total": 0.0315, "currency": "USD" },
+          "tools": { "total": 3, "by_name": { "Read": 2, "Edit": 1 } },
+          "signals": { "interrupted": false }
+        }
+      ],
+      "totals": {
+        "usd": 0.0315,
+        "currency": "USD",
+        "tokens": { "input": 100, "output": 200, "cache_read": 50, "cache_write": 10 }
+      }
+    },
+    "tools": {
+      "total": 3,
+      "failed": 0,
+      "calls": [
+        { "name": "Read", "ok": true, "duration_ms": 12 },
+        { "name": "Edit", "ok": true, "duration_ms": 8 },
+        { "name": "mcp__github__search", "ok": true, "duration_ms": 40, "mcp_server": "github" }
+      ]
+    },
+    "diff": {
+      "files_changed": 3,
+      "insertions": 42,
+      "deletions": 5
+    },
+    "subagent": {
+      "agent_id": "agent-1",
+      "agent_type": "Explore",
+      "phase": "stop",
+      "concurrent": 2,
+      "duration_ms": 5000,
+      "requests": 4,
+      "model": "claude-sonnet-5",
+      "tokens": { "input": 1000, "output": 2000, "cache_read": 500, "cache_write": 100 },
+      "usd": { "input": 0.1, "output": 0.2, "cache_read": 0.01, "cache_write": 0.005, "total": 0.315, "currency": "USD" }
+    },
+    "turn": {
+      "duration_ms": 12000,
+      "prompt_id": "prompt-xyz789"
+    },
+    "permission": {
+      "decision": "requested",
+      "tool_name": "Bash",
+      "mcp_server": ""
+    }
+  },
+  "attachments": [
+    {
+      "attachment_id": "att-1",
+      "filename": "screenshot.png",
+      "content_type": "image/png",
+      "size_bytes": 20480,
+      "type": "image"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
Adds a canonical v2 envelope golden fixture + a round-trip guard test in the CLI (the envelope's source of truth).

The v2 envelope is hand-mirrored across three repos — `cli/internal/envelope` (Go, source of truth), `platform/app/api/src/types/envelope.ts`, and `editor-extension/src/envelope.ts` — and nothing currently catches drift between them. This is the CLI half of a lightweight, per-repo guard: a shared canonical sample each repo tests its own view against.

## Changes
- `internal/envelope/testdata/envelope.golden.json` — fully-populated v2 envelope exercising every well-known enrichment slug (env, trace, vcs, prompt, cost, tools, diff, subagent, turn, permission) + attachments.
- `internal/envelope/golden_test.go` — asserts the Go struct round-trips the golden (every top-level field + slug survives; a renamed/removed json tag fails the test) and passes the schema>=2 gate.

## Follow-up (separate PRs)
- **platform**: vendor the same golden + a `validateEnvelope` test.
- **editor-extension**: vendor the same golden + a `parseEnvelopeV2` test.

## Testing
`go test ./internal/envelope/` — passes; `go vet` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)