### PR TITLE
fix(test): stop async-send test flaking on temp-dir cleanup

### DIFF
--- a/internal/client/async_send_test.go
+++ b/internal/client/async_send_test.go
@@ -66,7 +66,29 @@ func buildCLI(t *testing.T) string {
 // HOME (so the event log lands in a temp dir) and a config pointing at srvURL.
 func asyncHookEnv(t *testing.T, srvURL string) (home string, env []string) {
 	t.Helper()
-	home = t.TempDir()
+	// Deliberately NOT t.TempDir(): its automatic RemoveAll runs the moment the
+	// test returns, but the DETACHED sender child keeps writing status.json /
+	// events.jsonl into home for a beat after the server has the body — that
+	// race surfaces as a flaky "unlinkat …: directory not empty" cleanup
+	// failure. Use a manual dir with a retrying cleanup that lets the child
+	// quiesce first.
+	dir, err := os.MkdirTemp("", "pc-asynchome")
+	if err != nil {
+		t.Fatalf("mkdir temp home: %v", err)
+	}
+	home = dir
+	t.Cleanup(func() {
+		// The child finishes within ~a second; retry RemoveAll until it wins.
+		for i := 0; i < 60; i++ {
+			if err := os.RemoveAll(home); err == nil {
+				return
+			}
+			time.Sleep(50 * time.Millisecond)
+		}
+		if err := os.RemoveAll(home); err != nil {
+			t.Logf("temp home cleanup (async child still writing?): %v", err)
+		}
+	})
 
 	xdg := filepath.Join(home, ".config")
 	cfgDir := filepath.Join(xdg, ConfigDirName)


### PR DESCRIPTION
## Problem

`main` CI went red on run **29579807493** with:

```
testing.go:1225: TempDir RemoveAll cleanup: unlinkat /tmp/TestAsyncSend…/001: directory not empty
--- FAIL: TestAsyncSendSmallEnvelopeStillWorks
```

It's flaky (the same test passed on the prior main run), and unrelated to the graph PR that triggered the run — that PR doesn't touch `internal/client`.

## Cause

`asyncHookEnv` uses `t.TempDir()` for the hook subprocess's `HOME`. The async sender is a **detached child** that keeps writing `status.json` / `events.jsonl` into `HOME` for a moment after the server has the body. `t.TempDir()`'s automatic `RemoveAll` fires the instant the test returns and races that child → intermittent "directory not empty".

## Fix

Swap `t.TempDir()` for a manual `os.MkdirTemp` with a retrying cleanup that lets the child quiesce (up to ~3s of 50ms retries) before removing, and logs rather than fails if it still can't. Test-only; no production code changes. Both async tests pass repeatedly locally (`-count=3`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HQJt2w3Qz6FyksNmbJEGEm