### PR TITLE
fix(eventlog): append each JSONL line and its newline in one write

### DIFF
--- a/internal/eventlog/concurrent_append_test.go
+++ b/internal/eventlog/concurrent_append_test.go
@@ -1,0 +1,189 @@
+package eventlog
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"runtime"
+	"strconv"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+// Concurrency regression test for the events.jsonl append path (issue #125).
+//
+// The corruption this guards against is a cross-PROCESS race, so it cannot be
+// reproduced with goroutines: appendLine takes the package-level writeMu, which
+// serializes every writer inside a single process. Real hook invocations are
+// separate processes that share nothing but the file, so this test re-executes
+// the test binary as N independent worker processes that hammer one log.
+//
+// With the two-write (`Write(line)` then `Write("\n")`) implementation this
+// fails: O_APPEND makes each individual write atomic with respect to the file
+// offset, but between a worker's line write and its newline write another
+// worker can land its own line, yielding `A_lineB_line\n\n` — one line holding
+// two concatenated envelopes, followed by one empty line.
+
+const (
+	childDirEnv    = "PROMPTCONDUIT_EVENTLOG_CHILD_DIR"
+	childIDEnv     = "PROMPTCONDUIT_EVENTLOG_CHILD_ID"
+	childStartEnv  = "PROMPTCONDUIT_EVENTLOG_CHILD_START"
+	childWritesEnv = "PROMPTCONDUIT_EVENTLOG_CHILD_WRITES"
+	childPadEnv    = "PROMPTCONDUIT_EVENTLOG_CHILD_PAD"
+)
+
+// TestEventLogAppendWorker is not an assertion-bearing test. It is the worker
+// body that TestAppendLineIsAtomicAcrossProcesses re-executes as a separate
+// process, and is skipped during a normal test run.
+func TestEventLogAppendWorker(t *testing.T) {
+	dir := os.Getenv(childDirEnv)
+	if dir == "" {
+		t.Skip("not running as an append worker")
+	}
+
+	id := os.Getenv(childIDEnv)
+	writes, err := strconv.Atoi(os.Getenv(childWritesEnv))
+	if err != nil {
+		t.Fatalf("bad %s: %v", childWritesEnv, err)
+	}
+	pad, err := strconv.Atoi(os.Getenv(childPadEnv))
+	if err != nil {
+		t.Fatalf("bad %s: %v", childPadEnv, err)
+	}
+	startNano, err := strconv.ParseInt(os.Getenv(childStartEnv), 10, 64)
+	if err != nil {
+		t.Fatalf("bad %s: %v", childStartEnv, err)
+	}
+
+	SetDirForTest(dir)
+	SetEnabled(true)
+
+	// All workers idle until a common wall-clock instant so their writes
+	// actually overlap instead of being staggered by process startup.
+	if d := time.Until(time.Unix(0, startNano)); d > 0 {
+		time.Sleep(d)
+	}
+
+	filler := strings.Repeat("x", pad)
+	for i := 0; i < writes; i++ {
+		RecordCapture([]byte(fmt.Sprintf(
+			`{"schema":2,"event_id":"%s-%d","pad":"%s"}`, id, i, filler)))
+	}
+}
+
+func TestAppendLineIsAtomicAcrossProcesses(t *testing.T) {
+	if testing.Short() {
+		t.Skip("spawns worker processes; skipped under -short")
+	}
+
+	// Oversubscribe the CPUs so workers are preempted mid-append and actually
+	// race, but stay bounded: this spawns real processes, and an unbounded
+	// 2*NumCPU on a large CI host would fork a swarm for no extra signal.
+	workers := 2 * runtime.NumCPU()
+	if workers < 8 {
+		workers = 8
+	}
+	if workers > 24 {
+		workers = 24
+	}
+	const (
+		writesPerWorker = 1500
+		// ~2KB lines, matching the size of the envelopes observed corrupted in
+		// the field report on issue #125.
+		padBytes = 2000
+	)
+
+	// Must point THIS process at the temp dir too, not just the workers:
+	// EventsJSONLPath() below is resolved in the parent, and without the
+	// override it falls back to the real ~/.promptconduit/events.jsonl.
+	dir := withTempDir(t)
+	start := time.Now().Add(750 * time.Millisecond)
+
+	var wg sync.WaitGroup
+	errs := make([]error, workers)
+	output := make([]string, workers)
+	for i := 0; i < workers; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			cmd := exec.Command(os.Args[0], "-test.run=^TestEventLogAppendWorker$")
+			cmd.Env = append(os.Environ(),
+				childDirEnv+"="+dir,
+				childIDEnv+"="+strconv.Itoa(i),
+				childStartEnv+"="+strconv.FormatInt(start.UnixNano(), 10),
+				childWritesEnv+"="+strconv.Itoa(writesPerWorker),
+				childPadEnv+"="+strconv.Itoa(padBytes),
+			)
+			out, err := cmd.CombinedOutput()
+			errs[i], output[i] = err, string(out)
+		}(i)
+	}
+	wg.Wait()
+
+	for i, err := range errs {
+		if err != nil {
+			t.Fatalf("worker %d failed: %v\n%s", i, err, output[i])
+		}
+	}
+
+	f, err := os.Open(EventsJSONLPath())
+	if err != nil {
+		t.Fatalf("open events.jsonl: %v", err)
+	}
+	defer func() { _ = f.Close() }()
+
+	sc := bufio.NewScanner(f)
+	sc.Buffer(make([]byte, 0, 64*1024), 16*1024*1024)
+
+	var (
+		lineNo     int
+		good       int
+		empty      int
+		corrupt    int
+		firstFails []string
+	)
+	for sc.Scan() {
+		lineNo++
+		line := sc.Bytes()
+		if len(line) == 0 {
+			empty++
+			if len(firstFails) < 5 {
+				firstFails = append(firstFails, fmt.Sprintf("line %d: empty line", lineNo))
+			}
+			continue
+		}
+		// json.Unmarshal is strict about trailing data: two concatenated
+		// envelopes on one line fail here exactly as they do in the strict
+		// per-line readers (the editor extension's JSON.parse).
+		var v map[string]any
+		if err := json.Unmarshal(line, &v); err != nil {
+			corrupt++
+			if len(firstFails) < 5 {
+				firstFails = append(firstFails, fmt.Sprintf(
+					"line %d (len %d): %v", lineNo, len(line), err))
+			}
+			continue
+		}
+		good++
+	}
+	if err := sc.Err(); err != nil {
+		t.Fatalf("scan events.jsonl: %v", err)
+	}
+
+	wantLines := workers * writesPerWorker
+	t.Logf("workers=%d writes/worker=%d padBytes=%d", workers, writesPerWorker, padBytes)
+	t.Logf("lines=%d valid=%d corrupt=%d empty=%d (want %d valid, 0 corrupt, 0 empty)",
+		lineNo, good, corrupt, empty, wantLines)
+
+	if corrupt > 0 || empty > 0 {
+		t.Errorf("events.jsonl corrupted by concurrent appends: %d unparseable line(s), %d empty line(s)\n%s",
+			corrupt, empty, strings.Join(firstFails, "\n"))
+	}
+	if good != wantLines {
+		t.Errorf("valid lines = %d, want %d (events lost or merged)", good, wantLines)
+	}
+}

