### PR TITLE
fix(cost): price claude-sonnet-5 at list rates

### DIFF
--- a/internal/cost/cost_test.go
+++ b/internal/cost/cost_test.go
@@ -60,6 +60,49 @@ func TestResolvePrice(t *testing.T) {
 	}
 }
 
+// TestResolvePrice_CurrentClaudeFamily pins every model in the current Claude
+// lineup to its list input rate. ResolvePrice's fallbacks can't rescue a model
+// that's simply absent from the table — "claude-sonnet-5" trims to
+// "claude-sonnet" then "claude", neither of which is a key — so a new model that
+// misses the table resolves ok=false and is silently charged $0 with
+// ModelPriced=false (cli#123). This table is the guard: adding a model to the
+// lineup without adding its rates fails here.
+func TestResolvePrice_CurrentClaudeFamily(t *testing.T) {
+	tbl := mustTable(t)
+
+	cases := []struct {
+		model     string
+		wantInput float64 // USD per input token
+	}{
+		{"claude-sonnet-5", 0.000003},
+		{"claude-fable-5", 0.00001},
+		{"claude-mythos-5", 0.00001},
+		{"claude-opus-4-8", 0.000005},
+		{"claude-sonnet-4-6", 0.000003},
+		{"claude-haiku-4-5", 0.000001},
+	}
+	for _, tc := range cases {
+		mp, ok := tbl.ResolvePrice(tc.model)
+		if !ok {
+			t.Errorf("ResolvePrice(%q) = not priced; every current Claude model must resolve", tc.model)
+			continue
+		}
+		if mp.Input != tc.wantInput {
+			t.Errorf("ResolvePrice(%q).Input = %v, want %v", tc.model, mp.Input, tc.wantInput)
+		}
+		// A dated variant from a real hook payload must reach the same rates.
+		dated := tc.model + "-20260101"
+		datedMP, ok := tbl.ResolvePrice(dated)
+		if !ok {
+			t.Errorf("ResolvePrice(%q) = not priced; dated variant should trim to the base model", dated)
+			continue
+		}
+		if datedMP.Input != tc.wantInput {
+			t.Errorf("ResolvePrice(%q).Input = %v, want %v", dated, datedMP.Input, tc.wantInput)
+		}
+	}
+}
+
 // TestCostForUsage_RealBlock checks the exact dollar math against a real
 // Claude Code usage block captured from a live transcript:
 //

--- a/internal/cost/pricing_data.json
+++ b/internal/cost/pricing_data.json
@@ -14,6 +14,13 @@
     "cache_creation_input_token_cost_1h": 0.00002,
     "cache_read_input_token_cost": 0.000001
   },
+  "claude-sonnet-5": {
+    "input_cost_per_token": 0.000003,
+    "output_cost_per_token": 0.000015,
+    "cache_creation_input_token_cost": 0.00000375,
+    "cache_creation_input_token_cost_1h": 0.000006,
+    "cache_read_input_token_cost": 0.0000003
+  },
   "claude-opus-4-8": {
     "input_cost_per_token": 0.000005,
     "output_cost_per_token": 0.000025,


### PR DESCRIPTION
Closes #123

## The gap

`claude-sonnet-5` had no entry in `internal/cost/pricing_data.json`. The Claude 5 family was added partially — `claude-fable-5` and `claude-mythos-5` are both present — and Sonnet 5 was missed.

None of `ResolvePrice`'s three fallbacks rescue it:

| Step | Result |
|---|---|
| Exact key | miss — not in the table |
| `modelAliases` | miss — no entry |
| Dash-prefix trim | `claude-sonnet-5` → `claude-sonnet` → `claude`, none are keys |

So it returned `false`, and the caller did the correct-but-useless thing documented at `pricing.go:141-142`: charge zero and flag `ModelPriced=false`. Every Sonnet 5 request was billed $0, and the editor extension rendered "tokens only — unpriced".

## The fix

Adds the `claude-sonnet-5` entry, mirroring `claude-sonnet-4-6` — Sonnet 5 is the same $3/$15 per MTok tier. Cache rates follow the multipliers the file documents in its own `_comment` (5m write 1.25x input, 1h write 2x input, read 0.1x input). Verified byte-identical in value to the 4-6 entry via `jq '.["claude-sonnet-5"] == .["claude-sonnet-4-6"]'` → `true`.

**List vs. intro pricing:** this uses **list** ($3/$15), not Anthropic's introductory $2/$10 through 2026-08-31. The bundled table has no time dimension, so encoding the intro rate would silently under-report every Sonnet 5 request from 2026-09-01 onward with no mechanism to notice.

## Verification

Behavior before and after, from the real resolver:

```
BEFORE  ResolvePrice("claude-sonnet-5") -> ok=false input=0 output=0
        1M in + 1M out => $0 (input $0 + output $0), priced=false

AFTER   ResolvePrice("claude-sonnet-5") -> ok=true input=3e-06 output=1.5e-05
                                           cacheWrite5m=3.75e-06 cacheWrite1h=6e-06 cacheRead=3e-07
        1M in + 1M out => $18 (input $3 + output $15), priced=true
```

A side effect worth noting: `modelTier` returns `TierUnknown` for anything unpriced, so Sonnet 5 events were untiered too. They now correctly bucket as `TierStandard` via the existing default branch — no change needed there.

`make test` (all 16 packages) and `make build` both pass.

## Regression test

`TestResolvePrice_CurrentClaudeFamily` is table-driven over the current lineup (`claude-sonnet-5`, `claude-fable-5`, `claude-mythos-5`, `claude-opus-4-8`, `claude-sonnet-4-6`, `claude-haiku-4-5`), asserting `ok==true` and the exact expected input rate for each, in both bare and dated (`-20260101`) form. Confirmed it fails on the pre-fix table and passes after. The point is that the next model added to the lineup without rates trips this instead of silently billing zero.

## Notes for the reviewer

- **No `modelAliases` entry**, despite the issue suggesting one. The exact-key lookup hits first, so a self-referential `"claude-sonnet-5": "claude-sonnet-5"` passthrough is unreachable code. The map's doc comment says it is "kept small on purpose ... only needs the genuinely irregular cases", and the sibling Claude 5 entries (`fable-5`, `mythos-5`) have no aliases either. Happy to add it if you'd rather have the symmetry with the `claude-opus-4-8` / `claude-haiku-4-5` passthroughs, which are equally unreachable today.
- **Two pre-existing issues found while verifying, left untouched** as out of scope — say the word and I'll file them:
  - `internal/cost/pricing.go:53-60` is not gofmt-clean on `main` (the `modelAliases` block is over-aligned). Untouched by this PR, and `make lint` fails identically on `main` and this branch with 4 pre-existing issues in `internal/sessions/transcript.go` and `cmd/skills_local.go`. CI runs `make test` + `make build` only, not lint.
  - `modelAliases` maps `"composer-1"` → `"cursor-composer-1"`, which is **not a key** in the table (only `composer-2.5` / `composer-2.5-fast` exist). So `composer-1` is unpriced today — the same class of bug as this one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)