### PR TITLE
feat: promptconduit feedback command

### DIFF
--- a/cmd/feedback.go
+++ b/cmd/feedback.go
@@ -1,0 +1,109 @@
+package cmd
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"runtime"
+	"strings"
+	"time"
+
+	"github.com/promptconduit/cli/internal/client"
+	"github.com/spf13/cobra"
+)
+
+var feedbackCategory string
+
+var feedbackCmd = &cobra.Command{
+	Use:          "feedback [message]",
+	Short:        "Send feedback to the PromptConduit team",
+	SilenceUsage: true, // a runtime error shouldn't dump usage, but DO print it
+	Long: `Send a note straight to the PromptConduit team — an idea, a bug, or
+just what you think. Pass the message as an argument or pipe it on stdin.
+
+If you're logged in (an API key is configured) the feedback is tied to your
+account so we can follow up; otherwise it's sent anonymously.
+
+Examples:
+  promptconduit feedback "the graph view is great, add filtering"
+  promptconduit feedback --category bug "sync failed on a large repo"
+  echo "loving the cache savings stat" | promptconduit feedback`,
+	RunE: runFeedback,
+}
+
+func init() {
+	feedbackCmd.Flags().StringVar(&feedbackCategory, "category", "", "optional: bug | idea | praise | other")
+}
+
+func runFeedback(cmd *cobra.Command, args []string) error {
+	message := strings.TrimSpace(strings.Join(args, " "))
+	if message == "" {
+		// Fall back to a piped message (`echo "..." | promptconduit feedback`).
+		// Guard on ModeNamedPipe specifically so we never block reading a TTY or
+		// an inherited open stdin that will never send EOF.
+		if info, _ := os.Stdin.Stat(); info != nil && info.Mode()&os.ModeNamedPipe != 0 {
+			piped, _ := io.ReadAll(os.Stdin)
+			message = strings.TrimSpace(string(piped))
+		}
+	}
+	if message == "" {
+		return fmt.Errorf("no message — pass it as an argument or pipe it on stdin\n  promptconduit feedback \"your note\"")
+	}
+	if len(message) > 4000 {
+		return fmt.Errorf("message is too long (%d chars, max 4000)", len(message))
+	}
+
+	cfg := client.LoadConfig()
+
+	payload := map[string]any{
+		"message": message,
+		"source":  "cli",
+		"context": map[string]string{
+			"cli_version": Version,
+			"os":          runtime.GOOS,
+			"arch":        runtime.GOARCH,
+		},
+	}
+	if feedbackCategory != "" {
+		payload["category"] = feedbackCategory
+	}
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return fmt.Errorf("encode feedback: %w", err)
+	}
+
+	parent := cmd.Context()
+	if parent == nil {
+		parent = context.Background()
+	}
+	ctx, cancel := context.WithTimeout(parent, 15*time.Second)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, cfg.APIURL+"/v1/feedback", bytes.NewReader(body))
+	if err != nil {
+		return fmt.Errorf("build request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("User-Agent", fmt.Sprintf("PromptConduit-CLI/%s", Version))
+	if cfg.APIKey != "" {
+		req.Header.Set("Authorization", "Bearer "+cfg.APIKey)
+	}
+
+	resp, err := (&http.Client{Timeout: 15 * time.Second}).Do(req)
+	if err != nil {
+		return fmt.Errorf("send feedback: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		snippet, _ := io.ReadAll(io.LimitReader(resp.Body, 400))
+		return fmt.Errorf("feedback failed (%d): %s", resp.StatusCode, strings.TrimSpace(string(snippet)))
+	}
+
+	_, _ = fmt.Fprintln(cmd.OutOrStdout(), "Thanks — your feedback landed. We read every note.")
+	return nil
+}

--- a/cmd/feedback_test.go
+++ b/cmd/feedback_test.go
@@ -1,0 +1,75 @@
+package cmd
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+// isolateConfig points config resolution at an empty temp dir so the test never
+// reads the developer's real ~/.config/promptconduit (API key, URL).
+func isolateConfig(t *testing.T, apiURL string) {
+	t.Helper()
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("PROMPTCONDUIT_API_URL", apiURL)
+	t.Setenv("PROMPTCONDUIT_API_KEY", "")
+}
+
+func TestFeedback_PostsMessage(t *testing.T) {
+	var got map[string]any
+	var gotAuth string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		_ = json.NewDecoder(r.Body).Decode(&got)
+		w.WriteHeader(http.StatusCreated)
+		_, _ = w.Write([]byte(`{"id":"x"}`))
+	}))
+	defer srv.Close()
+	isolateConfig(t, srv.URL)
+
+	feedbackCategory = "idea"
+	t.Cleanup(func() { feedbackCategory = "" })
+
+	cmd := &cobra.Command{}
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	if err := runFeedback(cmd, []string{"add", "filtering"}); err != nil {
+		t.Fatalf("runFeedback: %v", err)
+	}
+
+	if got["source"] != "cli" || got["message"] != "add filtering" || got["category"] != "idea" {
+		t.Fatalf("server received %+v", got)
+	}
+	ctx, _ := got["context"].(map[string]any)
+	if ctx == nil || ctx["os"] == "" || ctx["cli_version"] == "" {
+		t.Fatalf("missing context: %+v", got["context"])
+	}
+	if gotAuth != "" {
+		t.Fatalf("expected no auth header for keyless config, got %q", gotAuth)
+	}
+	if !strings.Contains(out.String(), "Thanks") {
+		t.Fatalf("no confirmation printed: %q", out.String())
+	}
+}
+
+func TestFeedback_NoMessageErrors(t *testing.T) {
+	isolateConfig(t, "http://127.0.0.1:0")
+	feedbackCategory = ""
+	if err := runFeedback(&cobra.Command{}, nil); err == nil {
+		t.Fatal("expected an error when no message is given")
+	}
+}
+
+func TestFeedback_TooLongErrors(t *testing.T) {
+	isolateConfig(t, "http://127.0.0.1:0")
+	feedbackCategory = ""
+	err := runFeedback(&cobra.Command{}, []string{strings.Repeat("x", 4001)})
+	if err == nil || !strings.Contains(err.Error(), "too long") {
+		t.Fatalf("expected too-long error, got %v", err)
+	}
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -66,6 +66,7 @@ func init() {
 	rootCmd.AddCommand(eventsCmd)
 	rootCmd.AddCommand(costCmd)
 	rootCmd.AddCommand(graphCmd)
+	rootCmd.AddCommand(feedbackCmd)
 	rootCmd.AddCommand(pruneCmd)
 }
 


### PR DESCRIPTION
## What

`promptconduit feedback "your note"` (or `echo "..." | promptconduit feedback`) sends feedback straight to the team via `POST /v1/feedback` — the CLI half of the feedback loop.

- Message from an argument or a piped stdin; `--category bug|idea|praise|other` optional.
- Attaches `cli_version` / `os` / `arch` as context.
- Attributed to your account when an API key is configured (Bearer), **anonymous** otherwise — so free/local users can send feedback too.

## Testing

- httptest coverage of the posted payload (source=cli, message, category, context; no auth header when keyless), plus the no-message and too-long (>4000) guards.
- Stdin is read only for a real pipe (`ModeNamedPipe`) so it never blocks on a TTY or an inherited open stdin.
- Verified end-to-end against a mock server (arg + `--category` + key → attributed; piped → sent). Full CLI suite green.

Depends on platform `POST /v1/feedback` (PR in the platform repo). The endpoint already handles anonymous submissions, so this works against prod once that ships.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HQJt2w3Qz6FyksNmbJEGEm