--- a/internal/eventlog/eventlog.go
+++ b/internal/eventlog/eventlog.go
@@ -139,8 +139,23 @@ func appendLine(path string, line []byte, rotateAt int64) {
 	}
 	defer func() { _ = f.Close() }()
 
-	_, _ = f.Write(line)
-	_, _ = f.Write([]byte{'\n'})
+	// Emit the line and its terminator in ONE write. O_APPEND makes an
+	// individual write atomic with respect to the file offset, but that
+	// guarantee is per-write: with a separate Write(line) and Write("\n"),
+	// another PROCESS appending concurrently interleaves between the two —
+	// A.Write(line), B.Write(line), A.Write('\n'), B.Write('\n') — leaving
+	// `A_lineB_line\n\n`: one line holding two concatenated envelopes followed
+	// by an empty line. writeMu only serializes writers inside this process;
+	// each hook invocation is its own process, so the single write is what
+	// actually keeps the file parseable. See issue #125.
+	//
+	// Build a fresh buffer rather than append(line, '\n'): line's backing array
+	// belongs to the caller and may have spare capacity, so appending in place
+	// could scribble past the caller's slice.
+	buf := make([]byte, 0, len(line)+1)
+	buf = append(buf, line...)
+	buf = append(buf, '\n')
+	_, _ = f.Write(buf)
 }
 
 // rotateIfNeeded renames path -> path+".1" once it reaches rotateAt bytes. Any

--- a/internal/eventlog/prune.go
+++ b/internal/eventlog/prune.go
@@ -281,12 +281,19 @@ func pruneFileFrom(path string, ceiling int64, cutoff time.Time, tsOf timestampF
 	}
 	tmpName := tmp.Name()
 	w := bufio.NewWriter(tmp)
