### PR TITLE
chore: refresh Cursor model pricing for Grok, Gemini, and third-party models

### DIFF
--- a/internal/cost/cost_test.go
+++ b/internal/cost/cost_test.go
@@ -51,6 +51,28 @@ func TestResolvePrice(t *testing.T) {
 		t.Fatal("composer-2.5-fast must not resolve to the Standard rate")
 	}
 
+	// Claude 5 and Cursor Grok models.
+	if _, ok := tbl.ResolvePrice("claude-sonnet-5"); !ok {
+		t.Fatal("claude-sonnet-5 should resolve")
+	}
+	if _, ok := tbl.ResolvePrice("claude-sonnet-5-thinking-high"); !ok {
+		t.Fatal("claude-sonnet-5-thinking-high should resolve via suffix trim")
+	}
+	grokFast, ok := tbl.ResolvePrice("cursor-grok-4.6-high-fast")
+	if !ok {
+		t.Fatal("cursor-grok-4.6-high-fast should resolve via alias")
+	}
+	grokStd, ok := tbl.ResolvePrice("cursor-grok-4.6")
+	if !ok {
+		t.Fatal("cursor-grok-4.6 should resolve")
+	}
+	if grokFast.Input != 0.000004 || grokStd.Input != 0.000002 {
+		t.Fatalf("grok rates wrong: fast=%v std=%v", grokFast.Input, grokStd.Input)
+	}
+	if grokFast.Input == grokStd.Input {
+		t.Fatal("cursor-grok-4.6-high-fast must not resolve to the standard rate")
+	}
+
 	// Unknown model must report not-priced, not panic or guess.
 	if _, ok := tbl.ResolvePrice("some-other-llm-9"); ok {
 		t.Fatal("unknown model should not resolve")
@@ -276,8 +298,8 @@ func TestSessionSummaryToolAggregation(t *testing.T) {
 func TestParseCursorHookPayload(t *testing.T) {
 	tbl := mustTable(t)
 
-	// composer-2.5-fast is priced from Cursor's published input/output rates
-	// ($3/$15 per M); Cursor publishes no cache rate, so cache_read is priced 0.
+	// composer-2.5-fast is priced from Cursor's published input/output/cache-read
+	// rates ($3/$15/$0.50 per M); cache_write is priced at 0.
 	composer := []byte(`{"hook_event_name":"afterAgentResponse","model":"composer-2.5-fast","conversation_id":"conv1","generation_id":"gen1","session_id":"conv1","input_tokens":17072,"output_tokens":92,"cache_read_tokens":6048,"cache_write_tokens":0,"workspace_roots":["/Users/x/tolken"]}`)
 	ev, cwd, ok := ParseCursorHookPayload(composer, tbl)
 	if !ok {
@@ -289,7 +311,7 @@ func TestParseCursorHookPayload(t *testing.T) {
 	if !ev.ModelPriced {
 		t.Fatal("composer-2.5-fast should be priced")
 	}
-	const wantComposer = 17072*3e-6 + 92*15e-6 // cache_read priced at 0 (no Cursor cache rate)
+	const wantComposer = 17072*3e-6 + 92*15e-6 + 6048*5e-7
 	if math.Abs(ev.Cost.Total-wantComposer) > 1e-9 {
 		t.Fatalf("composer cost = %v, want %v", ev.Cost.Total, wantComposer)
 	}

--- a/internal/cost/cursor.go
+++ b/internal/cost/cursor.go
@@ -13,9 +13,8 @@ import (
 // reconciliation — Cursor cost is computed the same exact way as Claude Code,
 // just sourced from a hook payload instead of a transcript line.
 //
-// Cache pricing deferral (cli#63): cache_read / cache_write tokens are priced at
-// $0 until Cursor publishes per-model cache rates. Breakdown totals may
-// undercount cache-heavy Cursor sessions until then.
+// Cache pricing: Cursor publishes cache-read rates for Composer and Grok;
+// cache-write tokens are priced at $0 until Cursor publishes write rates.
 //
 // Both `stop` and `afterAgentResponse` fire per generation with the SAME
 // generation_id and identical final tokens, so dedup by generation_id collapses

--- a/internal/cost/pricing.go
+++ b/internal/cost/pricing.go
@@ -58,6 +58,10 @@ var modelAliases = map[string]string{
 	"composer-1":            "cursor-composer-1",
 	"claude-4.5-sonnet":     "claude-sonnet-4-5",
 	"claude-4.5-opus":       "claude-opus-4-5",
+	// Cursor Grok fast slugs include effort + speed suffixes; suffix-trim would
+	// land on the cheaper standard rate without these aliases.
+	"cursor-grok-4.6-high-fast": "cursor-grok-4.6-fast",
+	"cursor-grok-4.5-high-fast": "cursor-grok-4.5-fast",
 }
 
 // LoadBundledPriceTable parses the embedded snapshot only. Tests use this for

--- a/internal/cost/pricing_data.json
+++ b/internal/cost/pricing_data.json
@@ -21,6 +21,13 @@
     "cache_creation_input_token_cost_1h": 0.000006,
     "cache_read_input_token_cost": 0.0000003
   },
+  "claude-opus-5": {
+    "input_cost_per_token": 0.000005,
+    "output_cost_per_token": 0.000025,
+    "cache_creation_input_token_cost": 0.00000625,
+    "cache_creation_input_token_cost_1h": 0.00001,
+    "cache_read_input_token_cost": 0.0000005
+  },
   "claude-opus-4-8": {
     "input_cost_per_token": 0.000005,
     "output_cost_per_token": 0.000025,
@@ -98,13 +105,66 @@
     "cache_creation_input_token_cost_1h": 0.0000016,
     "cache_read_input_token_cost": 0.00000008
   },
-  "_cursor_comment": "Cursor's own Composer models, from cursor.com/changelog/composer-2-5 (input/output only — Cursor publishes no separate cache rate, so cache tokens are reported but priced at 0). The exact -fast key must precede the prefix-trim fallback so it doesn't resolve to the cheaper Standard rate.",
+  "gemini-3.5-flash": {
+    "input_cost_per_token": 0.0000015,
+    "output_cost_per_token": 0.000009,
+    "cache_read_input_token_cost": 0.00000015
+  },
+  "gemini-3.6-flash": {
+    "input_cost_per_token": 0.0000015,
+    "output_cost_per_token": 0.0000075,
+    "cache_read_input_token_cost": 0.00000015
+  },
+  "gemini-3.7-flash": {
+    "input_cost_per_token": 0.00000075,
+    "output_cost_per_token": 0.0000035,
+    "cache_read_input_token_cost": 0.000000075
+  },
+  "glm-5.2": {
+    "input_cost_per_token": 0.0000014,
+    "output_cost_per_token": 0.0000044,
+    "cache_read_input_token_cost": 0.00000026
+  },
+  "gpt-5.6-sol": {
+    "input_cost_per_token": 0.000005,
+    "output_cost_per_token": 0.00003,
+    "cache_creation_input_token_cost": 0.00000625,
+    "cache_read_input_token_cost": 0.0000005
+  },
+  "kimi-k3": {
+    "input_cost_per_token": 0.000003,
+    "output_cost_per_token": 0.000015,
+    "cache_read_input_token_cost": 0.0000003
+  },
+  "_cursor_comment": "Cursor first-party and third-party model rates from cursor.com/docs/models-and-pricing (2026-08-15). Composer/Grok publish cache-read only (no cache-write column). The exact -fast key must precede the prefix-trim fallback so it doesn't resolve to the cheaper standard rate; Grok fast slugs (cursor-grok-*-high-fast) are aliased in pricing.go.",
+  "cursor-grok-4.6-fast": {
+    "input_cost_per_token": 0.000004,
+    "output_cost_per_token": 0.000012,
+    "cache_read_input_token_cost": 0.000001
+  },
+  "cursor-grok-4.6": {
+    "input_cost_per_token": 0.000002,
+    "output_cost_per_token": 0.000006,
+    "cache_read_input_token_cost": 0.0000005
+  },
+  "cursor-grok-4.5-fast": {
+    "input_cost_per_token": 0.000004,
+    "output_cost_per_token": 0.000012,
+    "cache_read_input_token_cost": 0.000001
+  },
+  "cursor-grok-4.5": {
+    "input_cost_per_token": 0.000002,
+    "output_cost_per_token": 0.000006,
+    "cache_read_input_token_cost": 0.0000005
+  },
   "composer-2.5-fast": {
     "input_cost_per_token": 0.000003,
-    "output_cost_per_token": 0.000015
+    "output_cost_per_token": 0.000015,
+    "cache_read_input_token_cost": 0.0000005
   },
   "composer-2.5": {
     "input_cost_per_token": 0.0000005,
-    "output_cost_per_token": 0.0000025
+    "output_cost_per_token": 0.0000025,
+    "cache_read_input_token_cost": 0.0000002
   }
 }


### PR DESCRIPTION
## Summary

Updates the bundled `pricing_data.json` snapshot with rates for newly available Cursor models so the local cost meter prices them instead of showing "unpriced". Rates sourced from [cursor.com/docs/models-and-pricing](https://cursor.com/docs/models-and-pricing) (2026-08-15).

Closes #135

## Changes

### Pricing table (`pricing_data.json`)
- **Cursor Grok 4.5/4.6** (standard + fast) — first-party Cursor Models pool
- **Claude Opus 5** — Anthropic API rates (third-party pool)
- **Gemini 3.5/3.6/3.7 Flash**, **GLM 5.2**, **GPT-5.6 Sol**, **Kimi K3** — third-party models
- **Composer 2.5** — added cache-read rates now published by Cursor

### Resolution (`pricing.go`)
- Aliases `cursor-grok-4.6-high-fast` and `cursor-grok-4.5-high-fast` to fast rates (suffix-trim alone would hit the cheaper standard rate)

### Tests
- Grok alias and Claude 5 resolution tests
- Updated Composer hook payload cost expectation for cache-read pricing

## Architecture

```mermaid
flowchart LR
    Hook[Cursor hook model string] --> Resolve[ResolvePrice]
    Resolve --> Table[pricing_data.json]
    Resolve --> Alias[modelAliases]
    Table --> Cost[CostForUsage]
```

## Testing
- `go test ./internal/cost/...` — all pass

## Agent Review Context
- **change-type**: chore
- **risk-level**: low
- **key-files**: `internal/cost/pricing_data.json`, `pricing.go`
- **testing-confidence**: high

## Checklist
- [x] Tests pass
- [x] No breaking changes
- [x] Code follows project conventions

Changelog: none (internal only — user-facing note will ship via platform marketing PR)
Companion PR: promptconduit/editor-extension (mirrors this table)

Made with [Cursor](https://cursor.com)