### PR TITLE
fix(client): stop async send truncating envelopes at the pipe buffer

### DIFF
--- a/internal/client/api.go
+++ b/internal/client/api.go
@@ -11,7 +11,6 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"runtime"
 	"strings"
 	"time"
 
@@ -31,10 +30,13 @@ const eventsEndpoint = "/v1/events/raw"
 // outbound.ndjson. Best-effort and gated by config; never blocks the send.
 func recordEventSend(envJSON []byte, status int, latency time.Duration, _ int, sendErr error) {
 	var probe struct {
+		EventID   string `json:"event_id"`
 		HookEvent string `json:"hook_event"`
 	}
+	// Best-effort: a payload we couldn't parse still gets its outcome recorded,
+	// just without the identifiers.
 	_ = json.Unmarshal(envJSON, &probe)
-	eventlog.RecordSendOutcome(probe.HookEvent, status, latency.Milliseconds(), sendErr)
+	eventlog.RecordSendOutcome(probe.EventID, probe.HookEvent, status, latency.Milliseconds(), sendErr)
 }
 
 // APIResponse represents a response from the API
@@ -195,8 +197,18 @@ func (c *Client) SendEnvelopeWithAttachmentsAsync(env *envelope.RawEventEnvelope
 		return fmt.Errorf("failed to serialize envelope with attachments: %w", err)
 	}
 
-	// For payloads with attachments (typically images), always use blocking mode
-	// since subprocess stdin has ~64KB limit and images are often larger
+	// Attachments are sent in blocking mode because the detached sender speaks
+	// exactly one dialect: `hook --send-event` reads stdin and POSTs it verbatim
+	// as a JSON envelope (sendEnvelopeFromStdin). This payload is the other
+	// shape — envelope + binary blobs, which has to go out as multipart — and
+	// the child has no way to tell the two apart from the bytes alone.
+	//
+	// The previous rationale here ("subprocess stdin has ~64KB limit") was
+	// wrong: there is no such limit. What there was is a 64KB pipe buffer and a
+	// parent that exited before finishing the write, which truncated large
+	// sends on every path, attachments or not — see #124 and
+	// stageEnvelopeForChild. That's fixed, so going async here is now merely a
+	// matter of teaching the child a second dialect rather than a hard blocker.
 	return c.sendEnvelopeWithAttachmentsBlocking(jsonData)
 }
 
@@ -220,34 +232,87 @@ func (c *Client) SendEnvelopeWithAttachmentsDirect(jsonData []byte) error {
 	return c.sendEnvelopeWithAttachmentsBlocking(jsonData)
 }
 
-// SendEnvelopeAsync sends an envelope asynchronously without blocking
+// SendEnvelopeAsync sends an envelope asynchronously without blocking.
+//
+// Unix and Windows share one implementation. They used to diverge — Windows
+// spawned a `go cmd.Wait()` the unix path didn't — but that difference was
+// illusory (see startDetachedSender), and the only thing that genuinely differs
+// between the platforms is how a temp file is made to disappear on its own
+// (createEphemeralTemp).
 func (c *Client) SendEnvelopeAsync(env *envelope.RawEventEnvelope) error {
 	envJSON, err := env.ToJSON()
 	if err != nil {
 		return fmt.Errorf("failed to serialize envelope: %w", err)
 	}
 
-	if runtime.GOOS == "windows" {
-		return c.sendAsyncWindows(envJSON)
-	}
-
-	return c.sendAsyncUnix(envJSON)
+	return c.startDetachedSender(envJSON)
 }
 