+	// Record + terminator go out as one write, mirroring appendLine (issue
+	// #125). Nothing else holds this temp file's descriptor, so unlike the
+	// live append path this was never a corruption vector — it is kept
+	// single-write so the invariant "a line and its \n are never emitted
+	// separately" holds everywhere a JSONL record is produced.
+	line := make([]byte, 0, 4096)
 	for i, rec := range records {
 		if !keep[i] {
 			continue
 		}
-		_, _ = w.Write(rec.data)
-		_, _ = w.Write([]byte{'\n'})
+		line = append(line[:0], rec.data...)
+		line = append(line, '\n')
+		_, _ = w.Write(line)
 	}
 	// Carry over any bytes appended after startSize by a concurrent writer, so no
 	// in-flight capture is dropped by the rewrite.


### PR DESCRIPTION
Closes #125

## Root cause

`appendLine` wrote each record with **two** `write(2)` syscalls:

```go
_, _ = f.Write(line)
_, _ = f.Write([]byte{'\n'})
```

`O_APPEND` makes each *individual* write atomic with respect to the file offset, but that guarantee is per-write. Two concurrent hook **processes** interleave between them:

```
A.Write(line) → B.Write(line) → A.Write('\n') → B.Write('\n')
```

yielding `A_lineB_line\n\n` — one line holding two concatenated envelopes, followed by one empty line.

The package-level `writeMu` does **not** protect this: it only serializes writers inside a single process, and every hook invocation is its own process. That's precisely why this only ever showed up in the field.

`jq` masks the damage (it parses a stream of JSON values, so `{...}{...}` reads as two values and exits 0). Strict per-line readers — the editor extension's `JSON.parse`, `cost`, `events` — either throw or silently drop the second event.

## Fix

Build the record and its terminator into one buffer and issue a single write, so `O_APPEND`'s atomicity actually covers the whole line.

The buffer is built fresh rather than with `append(line, '\n')`: `line`'s backing array belongs to the caller and may have spare capacity, so appending in place could scribble past the caller's slice.

`prune.go` gets the same single-write shape. **It was never a corruption vector** — it rewrites into a private temp file that no other process holds a descriptor to — so that hunk is consistency/defense-in-depth, not a bugfix, and is labelled as such in the code.

## Reproduction

Added `TestAppendLineIsAtomicAcrossProcesses`. Because the race is cross-process, goroutines cannot reproduce it (`writeMu` serializes them); the test re-executes the test binary as N worker processes that release on a shared wall-clock start and hammer one log, then asserts every line parses standalone via `json.Unmarshal` (strict about trailing data, exactly like the extension's `JSON.parse`).

**Before** (20 workers x 1500 appends, ~2KB envelopes):
```
lines=30000 valid=17474 corrupt=5976 empty=6550 (want 30000 valid, 0 corrupt, 0 empty)
  line 1 (len 8154): invalid character '{' after top-level value
  line 2: empty line
--- FAIL: TestAppendLineIsAtomicAcrossProcesses (2.17s)
```

**After:**
```
lines=30000 valid=30000 corrupt=0 empty=0 (want 30000 valid, 0 corrupt, 0 empty)
--- PASS: TestAppendLineIsAtomicAcrossProcesses (2.38s)
```

Reverting only `eventlog.go` while keeping the test still fails, so it is a real regression guard rather than a vacuous pass.

## On the 2MB outlier envelopes

The issue rightly flags that POSIX only guarantees `O_APPEND` atomicity up to `PIPE_BUF` for pipes, and says nothing binding about large writes to regular files. I measured it rather than assume, with a standalone harness (12 processes x 40 appends of **2MB** lines):

- single write: **480/480 lines valid, 0 corrupt, 0 torn**
- two writes (control): **121 corrupt** — confirming the harness detects tearing at that size

So a single 2MB append held atomically here. Being precise about what that does and doesn't establish:

- It is **empirical, on macOS/APFS only**. Linux/ext4 is not covered by this run, though it holds `i_rwsem` across a buffered write, which makes same-file writers mutually exclusive.
- **Network filesystems (NFS) are a known exception** and would not be safe. `~/.promptconduit` on NFS is unusual but not impossible.

This is strictly better than the status quo at every size, so I did **not** add locking: an advisory `flock` would add a syscall pair to every hook's hot path, needs a careful best-effort fallback (this layer must never block the tool it observes), and would defend a case I could not actually provoke. Worth revisiting only if corruption resurfaces on a network mount.

## Verification

- `make test`: **passes**, exit 0, all 16 packages ok
- `make lint`: **fails — but identically on clean `origin/main`.** 4 pre-existing issues in `internal/sessions/transcript.go` and `cmd/skills_local.go`, both untouched here. `golangci-lint run ./internal/eventlog/...` reports **0 issues**. Left unrelated pre-existing failures out of this PR rather than widening its scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)