-// sendAsyncUnix uses fork to send envelope without blocking. The subprocess
-// inherits a file descriptor pointing at the persistent log file as stderr,
-// so any crash or panic — which the in-process logger can't catch — still
-// leaves a trace on disk. Previously stderr was discarded, which made
+// stageEnvelopeForChild materializes envJSON into a temp file that the OS has
+// already been told to discard, and returns it rewound and ready to be handed
+// to a child as stdin.
+//
+// Passing the child an *os.File is load-bearing, not a style choice. When
+// cmd.Stdin is an io.Reader that is NOT an *os.File, os/exec quietly creates an
+// OS pipe and copies the reader into it from a goroutine IN THIS PROCESS — and
+// cmd.Wait() is the only thing that joins that goroutine. The async sender
+// deliberately never waits: it releases the child and the hook exits
+// immediately. The copier was therefore killed mid-write and the child was left
+// with just the ~64KB the pipe buffer had absorbed, so it POSTed truncated JSON
+// and the platform answered 400 (#124). Handing over an *os.File instead makes
+// the child inherit the descriptor directly: no pipe, no goroutine, nothing
+// left to wait on, and no size ceiling.
+func stageEnvelopeForChild(envJSON []byte) (*os.File, error) {
+	f, err := createEphemeralTemp("promptconduit-envelope-")
+	if err != nil {
+		return nil, err
+	}
+	if _, err := f.Write(envJSON); err != nil {
+		_ = f.Close()
+		return nil, err
+	}
+	// The child inherits the descriptor along with its offset, so rewind.
+	if _, err := f.Seek(0, io.SeekStart); err != nil {
+		_ = f.Close()
+		return nil, err
+	}
+	return f, nil
+}
+
+// startDetachedSender spawns `hook --send-event`, feeding it envJSON via an
+// inherited descriptor, and does not wait for it. Any failure to set the child
+// up falls back to sending in-process so the event is never silently lost.
+//
+// Not waiting is the point — the hook must not make the user's editor wait on a
+// network round trip — and it's also why the payload must reach the child
+// without any parent-side bookkeeping (see stageEnvelopeForChild). The Windows
+// variant of this used to spawn a `go cmd.Wait()`, which looked like it joined
+// the stdin copier but didn't: the Go runtime tears the process down when main
+// returns without joining stray goroutines, and the hook returns immediately
+// after this call. Windows truncated exactly as unix did.
+//
+// The subprocess also inherits a descriptor pointing at the persistent log file
+// as stderr, so any crash or panic — which the in-process logger can't catch —
+// still leaves a trace on disk. Previously stderr was discarded, which made
 // failed sends invisible.
-func (c *Client) sendAsyncUnix(envJSON []byte) error {
+func (c *Client) startDetachedSender(envJSON []byte) error {
 	exe, err := os.Executable()
 	if err != nil {
 		logger.Error("async send: cannot resolve executable path: %v (falling back to blocking)", err)
 		return c.sendEnvelopeBlocking(envJSON)
 	}
 
+	stdin, err := stageEnvelopeForChild(envJSON)
+	if err != nil {
+		logger.Error("async send: cannot stage envelope for subprocess: %v (falling back to blocking)", err)
+		return c.sendEnvelopeBlocking(envJSON)
+	}
+	// Close our copy once the child has been given its own (or once we've
+	// given up). The file is already unlinked, so this is the whole cleanup.
+	defer func() { _ = stdin.Close() }()
+
 	cmd := exec.Command(exe, "hook", "--send-event")
-	cmd.Stdin = bytes.NewReader(envJSON)
+	cmd.Stdin = stdin
 	cmd.Stdout = nil
 	cmd.Stderr = openLogForStderr()
 
@@ -256,32 +321,9 @@ func (c *Client) sendAsyncUnix(envJSON []byte) error {
 		return c.sendEnvelopeBlocking(envJSON)
 	}
 
-	// Process already started, ignore error
+	// Detach: the child owns the send from here, and this process is free to
+	// exit. Nothing about the payload depends on us staying alive any more.
 	_ = cmd.Process.Release()
-
-	return nil
-}
-
-// sendAsyncWindows spawns a subprocess on Windows
-func (c *Client) sendAsyncWindows(envJSON []byte) error {
-	exe, err := os.Executable()
-	if err != nil {
-		logger.Error("async send: cannot resolve executable path: %v (falling back to blocking)", err)
-		return c.sendEnvelopeBlocking(envJSON)
-	}
-
-	cmd := exec.Command(exe, "hook", "--send-event")
-	cmd.Stdin = bytes.NewReader(envJSON)
-	cmd.Stderr = openLogForStderr()
-
-	if err := cmd.Start(); err != nil {
-		logger.Error("async send: cmd.Start failed: %v (falling back to blocking)", err)
-		return c.sendEnvelopeBlocking(envJSON)
-	}
-
-	go func() {
-		_ = cmd.Wait()
-	}()
 
 	return nil
 }

--- a/internal/client/async_send_test.go
+++ b/internal/client/async_send_test.go
@@ -1,0 +1,237 @@
+package client
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+// The async sender is a three-process story: this test spawns the CLI's `hook`
+// command (the parent), which spawns a detached `hook --send-event` child that
+// does the actual POST. The bug in #124 only reproduces when the PARENT EXITS
+// right after Start()+Release(), so an in-process unit test cannot see it —
+// the copy goroutine survives as long as the test binary does. Hence the real
+// binary and the real hook path.
+
+var (
+	buildOnce sync.Once
+	builtBin  string
+	buildErr  error
+)
+
+// buildCLI builds the promptconduit binary once per test run and returns its
+// path.
+func buildCLI(t *testing.T) string {
+	t.Helper()
+	buildOnce.Do(func() {
+		_, thisFile, _, ok := runtime.Caller(0)
+		if !ok {
+			buildErr = fmt.Errorf("cannot resolve test file path")
+			return
+		}
+		moduleRoot := filepath.Clean(filepath.Join(filepath.Dir(thisFile), "..", ".."))
+
+		outDir, err := os.MkdirTemp("", "pc-asyncsend-bin")
+		if err != nil {
+			buildErr = err
+			return
+		}
+		bin := filepath.Join(outDir, "promptconduit")
+		cmd := exec.Command("go", "build", "-o", bin, ".")
+		cmd.Dir = moduleRoot
+		if out, err := cmd.CombinedOutput(); err != nil {
+			buildErr = fmt.Errorf("go build failed: %v\n%s", err, out)
+			return
+		}
+		builtBin = bin
+	})
+	if buildErr != nil {
+		t.Fatalf("building CLI: %v", buildErr)
+	}
+	return builtBin
+}
+
+// asyncHookEnv returns a hermetic environment for the hook subprocess: its own
+// HOME (so the event log lands in a temp dir) and a config pointing at srvURL.
+func asyncHookEnv(t *testing.T, srvURL string) (home string, env []string) {
+	t.Helper()
+	home = t.TempDir()
+
+	xdg := filepath.Join(home, ".config")
+	cfgDir := filepath.Join(xdg, ConfigDirName)
+	if err := os.MkdirAll(cfgDir, 0o755); err != nil {
+		t.Fatalf("mkdir config dir: %v", err)
+	}
+	cfg := FileConfig{
+		APIKey:            "test-key",
+		APIURL:            srvURL,
+		Timeout:           30,
+		DisableAutoUpdate: true,
+	}
+	data, err := json.Marshal(&cfg)
+	if err != nil {
+		t.Fatalf("marshal config: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(cfgDir, ConfigFileName), data, 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	// Minimal env: no inherited PROMPTCONDUIT_* vars can leak in and point the
+	// subprocess at a real API.
+	env = []string{
+		"HOME=" + home,
+		"XDG_CONFIG_HOME=" + xdg,
+		"PATH=" + os.Getenv("PATH"),
+	}
+	return home, env
+}
+
+// runHookWithPayload runs `promptconduit hook` with payload on stdin and waits
+// for it to exit — mirroring what an AI tool's hook does. When it returns, the
+// parent is gone and only the detached sender child remains.
+func runHookWithPayload(t *testing.T, bin string, env []string, dir string, payload []byte) {
+	t.Helper()
+	cmd := exec.Command(bin, "hook")
+	cmd.Stdin = bytes.NewReader(payload)
+	cmd.Env = env
+	cmd.Dir = dir
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("hook exited with error: %v\n%s", err, out)
+	}
+}
+
+// bigHookPayload builds a native hook payload whose serialized envelope is far
+// larger than the 64KB OS pipe buffer.
+func bigHookPayload(t *testing.T, filler int) []byte {
+	t.Helper()
+	payload := map[string]interface{}{
+		"hook_event_name": "PreToolUse",
+		"session_id":      "async-send-test-session",
+		"cwd":             "/tmp",
+		// A single large field is enough; the envelope carries raw_event verbatim.
+		"tool_input": map[string]interface{}{
+			"content": strings.Repeat("x", filler),
+		},
+	}
+	data, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatalf("marshal payload: %v", err)
+	}
+	return data
+}
+
+// TestAsyncSendDeliversEnvelopeLargerThanPipeBuffer is the regression test for
+// #124. Before the fix the detached child received only the ~64KB that fit in
+// the OS pipe buffer, so the platform saw truncated JSON and returned 400.
+func TestAsyncSendDeliversEnvelopeLargerThanPipeBuffer(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("async send on Windows takes the sendAsyncWindows path; covered by the same assertions on unix")
+	}
+
+	bin := buildCLI(t)
+
+	bodies := make(chan []byte, 4)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		select {
+		case bodies <- body:
+		default:
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"status":"ok"}`))
+	}))
+	defer srv.Close()
+
+	home, env := asyncHookEnv(t, srv.URL)
+
+	const filler = 1 << 20 // 1MB — 16x the 64KB pipe buffer
+	runHookWithPayload(t, bin, env, home, bigHookPayload(t, filler))
+
+	var body []byte
+	select {
+	case body = <-bodies:
+	case <-time.After(30 * time.Second):
+		t.Fatal("no request reached the server within 30s")
+	}
+
+	if !json.Valid(body) {
+		t.Fatalf("server received invalid JSON: %d bytes (truncated envelope — #124). "+
+			"tail: %q", len(body), tail(body, 80))
+	}
+
+	var env2 struct {
+		EventID  string          `json:"event_id"`
+		RawEvent json.RawMessage `json:"raw_event"`
+	}
+	if err := json.Unmarshal(body, &env2); err != nil {
+		t.Fatalf("received body is not an envelope: %v", err)
+	}
+	if env2.EventID == "" {
+		t.Error("envelope has no event_id")
+	}
+	var raw struct {
+		ToolInput struct {
+			Content string `json:"content"`
+		} `json:"tool_input"`
+	}
+	if err := json.Unmarshal(env2.RawEvent, &raw); err != nil {
+		t.Fatalf("raw_event is not valid JSON: %v", err)
+	}
+	if got := len(raw.ToolInput.Content); got != filler {
+		t.Errorf("raw_event content = %d bytes, want %d (payload was truncated in transit)", got, filler)
+	}
+}
+
+// TestAsyncSendSmallEnvelopeStillWorks guards the path that always worked:
+// envelopes that fit in the pipe buffer must keep arriving intact.
+func TestAsyncSendSmallEnvelopeStillWorks(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("covered on unix")
+	}
+
+	bin := buildCLI(t)
+
+	bodies := make(chan []byte, 4)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		select {
+		case bodies <- body:
+		default:
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"status":"ok"}`))
+	}))
+	defer srv.Close()
+
+	home, env := asyncHookEnv(t, srv.URL)
+	runHookWithPayload(t, bin, env, home, bigHookPayload(t, 16))
+
+	select {
+	case body := <-bodies:
+		if !json.Valid(body) {
+			t.Fatalf("small envelope arrived invalid: %q", tail(body, 80))
+		}
+	case <-time.After(30 * time.Second):
+		t.Fatal("no request reached the server within 30s")
+	}
+}
+
+func tail(b []byte, n int) string {
+	if len(b) <= n {
+		return string(b)
+	}
+	return "..." + string(b[len(b)-n:])
+}

--- a/internal/client/asyncstdin_unix.go
+++ b/internal/client/asyncstdin_unix.go
@@ -1,0 +1,25 @@
+//go:build !windows
+
+package client
+
+import "os"
+
+// createEphemeralTemp returns an open temp file that has already been removed
+// from the filesystem.
+//
+// On unix an inode outlives its directory entry for as long as any descriptor
+// stays open, so unlinking immediately is safe: the parent still has the file,
+// the child inherits a descriptor to it across exec, and the kernel reclaims
+// the space once both are done. There is deliberately no cleanup path and
+// nothing to leak — not even if either process crashes mid-send.
+func createEphemeralTemp(prefix string) (*os.File, error) {
+	f, err := os.CreateTemp("", prefix)
+	if err != nil {
+		return nil, err
+	}
+	if err := os.Remove(f.Name()); err != nil {
+		_ = f.Close()
+		return nil, err
+	}
+	return f, nil
+}

--- a/internal/client/asyncstdin_windows.go
+++ b/internal/client/asyncstdin_windows.go
@@ -1,0 +1,67 @@
+//go:build windows
+
+package client
+
+import (
+	"os"
+	"path/filepath"
+	"strconv"
+	"syscall"
+	"time"
+)
+
+// Win32 constants the standard syscall package doesn't export. Values are from
+// the Windows SDK (fileapi.h / winnt.h) and are stable ABI.
+const (
+	fileFlagDeleteOnClose  = 0x04000000 // FILE_FLAG_DELETE_ON_CLOSE
+	fileAttributeTemporary = 0x00000100 // FILE_ATTRIBUTE_TEMPORARY
+)
+
+// createEphemeralTemp returns an open temp file that Windows unlinks as soon as
+// the last handle to it is closed.
+//
+// This is the Windows analogue of unlinking an open file on unix, and it needs
+// a raw CreateFile to express: os.CreateTemp opens without FILE_SHARE_DELETE,
+// which makes os.Remove on the still-open file fail with a sharing violation.
+// The inheritable duplicate that os/exec hands the child carries the same
+// delete-on-close disposition, so the file disappears once the parent and the
+// child have both closed it — crashes included.
+//
+// FILE_ATTRIBUTE_TEMPORARY additionally hints the cache manager to avoid
+// flushing the contents to disk when it can, since this file only ever exists
+// to be handed to a child that reads it immediately.
+func createEphemeralTemp(prefix string) (*os.File, error) {
+	dir := os.TempDir()
+	var lastErr error
+
+	// CREATE_NEW fails rather than clobbering an existing file, so retry a few
+	// times on the (very unlikely) name collision.
+	for i := 0; i < 10; i++ {
+		name := filepath.Join(dir, prefix+
+			strconv.Itoa(os.Getpid())+"-"+
+			strconv.FormatInt(time.Now().UnixNano(), 10)+"-"+
+			strconv.Itoa(i))
+
+		namep, err := syscall.UTF16PtrFromString(name)
+		if err != nil {
+			return nil, err
+		}
+
+		h, err := syscall.CreateFile(
+			namep,
+			syscall.GENERIC_READ|syscall.GENERIC_WRITE,
+			syscall.FILE_SHARE_READ|syscall.FILE_SHARE_WRITE|syscall.FILE_SHARE_DELETE,
+			nil,
+			syscall.CREATE_NEW,
+			fileAttributeTemporary|fileFlagDeleteOnClose,
+			0,
+		)
+		if err != nil {
+			lastErr = err
+			continue
+		}
+		return os.NewFile(uintptr(h), name), nil
+	}
+
+	return nil, lastErr
+}

--- a/internal/eventlog/eventlog_test.go
+++ b/internal/eventlog/eventlog_test.go
@@ -24,7 +24,7 @@ func withTempDir(t *testing.T) string {
 func TestRecordSendOutcomeBumpsSent(t *testing.T) {
 	withTempDir(t)
 
-	RecordSendOutcome("Stop", 200, 42, nil)
+	RecordSendOutcome("evt-1", "Stop", 200, 42, nil)
 
 	st := LoadStatus()
 	if st.Sent != 1 || st.Failed != 0 || st.Dropped != 0 {
@@ -38,7 +38,7 @@ func TestRecordSendOutcomeBumpsSent(t *testing.T) {
 func TestRecordSendOutcomeFailureWritesErrorAndBumpsFailed(t *testing.T) {
 	withTempDir(t)
 
-	RecordSendOutcome("Stop", 401, 10, errors.New("API error: 401 - unauthorized"))
+	RecordSendOutcome("evt-2", "Stop", 401, 10, errors.New("API error: 401 - unauthorized"))
 
 	st := LoadStatus()
 	if st.Failed != 1 || st.Sent != 0 {
@@ -54,6 +54,25 @@ func TestRecordSendOutcomeFailureWritesErrorAndBumpsFailed(t *testing.T) {
 	}
 	if !strings.Contains(string(errLog), "send failed") || !strings.Contains(string(errLog), "401") {
 		t.Errorf("errors.log missing failure line:\n%s", errLog)
+	}
+	// The event_id is what makes the line actionable: it's the key that finds
+	// the offending envelope in events.jsonl.
+	if !strings.Contains(string(errLog), "event_id=evt-2") {
+		t.Errorf("errors.log missing event_id:\n%s", errLog)
+	}
+}
+
+func TestRecordSendOutcomeUnknownIdentifiersRenderAsDash(t *testing.T) {
+	withTempDir(t)
+
+	RecordSendOutcome("", "", 400, 5, errors.New("API error: 400 - Invalid JSON in request body"))
+
+	errLog, err := os.ReadFile(ErrorsPath())
+	if err != nil {
+		t.Fatalf("read errors.log: %v", err)
+	}
+	if !strings.Contains(string(errLog), "event=- event_id=-") {
+		t.Errorf("errors.log should render unknown identifiers as dashes:\n%s", errLog)
 	}
 }
 
@@ -116,7 +135,7 @@ func TestDisabledIsNoOp(t *testing.T) {
 	t.Cleanup(func() { SetDirForTest("") })
 
 	RecordCapture([]byte(`{"schema":2}`))
-	RecordSendOutcome("Stop", 200, 1, nil)
+	RecordSendOutcome("evt-3", "Stop", 200, 1, nil)
 	RecordDrop("parse_error", "x")
 	Errorf("should not write")
 

--- a/internal/eventlog/outcome.go
+++ b/internal/eventlog/outcome.go
@@ -7,7 +7,13 @@ import "net/http"
 // re-recorded here — events.jsonl already captured it at hook time; full HTTP
 // diagnostics live in ~/.config/promptconduit/outbound.ndjson (`promptconduit
 // watch`). Best-effort and gated on Enabled().
-func RecordSendOutcome(hookEvent string, status int, latencyMs int64, sendErr error) {
+//
+// eventID is the envelope's event_id and is what makes a failure line
+// actionable: it's the key that finds the exact offending envelope in
+// events.jsonl. Both identifiers render as "-" when the caller couldn't
+// determine them (an unparseable payload), which is itself a signal worth
+// seeing in the log.
+func RecordSendOutcome(eventID, hookEvent string, status int, latencyMs int64, sendErr error) {
 	failed := sendErr != nil || status < 200 || status >= 300
 	if !failed {
 		Bump(OutcomeSent, "")
@@ -20,8 +26,8 @@ func RecordSendOutcome(hookEvent string, status int, latencyMs int64, sendErr er
 	if detail == "" {
 		detail = httpDetail(status)
 	}
-	Errorf("send failed event=%s status=%d latency=%dms: %s",
-		emptyDash(hookEvent), status, latencyMs, detail)
+	Errorf("send failed event=%s event_id=%s status=%d latency=%dms: %s",
+		emptyDash(hookEvent), emptyDash(eventID), status, latencyMs, detail)
 	Bump(OutcomeFailed, detail)
 }
 


### PR DESCRIPTION
Fixes the 1,553 events lost to HTTP 400 `Invalid JSON in request body`.

## Root cause

The detached sender passed the envelope as a plain reader:

```go
cmd.Stdin = bytes.NewReader(envJSON)   // NOT an *os.File
cmd.Start()
_ = cmd.Process.Release()              // parent detaches
return nil                             // never calls cmd.Wait()
```

When `cmd.Stdin` is an `io.Reader` that is **not** an `*os.File`, `os/exec` quietly allocates an OS pipe and copies the reader into it **from a goroutine in the parent** — and `cmd.Wait()` is the only thing that ever joins that goroutine. The async sender deliberately never waits: it releases the child and the hook returns immediately. The copier was killed mid-write, the child (`sendEnvelopeFromStdin`) `io.ReadAll`'d a truncated prefix, POSTed it, and the platform rejected it.

The events were **lost outright** — capture had already succeeded, and there is no retry path.

As the issue said: there is no ~64KB limit on subprocess stdin. There is a 64KB pipe buffer and a parent that exits before filling it twice.

## Reproduction

The bug needs a parent that *actually exits*, which an in-process unit test cannot stage — the copy goroutine survives as long as the test binary does, so a unit test passes against the broken code. `internal/client/async_send_test.go` therefore builds the CLI, runs the real `hook` command against an `httptest` server, and inspects what the detached child actually POSTs.

**Before** (unmodified `main`, 1MB envelope, 5/5 runs failed):

```
--- FAIL: TestAsyncSendDeliversEnvelopeLargerThanPipeBuffer (1.03s)
    server received invalid JSON: 65536 bytes (truncated envelope — #124)
--- FAIL: TestAsyncSendDeliversEnvelopeLargerThanPipeBuffer (0.26s)
    server received invalid JSON: 0 bytes (truncated envelope — #124)
```

65536 bytes — the pipe buffer, exactly.

**After** (10/10 runs): the full 1MB envelope arrives intact and parses.

## One finding that refines the diagnosis

Some runs delivered **0 bytes**, not 65536 — the copier can lose the race outright, before its first write. The mechanism isn't "envelopes >64KB fail"; it's "the parent exits before the copier finishes", which large payloads lose deterministically (16+ buffer round trips) and small ones merely *usually* win. So small envelopes were never strictly safe either, which plausibly explains part of the unexplained **3.91% cumulative vs 0.92% large-envelope** gap flagged in the issue.

## Fix

Hand the child an `*os.File`, so `os/exec` passes a real descriptor straight through (`exec.go` `childStdin` short-circuits on `*os.File`) — no pipe, no copier, nothing to wait on, no size ceiling.

The envelope is staged in a temp file that self-destructs:
- **unix** — unlinked the instant it's opened; the inode lives on the open descriptors alone.
- **Windows** — `FILE_FLAG_DELETE_ON_CLOSE`, because `os.CreateTemp` opens without `FILE_SHARE_DELETE`, so the unix unlink-while-open trick returns a sharing violation there. Same semantics via the platform's own primitive.

Either way the OS reclaims the file once parent and child are done — no cleanup path, no leak, crashes included. Verified: 0 stray `promptconduit-envelope-*` files after repeated runs. Any staging failure falls back to a blocking send, matching existing behavior.

### Windows was affected too

`sendAsyncWindows` spawned `go func() { cmd.Wait() }()`, which *looks* like it joins the copier but doesn't: the Go runtime tears the process down when `main` returns without joining stray goroutines, and the hook returns immediately after the call. That `Wait` never ran, and Windows truncated exactly as unix did. With the copier gone the two paths have nothing left to disagree about, so they collapse into one `startDetachedSender`; the only genuine platform difference is how a temp file self-destructs (`createEphemeralTemp`).

## Also in this PR

**`errors.log` now records the failing `event_id`.** It read `event=-` for precisely the reason under investigation: the truncated JSON couldn't be parsed to recover the identifier. Verified end-to-end against a 400-ing server:

```
... send failed event=PreToolUse event_id=019f639c-3ed0-77ac-8c1b-89ecb3c80ecb status=400 latency=5ms: API error: 400 - {"detail":"Invalid JSON in request body"}
```

**Attachments stay blocking, comment corrected.** The old rationale ("subprocess stdin has ~64KB limit") was this bug seen from the outside, and is gone. But async attachments aren't unblocked by fixing it: the child speaks exactly one dialect — `hook --send-event` reads stdin and POSTs it verbatim as a JSON envelope — while attachments are the other shape (envelope + blobs, sent multipart), and the child can't tell them apart from the bytes alone. Enabling async there means a wire flag plus a second branch in the child, which is a behavior change with its own regression surface rather than part of this fix. Left as a follow-up, with the real reason now written down.

## Verification

- Repro test: fails on `main` (5/5), passes after (10/10)
- `make test`: passes, exit 0, full suite
- `make lint`: **fails — 4 pre-existing issues**, all in files this PR doesn't touch (`internal/sessions/transcript.go`, `cmd/skills_local.go`). Confirmed identical on unmodified `main` by stashing. `golangci-lint run ./internal/client/... ./internal/eventlog/...` reports **0 issues**. Not fixed here to keep the diff focused.
- Cross-compiles clean for `windows/amd64` and `linux/amd64` (`go build` + `go vet`). **The Windows path is compile-verified only — I have no Windows host to run it on.** A bug there degrades to the blocking send, which is correct if slower.

Closes #124

🤖 Generated with [Claude Code](https://claude.com/claude-code)